### PR TITLE
Add an H2 header for Overview to index.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,8 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/tune)](https://CRAN.R-project.org/package=tune)
 <!-- badges: end -->
 
+## Overview
+
 The goal of tune is to facilitate the tuning of hyper-parameters the tidymodels packages. It relies heavily on `recipes`, `parsnip`, and `dials`. 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](h
 status](https://www.r-pkg.org/badges/version/tune)](https://CRAN.R-project.org/package=tune)
 <!-- badges: end -->
 
+## Overview
+
 The goal of tune is to facilitate the tuning of hyper-parameters the
 tidymodels packages. It relies heavily on `recipes`, `parsnip`, and
 `dials`.
 
 ## Installation
 
-Install from CRAN:
+Install from
+CRAN:
 
 ``` r
 install.packages("tune", repos = "http://cran.r-project.org") #or your local mirror

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,14 +114,18 @@
 
 <!-- badges: start -->
 
+<div id="overview" class="section level2">
+<h2 class="hasAnchor">
+<a href="#overview" class="anchor"></a>Overview</h2>
 <p>The goal of tune is to facilitate the tuning of hyper-parameters the tidymodels packages. It relies heavily on <code>recipes</code>, <code>parsnip</code>, and <code>dials</code>.</p>
+</div>
 <div id="installation" class="section level2">
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
 <p>Install from CRAN:</p>
 <div class="sourceCode" id="cb1"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"tune"</span>, <span class="kw">repos</span> <span class="kw">=</span> <span class="st">"http://cran.r-project.org"</span>) <span class="co">#or your local mirror</span></pre></div>
 <p>or you can install the current development version using</p>
-<div class="sourceCode" id="cb2"><pre class="r"><span class="kw pkg">devtools</span><span class="kw ns">::</span><span class="fu"><a href="https://devtools.r-lib.org//reference/remote-reexports.html">install_github</a></span>(<span class="st">"tidymodels/tune"</span>)</pre></div>
+<div class="sourceCode" id="cb2"><pre class="r"><span class="kw pkg">devtools</span><span class="kw ns">::</span><span class="fu"><a href="https://rdrr.io/pkg/devtools/man/reexports.html">install_github</a></span>(<span class="st">"tidymodels/tune"</span>)</pre></div>
 </div>
 <div id="examples" class="section level2">
 <h2 class="hasAnchor">


### PR DESCRIPTION
Hi! This adds an H2 to the tune pkgdown homepage so that

* the site will be more consistent with other tidymodels pkgdown sites (e.g. [yardstick](https://yardstick.tidymodels.org/) and [rsample](https://rsample.tidymodels.org/))

* and ensures the tidymodels theme CSS creates enough space between page content and the navbar 

**Before:** 
![image](https://user-images.githubusercontent.com/29008894/84195660-f44b8000-aa6c-11ea-98ce-e57fc0b37abc.png)

**After**: 
![image](https://user-images.githubusercontent.com/29008894/84195629-e7c72780-aa6c-11ea-9f1d-3072ca83dd37.png)


