### PR TITLE
Improve error capture

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -278,6 +278,18 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, object, metrics, ctrl
                   "recipe",
                   notes = .notes)
 
+  # check for recipe failure
+  if (inherits(tmp_rec, "try-error")) {
+    out <- list(
+      .metrics = metric_est,
+      .extracts = extracted,
+      .predictions = pred_vals,
+      .notes = .notes
+    )
+
+    return(out)
+  }
+
   # Determine the _minimal_ number of models to fit in order to get
   # predictions on all models.
   mod_grid_vals <- get_wflow_model(object) %>% min_grid(grid)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -76,7 +76,12 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
       rec_grid %>%
       dplyr::slice(rec_iter) %>%
       dplyr::select(-data)
+
     tmp_rec <- catch_and_log(train_recipe(split, object, rec_grid_vals), ctrl, split, rec_msg, notes = .notes)
+
+    if (inherits(tmp_rec, "try-error")) {
+      next
+    }
 
     # All model tune parameters associated with the current recipe parameters
     mod_grid_vals <-

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -367,6 +367,19 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, object, metrics, ctr
   # ----------------------------------------------------------------------------
 
   tmp_df <- catch_and_log(exec_formula(split, object), ctrl, split, "formula", notes = .notes)
+
+  # check for formula failure
+  if (inherits(tmp_df, "try-error")) {
+    out <- list(
+      .metrics = metric_est,
+      .extracts = extracted,
+      .predictions = pred_vals,
+      .notes = .notes
+    )
+
+    return(out)
+  }
+
   tmp_trms <- tmp_df$terms
   tmp_df <- tmp_df[c("x", "y")]
 

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -423,26 +423,31 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, object, metrics, ctr
         notes = .notes
       )
 
-    # check for failure
-    if (!inherits(tmp_fit$fit, "try-error")) {
-
-      pred_msg <- paste(mod_msg, "(predictions)")
-
-      tmp_pred <-
-        catch_and_log(
-          predict_model_from_terms(split, tmp_fit, tmp_trms, param_val, metrics),
-          ctrl,
-          split,
-          mod_msg,
-          notes = .notes
-        )
-
-      metric_est  <- append_metrics(metric_est, tmp_pred, object, metrics, split)
-      pred_vals <- append_predictions(pred_vals, tmp_pred, split, ctrl)
-
+    # check for parsnip level and model level failure
+    if (inherits(tmp_fit, "try-error") || inherits(tmp_fit$fit, "try-error")) {
+      next
     }
 
     extracted <- append_extracts(extracted, NULL, tmp_fit$fit, param_val, split, ctrl)
+
+    pred_msg <- paste(mod_msg, "(predictions)")
+
+    tmp_pred <-
+      catch_and_log(
+        predict_model_from_terms(split, tmp_fit, tmp_trms, param_val, metrics),
+        ctrl,
+        split,
+        mod_msg,
+        notes = .notes
+      )
+
+    # check for prediction level failure
+    if (inherits(tmp_pred, "try-error")) {
+      next
+    }
+
+    metric_est  <- append_metrics(metric_est, tmp_pred, object, metrics, split)
+    pred_vals <- append_predictions(pred_vals, tmp_pred, split, ctrl)
   } # end model loop
 
   list(.metrics = metric_est, .extracts = extracted, .predictions = pred_vals, .notes = .notes)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -324,25 +324,30 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, object, metrics, ctrl
         notes = .notes
       )
 
