### PR TITLE
fixes to get real outcome name for issue #121

### DIFF
--- a/R/outcome-names.R
+++ b/R/outcome-names.R
@@ -39,6 +39,12 @@ outcome_names.recipe <- function(x, ...) {
 #' @export
 #' @rdname outcome_names
 outcome_names.workflow <- function(x, ...) {
-  preprocessor <- workflows::pull_workflow_preprocessor(x)
-  outcome_names(preprocessor)
+  if (!is.null(x$fit$fit)) {
+    y_vals <- workflows::pull_workflow_mold(x)$outcomes
+    res <- colnames(y_vals)
+  } else {
+    preprocessor <- workflows::pull_workflow_preprocessor(x)
+    res <- outcome_names(preprocessor)
+  }
+  res
 }

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -189,6 +189,7 @@
 #'   set_engine("kernlab") %>%
 #'   set_mode("regression")
 #'
+#' \dontrun{
 #' # Use a space-filling design with 7 points
 #' set.seed(3254)
 #' svm_res <- tune_grid(car_rec, model = svm_mod, resamples = folds, grid = 7)
@@ -198,6 +199,7 @@
 #'
 #' autoplot(svm_res, metric = "rmse") +
 #'   scale_x_log10()
+#' }
 #' @export
 tune_grid <- function(object, ...) {
   UseMethod("tune_grid")

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -247,6 +247,7 @@ svm_mod <-
   set_engine("kernlab") \%>\%
   set_mode("regression")
 
+\dontrun{
 # Use a space-filling design with 7 points
 set.seed(3254)
 svm_res <- tune_grid(car_rec, model = svm_mod, resamples = folds, grid = 7)
@@ -256,6 +257,7 @@ show_best(svm_res, metric = "rmse", maximize = FALSE)
 
 autoplot(svm_res, metric = "rmse") +
   scale_x_log10()
+}
 }
 \seealso{
 \code{\link[=control_grid]{control_grid()}}, \code{\link[=tune]{tune()}}, \code{\link[=fit_resamples]{fit_resamples()}},

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -32,3 +32,32 @@ test_that('exponential decay', {
     expo_decay(10, start_val = 0, limit_val = 50, slope = 1), (1 - exp(-9)) * 50
   )
 })
+
+# ------------------------------------------------------------------------------
+
+test_that('in-line formulas on outcome', {
+  # see issues 121
+  w1 <-
+    workflow() %>%
+    add_formula(log(mpg) ~ .) %>%
+    add_model(linear_reg() %>% set_engine("lm"))
+
+  expect_error(
+    f1 <- fit_resamples(w1, resamples = vfold_cv(mtcars)),
+    regex = NA
+  )
+  expect_true(inherits(f1, "resample_results"))
+
+  w2 <-
+    workflow() %>%
+    add_recipe(recipe(mpg ~ ., data = mtcars) %>% step_log(mpg)) %>%
+    add_model(linear_reg() %>% set_engine("lm"))
+
+  expect_error(
+    f2 <- fit_resamples(w2, resamples = vfold_cv(mtcars)),
+    regex = NA
+  )
+  expect_true(inherits(f2, "resample_results"))
+
+})
+


### PR DESCRIPTION
``` r
library(tidymodels)
#> Registered S3 method overwritten by 'xts':
#>   method     from
#>   as.zoo.xts zoo
#> ── Attaching packages ────────────────────────────────────────────────────────────────────────── tidymodels 0.0.3 ──
#> ✔ broom     0.5.2            ✔ purrr     0.3.3       
#> ✔ dials     0.0.3.9001       ✔ recipes   0.1.7.9001  
#> ✔ dplyr     0.8.3            ✔ rsample   0.0.5       
#> ✔ ggplot2   3.2.1            ✔ tibble    2.99.99.9010
#> ✔ infer     0.5.0            ✔ yardstick 0.0.4       
#> ✔ parsnip   0.0.4
#> ── Conflicts ───────────────────────────────────────────────────────────────────────────── tidymodels_conflicts() ──
#> ✖ purrr::discard()  masks scales::discard()
#> ✖ dplyr::filter()   masks stats::filter()
#> ✖ dplyr::lag()      masks stats::lag()
#> ✖ ggplot2::margin() masks dials::margin()
#> ✖ dials::offset()   masks stats::offset()
#> ✖ recipes::step()   masks stats::step()
library(tune)
library(AmesHousing)

ames <- make_ames() %>% 
  dplyr::select(-matches("Qu"))

set.seed(1000)

data_split <- initial_split(ames)
ames_train <- training(data_split)
ames_test  <- testing(data_split)
folds      <- vfold_cv(data = ames_train, v = 10, strata = "Sale_Price", breaks = 10)

# tune mtry
rf_tuner <-
  rand_forest(mtry = 1) %>%                                   
  set_engine("ranger") %>% 
  set_mode("regression")

rf_tune_by_fold <- fit_resamples(log10(Sale_Price) ~ Gr_Liv_Area, 
                                 model = rf_tuner, 
                                 resamples = folds, 
                                 metric = metric_set(rmse))
collect_metrics(rf_tune_by_fold)
#> # A tibble: 2 x 5
#>   .metric .estimator  mean     n std_err
#>   <chr>   <chr>      <dbl> <int>   <dbl>
#> 1 rmse    standard   0.138    10 0.00218
#> 2 rsq     standard   0.440    10 0.0124
```

<sup>Created on 2019-12-01 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>