### PR TITLE
Adds custom class for control_* funs

### DIFF
--- a/R/control.R
+++ b/R/control.R
@@ -40,8 +40,20 @@ control_grid <- function(verbose = FALSE, allow_par = TRUE,
   val_class_or_null(extract, "function", "control_grid()")
 
 
-  list(verbose = verbose, allow_par = allow_par, extract = extract,
-       save_pred = save_pred, pkgs = pkgs)
+  res <- list(verbose = verbose,
+              allow_par = allow_par,
+              extract = extract,
+              save_pred = save_pred,
+              pkgs = pkgs)
+
+  class(res) <- c("control_grid", "control_resamples")
+  res
+}
+
+#' @export
+print.control_grid <- function(x, ...) {
+  cat("grid/resamples control object\n")
+  invisible(x)
 }
 
 #' @rdname control_grid
@@ -124,14 +136,23 @@ control_bayes <-
       )
     }
 
-    list(
-      verbose = verbose,
-      no_improve = no_improve,
-      uncertain = uncertain,
-      seed = seed,
-      extract = extract,
-      save_pred = save_pred,
-      time_limit = time_limit,
-      pkgs = pkgs
-    )
+    res <-
+      list(
+        verbose = verbose,
+        no_improve = no_improve,
+        uncertain = uncertain,
+        seed = seed,
+        extract = extract,
+        save_pred = save_pred,
+        time_limit = time_limit,
+        pkgs = pkgs
+      )
+
+    class(res) <- "control_bayes"
+    res
   }
+
+print.control_bayes <- function(x, ...) {
+  cat("bayes control object\n")
+  invisible(x)
+}

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -182,7 +182,7 @@ test_that('grid control objects', {
   expect_error(control_grid(extract = I), NA)
   expect_error(control_grid(pkgs = NULL), NA)
   expect_error(control_grid(pkgs = letters), NA)
-
+  expect_is(control_grid(), c("control_grid", "control_resamples"))
 })
 
 test_that('Bayes control objects', {
@@ -210,7 +210,7 @@ test_that('Bayes control objects', {
   expect_error(control_bayes(pkgs = NULL), NA)
   expect_error(control_bayes(pkgs = letters), NA)
   expect_error(control_bayes(time_limit = 2), NA)
-
+  expect_is(control_bayes(), "control_bayes")
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR implements what was discussed in #183 .

* Adds a custom class to `control_bayes()` and checks the class in the tests

* Adds a custom class to `control_grid()` of `control_grid` and `control_resamples`. Not sure whether that makes sense since every call to `val_class_*` explicitly calls `control_grid` even if it was called from `control_resamples`. Should `control_resamples` be a separate copy of `control_grid` w/ same args, etc..?

* Implements a simple printout _a la_ `control_parsnip` for the three `control_*`.

Let me know your thoughts on what is useful or what can be improved.