-    # check for failure
-    if (!inherits(tmp_fit$fit, "try-error")) {
-
-      tmp_pred <-
-        catch_and_log(
-          predict_model_from_recipe(split, tmp_fit, tmp_rec, mod_grid_vals[mod_iter,], metrics),
-          ctrl,
-          split,
-          paste(mod_msg, "(predictions)"),
-          bad_only = TRUE,
-          notes = .notes
-        )
-
-      metric_est  <- append_metrics(metric_est, tmp_pred, object, metrics, split)
-      pred_vals <- append_predictions(pred_vals, tmp_pred, split, ctrl)
-
+    # check for parsnip level and model level failure
+    if (inherits(tmp_fit, "try-error") || inherits(tmp_fit$fit, "try-error")) {
+      next
     }
 
     extracted <- append_extracts(extracted, tmp_rec, tmp_fit$fit, mod_grid_vals[mod_iter, ], split, ctrl)
+
+    tmp_pred <-
+      catch_and_log(
+        predict_model_from_recipe(split, tmp_fit, tmp_rec, mod_grid_vals[mod_iter,], metrics),
+        ctrl,
+        split,
+        paste(mod_msg, "(predictions)"),
+        bad_only = TRUE,
+        notes = .notes
+      )
+
+    # check for prediction level failure
+    if (inherits(tmp_pred, "try-error")) {
+      next
+    }
+
+    metric_est  <- append_metrics(metric_est, tmp_pred, object, metrics, split)
+    pred_vals <- append_predictions(pred_vals, tmp_pred, split, ctrl)
   } # end model loop
 
   list(.metrics = metric_est, .extracts = extracted, .predictions = pred_vals, .notes = .notes)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -178,6 +178,11 @@ iter_rec <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
 
     tmp_rec <- catch_and_log(train_recipe(split, object, param_vals), ctrl, split, rec_msg, notes = .notes)
 
