### PR TITLE
Add support for dark mode through the option `tune.dark`

### DIFF
--- a/R/control.R
+++ b/R/control.R
@@ -1,7 +1,10 @@
 #' Control the grid search process
 #'
 #' @param verbose A logical for logging results as they are generated. Despite
-#'   this argument, warnings and errors are always shown.
+#'   this argument, warnings and errors are always shown. If using a dark IDE
+#'   theme, some logging messages might be hard to see. If this is the case,
+#'   try setting the `tune.dark` option with `options(tune.dark = TRUE)` to
+#'   print lighter colors.
 #' @param allow_par A logical to allow parallel processing (if a parallel
 #'   backend is registered).
 #' @param extract An optional function with at least one argument (or `NULL`)

--- a/R/logging.R
+++ b/R/logging.R
@@ -3,28 +3,42 @@
 
 siren <- function(x, type = "info") {
   types <- c("warning", "go", "danger", "success", "info")
+
   if (!any(type == types)) {
-    rlang::abort(
-      paste("`type` should be one of: ",
-            paste0("'", types, "'", collapse = ", ")
-      )
+    msg <- paste(
+      "`type` should be one of: ",
+      paste0("'", types, "'", collapse = ", ")
     )
+
+    rlang::abort(msg)
   }
+
   msg <- glue::glue(x)
+
   symb <- dplyr::case_when(
-    type == "warning" ~ crayon::yellow("!"),
-    type == "go" ~ crayon::black(cli::symbol$pointer ),
-    type == "danger" ~ crayon::red("x"),
-    type == "success" ~ crayon::green(tune_symbol$success),
-    TRUE ~ crayon::blue("i")
+    type == "warning" ~ tune_color$symbol$warning("!"),
+    type == "go" ~ tune_color$symbol$go(cli::symbol$pointer),
+    type == "danger" ~ tune_color$symbol$danger("x"),
+    type == "success" ~ tune_color$symbol$success(tune_symbol$success),
+    type == "info" ~ tune_color$symbol$info("i")
   )
+
+  if (is.na(symb)) {
+    rlang::abort("Internal error: Unknown `type`")
+  }
+
   msg <- dplyr::case_when(
-    type == "warning" ~ crayon::yellow(msg),
-    type == "go" ~  crayon::black(msg),
-    type == "danger" ~ crayon::red(msg),
-    type == "success" ~  crayon::black(msg),
-    TRUE ~  crayon::black(msg)
+    type == "warning" ~ tune_color$message$warning(msg),
+    type == "go" ~  tune_color$message$go(msg),
+    type == "danger" ~ tune_color$message$danger(msg),
+    type == "success" ~  tune_color$message$success(msg),
+    type == "info" ~ tune_color$message$info(msg)
   )
+
+  if (is.na(msg)) {
+    rlang::abort("Internal error: Unknown `type`")
+  }
+
   message(paste(symb, msg))
 }
 

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -14,6 +14,44 @@ tune_symbol_ascii <- list(
 
 # ------------------------------------------------------------------------------
 
+# For use in setting the `tune_color` active binding in `.onLoad()`
+
+tune_color_dark <- list(
+  symbol = list(
+    "warning" = crayon::yellow,
+    "go" = crayon::white,
+    "danger" = crayon::red,
+    "success" = crayon::green,
+    "info" = crayon::blue
+  ),
+  message = list(
+    "warning" = crayon::yellow,
+    "go" = crayon::white,
+    "danger" = crayon::red,
+    "success" = crayon::white,
+    "info" = crayon::white
+  )
+)
+
+tune_color_light <- list(
+  symbol = list(
+    "warning" = crayon::yellow,
+    "go" = crayon::black,
+    "danger" = crayon::red,
+    "success" = crayon::green,
+    "info" = crayon::blue
+  ),
+  message = list(
+    "warning" = crayon::yellow,
+    "go" = crayon::black,
+    "danger" = crayon::red,
+    "success" = crayon::black,
+    "info" = crayon::black
+  )
+)
+
+# ------------------------------------------------------------------------------
+
 # cli:::is_latex_output()
 is_latex_output <- function () {
   if (!("knitr" %in% loadedNamespaces())) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -27,4 +27,22 @@
     },
     ns
   )
+
+  makeActiveBinding(
+    "tune_color",
+    function() {
+      opt <- getOption("tune.dark",  NULL)
+
+      if (!is.null(opt)) {
+        if (isTRUE(opt)) {
+          return(tune_color_dark)
+        } else {
+          return(tune_color_light)
+        }
+      }
+
+      tune_color_light
+    },
+    ns
+  )
 }

--- a/man/control_grid.Rd
+++ b/man/control_grid.Rd
@@ -23,7 +23,10 @@ control_resamples(
 }
 \arguments{
 \item{verbose}{A logical for logging results as they are generated. Despite
-this argument, warnings and errors are always shown.}
+this argument, warnings and errors are always shown. If using a dark IDE
+theme, some logging messages might be hard to see. If this is the case,
+try setting the \code{tune.dark} option with \code{options(tune.dark = TRUE)} to
+print lighter colors.}
 
 \item{allow_par}{A logical to allow parallel processing (if a parallel
 backend is registered).}

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -1,0 +1,44 @@
+test_that("Light mode / default `tune_color`s work", {
+  old <- options(tune.dark = NULL)
+  on.exit(options(old))
+
+  expect_equal(
+    tune:::tune_color$symbol$go("hi"),
+    crayon::black("hi")
+  )
+
+  expect_equal(
+    tune:::tune_color$message$info("hi"),
+    crayon::black("hi")
+  )
+})
+
+test_that("Dark mode `tune_color`s work", {
+  old <- options(tune.dark = TRUE)
+  on.exit(options(old))
+
+  expect_equal(
+    tune:::tune_color$symbol$go("hi"),
+    crayon::white("hi")
+  )
+
+  expect_equal(
+    tune:::tune_color$message$info("hi"),
+    crayon::white("hi")
+  )
+})
+
+test_that("`tune_color` falls back to light mode with back `tune.dark` option", {
+  old <- options(tune.dark = "oh no")
+  on.exit(options(old))
+
+  expect_equal(
+    tune:::tune_color$symbol$go("hi"),
+    crayon::black("hi")
+  )
+
+  expect_equal(
+    tune:::tune_color$message$info("hi"),
+    crayon::black("hi")
+  )
+})


### PR DESCRIPTION
Closes #77 

Yay colors!

Before:

<img width="259" alt="Screen Shot 2019-11-13 at 2 47 49 PM" src="https://user-images.githubusercontent.com/19150088/68798620-b8f6e900-0624-11ea-8ba5-c31c978310a9.png">

<img width="482" alt="Screen Shot 2019-11-13 at 2 47 26 PM" src="https://user-images.githubusercontent.com/19150088/68798636-beecca00-0624-11ea-9a2d-9efa85e673e6.png">

After:

<img width="262" alt="Screen Shot 2019-11-13 at 2 47 57 PM" src="https://user-images.githubusercontent.com/19150088/68798658-c57b4180-0624-11ea-970a-f5b223f3545d.png">

<img width="462" alt="Screen Shot 2019-11-13 at 2 47 34 PM" src="https://user-images.githubusercontent.com/19150088/68798659-c57b4180-0624-11ea-855b-226b884829d6.png">