### PR TITLE
no TinyTex and no-manual

### DIFF
--- a/.github/workflows/R.yaml
+++ b/.github/workflows/R.yaml
@@ -14,13 +14,12 @@ jobs:
         with:
           r-version: ${{ matrix.r }}
       - uses: r-lib/actions/setup-pandoc@master
-      - uses: r-lib/actions/setup-tinytex@master
       - name: Install dependencies
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck(error_on = 'error')"
+        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--no-manual', error_on = 'error')"
       - name: Test coverage
         if: matrix.r == '3.6'
         run: |
@@ -33,8 +32,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: r-lib/actions/setup-r@master
       - uses: r-lib/actions/setup-pandoc@master
-      - uses: r-lib/actions/setup-tinytex@master
       - name: Install dependencies
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck(error_on = 'error')"
+        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--no-manual', error_on = 'error')"


### PR DESCRIPTION
For GH actions, TidyTex was timing out. We don't need it for vignettes so we removed it and added `--no-manual` option to `R CMD check`. 