+    # check for recipe failure
+    if (inherits(tmp_rec, "try-error")) {
+      next
+    }
+
     tmp_fit <-
       catch_and_log(
         train_model_from_recipe(object, tmp_rec, NULL, control = fit_ctrl),

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -79,7 +79,7 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
 
     tmp_rec <- catch_and_log(train_recipe(split, object, rec_grid_vals), ctrl, split, rec_msg, notes = .notes)
 
-    if (inherits(tmp_rec, "try-error")) {
+    if (is_failure(tmp_rec)) {
       next
     }
 
@@ -114,7 +114,7 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
         )
 
       # check for parsnip level and model level failure
-      if (inherits(tmp_fit, "try-error") || inherits(tmp_fit$fit, "try-error")) {
+      if (is_failure(tmp_fit) || is_failure(tmp_fit$fit)) {
         next
       }
 
@@ -133,7 +133,7 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
         )
 
       # check for prediction level failure
-      if (inherits(tmp_pred, "try-error")) {
+      if (is_failure(tmp_pred)) {
         next
       }
 
@@ -190,7 +190,7 @@ iter_rec <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
     tmp_rec <- catch_and_log(train_recipe(split, object, param_vals), ctrl, split, rec_msg, notes = .notes)
 
     # check for recipe failure
-    if (inherits(tmp_rec, "try-error")) {
+    if (is_failure(tmp_rec)) {
       next
     }
 
@@ -204,7 +204,7 @@ iter_rec <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
       )
 
     # check for parsnip level and model level failure
-    if (inherits(tmp_fit, "try-error") || inherits(tmp_fit$fit, "try-error")) {
+    if (is_failure(tmp_fit) || is_failure(tmp_fit$fit)) {
       next
     }
 
@@ -223,7 +223,7 @@ iter_rec <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
       )
 
     # check for prediction level failure
-    if (inherits(tmp_pred, "try-error")) {
+    if (is_failure(tmp_pred)) {
       next
     }
 
@@ -296,7 +296,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, object, metrics, ctrl
                   notes = .notes)
 
   # check for recipe failure
-  if (inherits(tmp_rec, "try-error")) {
+  if (is_failure(tmp_rec)) {
     out <- list(
       .metrics = metric_est,
       .extracts = extracted,
@@ -325,7 +325,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, object, metrics, ctrl
       )
 
     # check for parsnip level and model level failure
-    if (inherits(tmp_fit, "try-error") || inherits(tmp_fit$fit, "try-error")) {
+    if (is_failure(tmp_fit) || is_failure(tmp_fit$fit)) {
       next
     }
 
@@ -342,7 +342,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, object, metrics, ctrl
       )
 
     # check for prediction level failure
-    if (inherits(tmp_pred, "try-error")) {
+    if (is_failure(tmp_pred)) {
       next
     }
 
@@ -391,7 +391,7 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, object, metrics, ctr
   tmp_df <- catch_and_log(exec_formula(split, object), ctrl, split, "formula", notes = .notes)
 
   # check for formula failure
-  if (inherits(tmp_df, "try-error")) {
+  if (is_failure(tmp_df)) {
     out <- list(
       .metrics = metric_est,
       .extracts = extracted,
@@ -424,7 +424,7 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, object, metrics, ctr
       )
 
     # check for parsnip level and model level failure
-    if (inherits(tmp_fit, "try-error") || inherits(tmp_fit$fit, "try-error")) {
+    if (is_failure(tmp_fit) || is_failure(tmp_fit$fit)) {
       next
     }
 
@@ -442,7 +442,7 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, object, metrics, ctr
       )
 
     # check for prediction level failure
-    if (inherits(tmp_pred, "try-error")) {
+    if (is_failure(tmp_pred)) {
       next
     }
 
@@ -536,3 +536,8 @@ super_safely <- function(fn) {
   safe_fn
 }
 
+# ----------------------------------------------------------------------------
+
+is_failure <- function(x) {
+  inherits(x, "try-error")
+}

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -76,7 +76,7 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, object, metrics, ctrl) {
       rec_grid %>%
       dplyr::slice(rec_iter) %>%
       dplyr::select(-data)
-    tmp_rec <- catch_and_log(train_recipe(split, object, rec_grid_vals), ctrl, split, "recipe", notes = .notes)
+    tmp_rec <- catch_and_log(train_recipe(split, object, rec_grid_vals), ctrl, split, rec_msg, notes = .notes)
 
     # All model tune parameters associated with the current recipe parameters
     mod_grid_vals <-

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -150,8 +150,6 @@ test_that("tune recipe only - failure in recipe is caught elegantly", {
   used_deg_free <- sort(unique(predictions$deg_free))
 
   expect_length(notes, 2L)
-  expect_match(note, "recipe")
-  expect_match(note, "Error")
 
   # failing rows are not in the output
   expect_equal(nrow(extract), 2L)
@@ -191,8 +189,6 @@ test_that("tune model only - failure in recipe is caught elegantly", {
   predictions <- cars_res$.predictions
 
   expect_length(notes, 2L)
-  expect_match(note, "recipe")
-  expect_match(note, "Error")
 
   # recipe failed - no models run
   expect_equal(extracts, list(NULL, NULL))
@@ -227,8 +223,6 @@ test_that("tune model only - failure in formula is caught elegantly", {
   predictions <- cars_res$.predictions
 
   expect_length(notes, 2L)
-  expect_match(note, "formula")
-  expect_match(note, "Error")
 
   # formula failed - no models run
   expect_equal(extracts, list(NULL, NULL))
@@ -263,8 +257,6 @@ test_that("tune model and recipe - failure in recipe is caught elegantly", {
   prediction <- cars_res$.predictions[[1]]
 
   expect_length(notes, 2L)
-  expect_match(note, "recipe")
-  expect_match(note, "Error")
 
   # recipe failed half of the time, only 1 model passed
   expect_equal(nrow(extract), 1L)

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -171,7 +171,6 @@ test_that("tune model only - failure in recipe is caught elegantly", {
   model <- linear_reg(mode = "regression", penalty = tune()) %>%
     set_engine("glmnet")
 
-  # NA values not allowed in recipe
   cars_grid <- tibble(penalty = c(0.01, 0.02))
 
   cars_res <- tune_grid(

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -173,12 +173,15 @@ test_that("tune model only - failure in recipe is caught elegantly", {
 
   cars_grid <- tibble(penalty = c(0.01, 0.02))
 
-  cars_res <- tune_grid(
-    rec,
-    model = model,
-    resamples = data_folds,
-    grid = cars_grid,
-    control = control_grid(extract = function(x) {1}, save_pred = TRUE)
+  expect_warning(
+    cars_res <- tune_grid(
+      rec,
+      model = model,
+      resamples = data_folds,
+      grid = cars_grid,
+      control = control_grid(extract = function(x) {1}, save_pred = TRUE)
+    ),
+    "All models failed"
   )
 
   notes <- cars_res$.notes
@@ -206,12 +209,15 @@ test_that("tune model only - failure in formula is caught elegantly", {
   cars_grid <- tibble(penalty = 0.01)
 
   # these terms don't exist!
-  cars_res <- tune_grid(
-    y ~ z,
-    model = model,
-    resamples = data_folds,
-    grid = cars_grid,
-    control = control_grid(extract = function(x) {1}, save_pred = TRUE)
+  expect_warning(
+    cars_res <- tune_grid(
+      y ~ z,
+      model = model,
+      resamples = data_folds,
+      grid = cars_grid,
+      control = control_grid(extract = function(x) {1}, save_pred = TRUE)
+    ),
+    "All models failed"
   )
 
   notes <- cars_res$.notes

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -228,3 +228,45 @@ test_that("tune model only - failure in formula is caught elegantly", {
   expect_equal(extracts, list(NULL, NULL))
   expect_equal(predictions, list(NULL, NULL))
 })
+
+test_that("tune model and recipe - failure in recipe is caught elegantly", {
+  set.seed(7898)
+  data_folds <- vfold_cv(mtcars, v = 2)
+
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_bs(disp, deg_free = tune())
+
+  model <- linear_reg(mode = "regression", penalty = tune()) %>%
+    set_engine("glmnet")
+
+  # NA values not allowed in recipe
+  cars_grid <- tibble(deg_free = c(NA_real_, 10L), penalty = 0.01)
+
+  cars_res <- tune_grid(
+    rec,
+    model = model,
+    resamples = data_folds,
+    grid = cars_grid,
+    control = control_grid(extract = function(x) {1}, save_pred = TRUE)
+  )
+
+  notes <- cars_res$.notes
+  note <- notes[[1]]$.notes
+
+  extract <- cars_res$.extracts[[1]]
+  prediction <- cars_res$.predictions[[1]]
+
+  expect_length(notes, 2L)
+  expect_match(note, "recipe")
+  expect_match(note, "Error")
+
+  # recipe failed half of the time, only 1 model passed
+  expect_equal(nrow(extract), 1L)
+  expect_equal(extract$deg_free, 10L)
+  expect_equal(extract$penalty, 0.01)
+
+  expect_equal(
+    unique(prediction[, c("deg_free", "penalty")]),
+    tibble(deg_free = 10, penalty = 0.01)
+  )
+})

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -159,3 +159,40 @@ test_that("tune recipe only - failure in recipe is caught elegantly", {
 
   expect_equal(used_deg_free, c(3, 4))
 })
+
+test_that("tune model only - failure in recipe is caught elegantly", {
+  set.seed(7898)
+  data_folds <- vfold_cv(mtcars, v = 2)
+
+  # NA values not allowed in recipe
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_bs(disp, deg_free = NA_real_)
+
+  model <- linear_reg(mode = "regression", penalty = tune()) %>%
+    set_engine("glmnet")
+
+  # NA values not allowed in recipe
+  cars_grid <- tibble(penalty = c(0.01, 0.02))
+
+  cars_res <- tune_grid(
+    rec,
+    model = model,
+    resamples = data_folds,
+    grid = cars_grid,
+    control = control_grid(extract = function(x) {1}, save_pred = TRUE)
+  )
+
+  notes <- cars_res$.notes
+  note <- notes[[1]]$.notes
+
+  extracts <- cars_res$.extracts
+  predictions <- cars_res$.predictions
+
+  expect_length(notes, 2L)
+  expect_match(note, "recipe")
+  expect_match(note, "Error")
+
+  # recipe failed - no models run
+  expect_equal(extracts, list(NULL, NULL))
+  expect_equal(predictions, list(NULL, NULL))
+})


### PR DESCRIPTION
Closes #88 

- General errors in any of the `iter_*()` functions are now caught and returned in the `$notes` column.
- We now also elegantly capture the failure error message and continue on when any of the following error:
   - The recipe
   - The parsnip level checks before running the model
   - The model itself
   - The predictions

All commits should be fairly self contained and straightforward to follow.

I restructured the fit/prediction sections a little to maximize the amount of information that we can capture at each stage. Specifically, I moved the `extracted <-` section up before when the predictions are made. The predictions aren't needed for this section, so we can capture that extraction info even if the predictions happen to fail later on.

I have added a number of tests for failures in the recipe / model, but it is very hard to come up with "general" failures that happen in the tune code as we would try and fix them immediately if they occur.