### PR TITLE
always have a default metric

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 * `conf_mat_resampled()` computes the average confusion matrix across resampling statistics for a single model.  
 
+* `show_best()`, and the `select_*()` functions will now use the first metric in the metric set if no metric is supplied. 
+
 # tune 0.1.0
 
 ## Breaking Changes

--- a/man/show_best.Rd
+++ b/man/show_best.Rd
@@ -7,13 +7,13 @@
 \alias{select_by_one_std_err}
 \title{Investigate best tuning parameters}
 \usage{
-show_best(x, metric, n = 5, ...)
+show_best(x, metric = NULL, n = 5, ...)
 
-select_best(x, metric, ...)
+select_best(x, metric = NULL, ...)
 
-select_by_pct_loss(x, ..., metric, limit = 2)
+select_by_pct_loss(x, ..., metric = NULL, limit = 2)
 
-select_by_one_std_err(x, ..., metric)
+select_by_one_std_err(x, ..., metric = NULL)
 }
 \arguments{
 \item{x}{The results of \code{\link[=tune_grid]{tune_grid()}} or \code{\link[=tune_bayes]{tune_bayes()}}.}
@@ -21,7 +21,9 @@ select_by_one_std_err(x, ..., metric)
 \item{metric}{A character value for the metric that will be used to sort
 the models. (See
 \url{https://tidymodels.github.io/yardstick/articles/metric-types.html} for
-more details). Not required if a single metric exists in \code{x}.}
+more details). Not required if a single metric exists in \code{x}. If there are
+multiple metric and none are given, the first in the metric set is used (and
+a warning is issued).}
 
 \item{n}{An integer for the number of top results/rows to return.}
 

--- a/tests/testthat/test-select_best.R
+++ b/tests/testthat/test-select_best.R
@@ -91,9 +91,12 @@ test_that("select_best()", {
     select_best(rcv_results, metric = c("rmse", "rsq")),
     "Please specify a single character"
   )
-  expect_error(
-    select_best(rcv_results),
-    'argument "metric" is missing, with no default'
+  expect_warning(
+    expect_equal(
+      select_best(rcv_results),
+      select_best(rcv_results, metric = "rmse")
+    ),
+    "metric 'rmse' will be used"
   )
 })
 
@@ -117,6 +120,13 @@ test_that("show_best()", {
   expect_equal(
     show_best(rcv_results, metric = "rmse", n = 1) %>% names(),
     rcv_rmse %>% names()
+  )
+  expect_warning(
+    expect_equal(
+      show_best(rcv_results),
+      show_best(rcv_results, metric = "rmse")
+    ),
+    "metric 'rmse' will be used"
   )
 })
 
@@ -148,9 +158,12 @@ test_that("one-std error rule", {
     select_by_one_std_err(rcv_results, metric = c("rmse", "rsq"), deg_free),
     "Please specify a single character"
   )
-  expect_error(
-    select_by_one_std_err(rcv_results, deg_free),
-    'argument "metric" is missing, with no default'
+  expect_warning(
+    expect_equal(
+      select_by_one_std_err(knn_results, K),
+      select_by_one_std_err(knn_results, K, metric = "roc_auc")
+    ),
+    "metric 'roc_auc' will be used"
   )
   expect_error(
     select_by_one_std_err(rcv_results, metric = "random"),
@@ -186,9 +199,12 @@ test_that("percent loss", {
     select_by_pct_loss(rcv_results, metric = c("rmse", "rsq"), deg_free),
     "Please specify a single character"
   )
-  expect_error(
-    select_by_pct_loss(rcv_results, deg_free),
-    'argument "metric" is missing, with no default'
+  expect_warning(
+    expect_equal(
+      select_by_pct_loss(knn_results, K),
+      select_by_pct_loss(knn_results, K, metric = "roc_auc")
+    ),
+    "metric 'roc_auc' will be used"
   )
   expect_error(
     select_by_pct_loss(rcv_results, metric = "random"),


### PR DESCRIPTION
`show_best()`, and the `select_*()` functions will now use the first metric in the metric set if no metric is supplied. 
