### PR TITLE
Unify model fitting under `train_model()`

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -92,7 +92,7 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, contro
 
       workflow <-
         catch_and_log(
-          train_model_from_recipe(workflow, fixed_param, control = control_workflow),
+          train_model(workflow, fixed_param, control = control_workflow),
           control,
           split,
           mod_msg,
@@ -192,7 +192,7 @@ iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
     }
 
     workflow <- catch_and_log(
-      train_model_from_recipe(workflow, NULL, control = control_workflow),
+      train_model(workflow, NULL, control = control_workflow),
       control,
       split,
       mod_msg,
@@ -327,7 +327,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
     mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
 
     workflow <- catch_and_log(
-      train_model_from_recipe(workflow, mod_grid_vals[mod_iter,], control_workflow),
+      train_model(workflow, mod_grid_vals[mod_iter,], control_workflow),
       control,
       split,
       mod_msg,
@@ -440,7 +440,7 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
     mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
 
     workflow <- catch_and_log(
-      train_model_from_mold(workflow, param_val, control = control_workflow),
+      train_model(workflow, param_val, control = control_workflow),
       control,
       split,
       mod_msg,

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -22,7 +22,7 @@ train_recipe <- function(split, workflow, grid) {
   workflow
 }
 
-train_model_from_recipe <- function(workflow, grid, control) {
+train_model <- function(workflow, grid, control) {
   original_spec <- workflows::pull_workflow_spec(workflow)
 
   if (!is.null(grid)) {
@@ -145,18 +145,6 @@ make_rename_arg <- function(grid, model) {
 train_formula <- function(split, workflow) {
   training <- rsample::analysis(split)
   .fit_pre(workflow, training)
-}
-
-train_model_from_mold <- function(workflow, grid, control) {
-  spec <- workflows::pull_workflow_spec(workflow)
-
-  if (!is.null(grid)) {
-    spec <- merge(spec, grid)$x[[1]]
-  }
-
-  workflow <- set_workflow_spec(workflow, spec)
-
-  .fit_model(workflow, control)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/resample.R
+++ b/R/resample.R
@@ -204,7 +204,7 @@ iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, con
   }
 
   workflow <- catch_and_log(
-    train_model_from_recipe(workflow, NULL, control = control_workflow),
+    train_model(workflow, NULL, control = control_workflow),
     control,
     split,
     "model",
@@ -319,7 +319,7 @@ iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, co
   }
 
   workflow <- catch_and_log(
-    train_model_from_mold(workflow, NULL, control = control_workflow),
+    train_model(workflow, NULL, control = control_workflow),
     control,
     split,
     "model",

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -70,6 +70,10 @@ test_that('tune model only (with recipe, multi-predict)', {
   folds <- vfold_cv(mtcars)
   res <- tune_grid(wflow, resamples = folds, grid = grid)
   expect_equal(res$id, folds$id)
+  expect_equal(
+    colnames(res$.metrics[[1]]),
+    c("cost", ".metric", ".estimator", ".estimate")
+  )
   res_est <- collect_metrics(res)
   expect_equal(nrow(res_est), nrow(grid) * 2)
   expect_equal(sum(res_est$.metric == "rmse"), nrow(grid))
@@ -87,6 +91,10 @@ test_that('tune model and recipe', {
   folds <- vfold_cv(mtcars)
   res <- tune_grid(wflow, resamples = folds, grid = grid)
   expect_equal(res$id, folds$id)
+  expect_equal(
+    colnames(res$.metrics[[1]]),
+    c("cost", "num_comp", ".metric", ".estimator", ".estimate")
+  )
   res_est <- collect_metrics(res)
   expect_equal(nrow(res_est), nrow(grid) * 2)
   expect_equal(sum(res_est$.metric == "rmse"), nrow(grid))


### PR DESCRIPTION
Closes #125 

Yea, this happened in the transition. We always need to restore the "original" unfinalized recipe and model after fitting with it.

Because of workflows/hardhat, we can now unify the "fit from formula" and "fit from recipe" paths into a single function, `train_model()`

Note: This will probably fail due to the dials `spline_degree` change in recipes