### PR TITLE
Add custom `tune_symbol` for better unicode support

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -15,7 +15,7 @@ siren <- function(x, type = "info") {
     type == "warning" ~ crayon::yellow("!"),
     type == "go" ~ crayon::black(cli::symbol$pointer ),
     type == "danger" ~ crayon::red("x"),
-    type == "success" ~ crayon::green("\u2713"),
+    type == "success" ~ crayon::green(tune_symbol$success),
     TRUE ~ crayon::blue("i")
   )
   msg <- dplyr::case_when(

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -1,0 +1,29 @@
+# For use in setting the `tune_symbol` active binding in `.onLoad()`
+
+tune_symbol_utf8 <- list(
+  "success" = "\u2713"
+)
+
+tune_symbol_windows <- list(
+  "success" = "\u221A"
+)
+
+tune_symbol_ascii <- list(
+  "success" = "v"
+)
+
+# ------------------------------------------------------------------------------
+
+# cli:::is_latex_output()
+is_latex_output <- function () {
+  if (!("knitr" %in% loadedNamespaces())) {
+    return(FALSE)
+  }
+
+  get("is_latex_output", asNamespace("knitr"))()
+}
+
+# cli:::is_windows()
+is_windows <- function () {
+  .Platform$OS.type == "windows"
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,30 @@
+.onLoad <- function(libname, pkgname) {
+  ns <- rlang::ns_env("tune")
+
+  # Modified version of the cli .onLoad()
+  # We can't use cli::symbol$tick because the width of the character
+  # looks awful when you output it alongside info / warning characters
+  makeActiveBinding(
+    "tune_symbol",
+    function() {
+      # If `cli.unicode` is set we use that
+      opt <- getOption("cli.unicode",  NULL)
+
+      if (!is.null(opt)) {
+        if (isTRUE(opt)) return(tune_symbol_utf8) else return(tune_symbol_ascii)
+      }
+
+      # Otherwise we try to auto-detect
+      if (cli::is_utf8_output()) {
+        tune_symbol_utf8
+      } else if (is_latex_output()) {
+        tune_symbol_ascii
+      } else if (is_windows()) {
+        tune_symbol_windows
+      } else {
+        tune_symbol_ascii
+      }
+    },
+    ns
+  )
+}

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -34,7 +34,7 @@ test_that('low-level messages', {
   expect_message(tune:::siren("bat", "warning"), "!")
 
   skip_on_os("windows")
-  expect_message(tune:::siren("bat", "success"), tune_symbol$success)
+  expect_message(tune:::siren("bat", "success"), tune::tune_symbol$success)
 })
 
 test_that('tune_log', {
@@ -45,7 +45,7 @@ test_that('tune_log', {
   expect_silent(tune:::tune_log(ctrl_f, NULL, task = "cube", type = "go"))
 
   skip_on_os("windows")
-  expect_message(tune:::tune_log(ctrl_t, rs, task = "cube", type = "success"), tune_symbol$success)
+  expect_message(tune:::tune_log(ctrl_t, rs, task = "cube", type = "success"), tune::tune_symbol$success)
 })
 
 test_that('log issues', {

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -34,7 +34,7 @@ test_that('low-level messages', {
   expect_message(tune:::siren("bat", "warning"), "!")
 
   skip_on_os("windows")
-  expect_message(tune:::siren("bat", "success"), "\u2713")
+  expect_message(tune:::siren("bat", "success"), tune_symbol$success)
 })
 
 test_that('tune_log', {
@@ -45,7 +45,7 @@ test_that('tune_log', {
   expect_silent(tune:::tune_log(ctrl_f, NULL, task = "cube", type = "go"))
 
   skip_on_os("windows")
-  expect_message(tune:::tune_log(ctrl_t, rs, task = "cube", type = "success"), "\u2713")
+  expect_message(tune:::tune_log(ctrl_t, rs, task = "cube", type = "success"), tune_symbol$success)
 })
 
 test_that('log issues', {

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -34,7 +34,7 @@ test_that('low-level messages', {
   expect_message(tune:::siren("bat", "warning"), "!")
 
   skip_on_os("windows")
-  expect_message(tune:::siren("bat", "success"), tune::tune_symbol$success)
+  expect_message(tune:::siren("bat", "success"), tune:::tune_symbol$success)
 })
 
 test_that('tune_log', {
@@ -45,7 +45,7 @@ test_that('tune_log', {
   expect_silent(tune:::tune_log(ctrl_f, NULL, task = "cube", type = "go"))
 
   skip_on_os("windows")
-  expect_message(tune:::tune_log(ctrl_t, rs, task = "cube", type = "success"), tune::tune_symbol$success)
+  expect_message(tune:::tune_log(ctrl_t, rs, task = "cube", type = "success"), tune:::tune_symbol$success)
 })
 
 test_that('log issues', {


### PR DESCRIPTION
@jaredlander this should fix the green unicode checkmark you mentioned here https://github.com/tidymodels/tune/issues/77#issuecomment-547251247