### PR TITLE
Make tunable.model_spec() more type safe.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,7 +12,5 @@ issue_template.md
 ^codecov\.yml$
 ^\.github$
 _cache$
-^.inst/examples$
 ^inst/examples$
 ^LICENSE\.md$
-

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,5 +13,5 @@ issue_template.md
 ^.github$
 _cache$
 ^\.github/workflows/R-CMD-check\.yaml$
-^\inst\examples$
+^\inst/examples$
 ^LICENSE\.md$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,8 +10,9 @@
 issue_template.md
 ^azure-pipelines\.yml$
 ^codecov\.yml$
-^.github$
+^\.github$
 _cache$
-^\.github/workflows/R-CMD-check\.yaml$
-^\inst/examples$
+^.inst/examples$
+^inst/examples$
 ^LICENSE\.md$
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools 
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
     person(given = "Max", family = "Kuhn", email = "max@rstudio.com", role = c("aut", "cre")),
     person("RStudio", role = "cph"))

--- a/R/tunable.R
+++ b/R/tunable.R
@@ -99,9 +99,7 @@ tunable.model_spec <- function(x, ...) {
     dplyr::mutate(
       source = "model_spec",
       component = mod_type(x),
-      component_id = as.character(
-        ifelse(name %in% names(x$args), "main", "engine")
-      )
+      component_id = dplyr::if_else(name %in% names(x$args), "main", "engine")
     )
 
   if (nrow(arg_vals) > 0) {

--- a/R/tunable.R
+++ b/R/tunable.R
@@ -99,7 +99,10 @@ tunable.model_spec <- function(x, ...) {
     dplyr::mutate(
       source = "model_spec",
       component = mod_type(x),
-      component_id = ifelse(name %in% names(x$args), "main", "engine"))
+      component_id = as.character(
+        ifelse(name %in% names(x$args), "main", "engine")
+      )
+    )
 
   if (nrow(arg_vals) > 0) {
     has_info <- purrr::map_lgl(arg_vals$call_info, is.null)


### PR DESCRIPTION
The current version of `tunable.model_spec()` is not type safe because `ifelse()` is not type safe. For example, `ifelse(logical(1), character(1), character(1))` returns `character(1)` but `ifelse(logical(0), character(1), character(1))` returns `logical(0)`. This rears its ugly head in the following example.

``` r
suppressMessages(library(tidymodels))

null_mod_spec <- null_model(mode = "regression") %>% 
  set_engine("parsnip")

training_data <- data.frame(y = runif(99))

rec <- recipe(training_data) %>% 
  update_role(y, new_role = "outcome")

resamp <- vfold_cv(training_data, v = 3)

fit_resamples(null_mod_spec, rec, resamp,
              metrics = metric_set(mae))
#> x Fold1: internal: Error: Element `component_id` should be a character string.
#> x Fold2: internal: Error: Element `component_id` should be a character string.
#> x Fold3: internal: Error: Element `component_id` should be a character string.
#> Warning: All models failed in [fit_resamples()]. See the `.notes` column.
#> Error: Element `component_id` should be a character string.
```

This PR does fix this issue. Here is the same code run with the bug-fixed `tune`.

``` r
suppressMessages(library(tidymodels))

null_mod_spec <- null_model(mode = "regression") %>% 
  set_engine("parsnip")

training_data <- data.frame(y = runif(99))

rec <- recipe(training_data) %>% 
  update_role(y, new_role = "outcome")

resamp <- vfold_cv(training_data, v = 3)

fit_resamples(null_mod_spec, rec, resamp,
              metrics = metric_set(mae))
#> #  3-fold cross-validation 
#> # A tibble: 3 x 4
#>   splits          id    .metrics         .notes          
#>   <list>          <chr> <list>           <list>          
#> 1 <split [66/33]> Fold1 <tibble [1 × 3]> <tibble [0 × 1]>
#> 2 <split [66/33]> Fold2 <tibble [1 × 3]> <tibble [0 × 1]>
#> 3 <split [66/33]> Fold3 <tibble [1 × 3]> <tibble [0 × 1]>
```

<sup>Created on 2020-05-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
