### PR TITLE
Parsnip logging

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -91,7 +91,7 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, contro
       submd_param <- submd_param$.submodels[[1]]
 
       workflow <-
-        catch_and_log(
+        catch_and_log_fit(
           train_model(workflow, fixed_param, control = control_workflow),
           control,
           split,
@@ -191,7 +191,7 @@ iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
       next
     }
 
-    workflow <- catch_and_log(
+    workflow <- catch_and_log_fit(
       train_model(workflow, NULL, control = control_workflow),
       control,
       split,
@@ -326,7 +326,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
 
     mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
 
-    workflow <- catch_and_log(
+    workflow <- catch_and_log_fit(
       train_model(workflow, mod_grid_vals[mod_iter,], control_workflow),
       control,
       split,
@@ -439,7 +439,7 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
     param_val <- mod_grid_vals[mod_iter, ]
     mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
 
-    workflow <- catch_and_log(
+    workflow <- catch_and_log_fit(
       train_model(workflow, param_val, control = control_workflow),
       control,
       split,

--- a/R/logging.R
+++ b/R/logging.R
@@ -73,17 +73,21 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
     wrn_msg <- map_chr(wrn, ~ .x$message)
     wrn_msg <- unique(wrn_msg)
     wrn_msg <- paste(wrn_msg, collapse = ", ")
-    wrn_msg <- glue::glue_collapse(wrn_msg, width = options()$width - 5)
     wrn_msg <- paste0(loc, ": ", wrn_msg)
+
     notes <- c(notes, wrn_msg)
+
+    wrn_msg <- glue::glue_collapse(wrn_msg, width = options()$width - 5)
     tune_log(control2, split, wrn_msg, type = "warning")
   }
   if (inherits(res$res, "try-error")) {
     err_msg <- as.character(attr(res$res,"condition"))
     err_msg <- gsub("\n$", "", err_msg)
-    err_msg <- glue::glue_collapse(err_msg, width = options()$width - 5)
     err_msg <- paste0(loc, ": ", err_msg)
+
     notes <- c(notes, err_msg)
+
+    err_msg <- glue::glue_collapse(err_msg, width = options()$width - 5)
     tune_log(control2, split, err_msg, type = "danger")
   } else {
     if (!bad_only) {

--- a/R/logging.R
+++ b/R/logging.R
@@ -105,6 +105,26 @@ catch_and_log <- function(.expr, ..., bad_only = FALSE, notes) {
   tmp$res
 }
 
+catch_and_log_fit <- function(expr, ..., notes) {
+  tune_log(..., type = "info")
+
+  result <- catcher(expr)
+  fit <- result$res$fit$fit$fit
+
+  # Log underlying fit failures that parsnip caught and exit
+  if (is_failure(fit)) {
+    result_fit <- list(res = fit, signals = list())
+
+    new_notes <- log_problems(notes, ..., result_fit)
+    assign(".notes", new_notes, envir = parent.frame())
+    return(result$res)
+  }
+
+  new_notes <- log_problems(notes, ..., result)
+  assign(".notes", new_notes, envir = parent.frame())
+  result$res
+}
+
 log_best <- function(control, iter, info, digits = 4) {
   if (!control$verbose) {
     return(invisible(NULL))

--- a/R/resample.R
+++ b/R/resample.R
@@ -203,7 +203,7 @@ iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, con
     return(out)
   }
 
-  workflow <- catch_and_log(
+  workflow <- catch_and_log_fit(
     train_model(workflow, NULL, control = control_workflow),
     control,
     split,
@@ -318,7 +318,7 @@ iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, co
     return(out)
   }
 
-  workflow <- catch_and_log(
+  workflow <- catch_and_log_fit(
     train_model(workflow, NULL, control = control_workflow),
     control,
     split,


### PR DESCRIPTION
Closes #119 

- I've changed `log_problems()` to only truncate the printed error message. The one that ends up in the notes column should be the full thing

- We now have a special `catch_and_log_fit()` that checks to see if the underlying parsnip model failed or not (which parsnip catches elegantly). If it did, it logs that information instead of checking if the overarching fitting process for that model failed.