### PR TITLE
package install check

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -57,7 +57,8 @@ check_installs <- function(x) {
   } else {
     m_type <- class(x)[1]
     deps <- parsnip::get_dependency(m_type)
-    deps <- deps$pkg[[deps$engine == x$engine]]
+    deps <- deps$pkg[deps$engine == x$engine]
+    deps <- unlist(deps)
   }
 
   if (length(deps) > 0) {

--- a/R/checks.R
+++ b/R/checks.R
@@ -41,6 +41,36 @@ check_grid <- function(x, object) {
   x
 }
 
+shhhh <- function(x) {
+  suppressPackageStartupMessages(requireNamespace(x, quietly = TRUE))
+}
+
+is_installed <- function(pkg) {
+  res <- try(shhhh(pkg), silent = TRUE)
+  res
+}
+
+check_installs <- function(x) {
+
+  if (x$engine == "unknown") {
+    rlang::abort("Please declare an engine for the model")
+  } else {
+    m_type <- class(x)[1]
+    deps <- parsnip::get_dependency(m_type)
+    deps <- deps$pkg[[deps$engine == x$engine]]
+  }
+
+  if (length(deps) > 0) {
+    is_inst <- purrr::map_lgl(deps, is_installed)
+    if (any(!is_inst)) {
+      stop("Some package installs are required: ",
+        paste0("'", deps[!is_inst], "'", collapse = ", "),
+        call. = FALSE
+      )
+    }
+  }
+}
+
 check_object <- function(x, check_dials = FALSE) {
   if (!inherits(x, "workflow")) {
     stop("The `object` argument should be a 'workflow' object.",
@@ -65,6 +95,9 @@ check_object <- function(x, check_dials = FALSE) {
            call. = FALSE)
     }
   }
+
+  mod <- get_wflow_model(x)
+  check_installs(mod)
 
   invisible(NULL)
 }

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -53,6 +53,7 @@ test_that('grid objects', {
 # ------------------------------------------------------------------------------
 
 test_that('workflow objects', {
+  skip_if_not_installed("xgboost")
   wflow_1 <-
     workflow() %>%
     add_model(glmn) %>%


### PR DESCRIPTION
A check that the model-related packages are installed before any work is started. `parsnip` does this but once the model is being fit. `tune` will check before hand to save time. 

recipe-oriented checks are not done (because they are not set up to be checked) until the recipe is executed. We'll work on changing this soon.  

fixes #59 and addresses #62 