### PR TITLE
moved some tests away from glmnet, added skips for others

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Suggests:
     knitr,
     covr,
     kernlab,
-    glmnet,
     xml2
 Encoding: UTF-8
 LazyData: true

--- a/tests/helper-objects.R
+++ b/tests/helper-objects.R
@@ -47,6 +47,11 @@ weird_annotation <-
 
 glmn <- linear_reg(penalty = tune(), mixture = tune()) %>% set_engine("glmnet")
 
+svm_mod <-
+  svm_rbf(cost = tune()) %>%
+  set_engine("kernlab") %>%
+  set_mode("regression")
+
 # ------------------------------------------------------------------------------
 
 chi_wflow <-

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -37,7 +37,7 @@ test_that('grid objects', {
 
   wflow_1 <-
     workflow() %>%
-    add_model(glmn) %>%
+    add_model(svm_mod) %>%
     add_recipe(bare_rec)
 
   expect_error(grid_2 <- tune:::check_grid(6, wflow_1), NA)
@@ -56,10 +56,9 @@ test_that('workflow objects', {
   skip_if_not_installed("xgboost")
   wflow_1 <-
     workflow() %>%
-    add_model(glmn) %>%
+    add_model(svm_mod) %>%
     add_recipe(bare_rec)
 
-  expect_null(tune:::check_object(x = chi_wflow))
   expect_null(tune:::check_object(x = wflow_1))
 
   wflow_2 <-
@@ -168,9 +167,14 @@ test_that('Bayes control objects', {
 # ------------------------------------------------------------------------------
 
 test_that('initial values', {
+  svm_mod <-
+    svm_rbf(cost = tune()) %>%
+    set_engine("kernlab") %>%
+    set_mode("regression")
+
   wflow_1 <-
     workflow() %>%
-    add_model(glmn) %>%
+    add_model(svm_mod) %>%
     add_recipe(recipe(mpg ~ ., data = mtcars))
 
   grid_1 <- tune:::check_initial(2, dials::parameters(wflow_1), wflow_1,

--- a/tests/testthat/test-min-grid.R
+++ b/tests/testthat/test-min-grid.R
@@ -175,6 +175,9 @@ test_that('boosted tree grid reduction - C5.0', {
 
 
 test_that('linear regression grid reduction - glmnet', {
+  # glmnet depends on >= 3.6.0 so we only test locally
+  skip_if_not_installed("glmnet")
+
   mod <- linear_reg() %>% set_engine("glmnet")
 
   # A typical grid
@@ -263,6 +266,9 @@ test_that('linear regression grid reduction - glmnet', {
 # ------------------------------------------------------------------------------
 
 test_that('logistic regression grid reduction - glmnet', {
+  # glmnet depends on >= 3.6.0 so we only test locally
+  skip_if_not_installed("glmnet")
+
   mod <- logistic_reg() %>% set_engine("glmnet")
 
   # A typical grid
@@ -446,6 +452,9 @@ test_that('MARS grid reduction - earth', {
 # ------------------------------------------------------------------------------
 
 test_that('multinomial regression grid reduction - glmnet', {
+  # glmnet depends on >= 3.6.0 so we only test locally
+  skip_if_not_installed("glmnet")
+
   mod <- multinom_reg() %>% set_engine("glmnet")
 
   # A typical grid


### PR DESCRIPTION
Despite the new `glmnet` version having a dependency of ≥ 3.5.0, it fails on builds less than 3.6.0

This causes `tune` to fail for those versions since it is a dependency.

Anywhere were we could remove `glmnet` from test cases, we switched to a different model. In the other cases, `skip` commands were added. 