### PR TITLE
Small typo in tune_grid() documentation

### DIFF
--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -40,7 +40,7 @@
 #'         and/or post-processing parameters, the minimum number of fits are
 #'         used. For example, if the number of PCA components in a recipe step
 #'         are being tuned over three values (along with model tuning
-#'         parameters), only three recipes are are trained. The alternative
+#'         parameters), only three recipes are trained. The alternative
 #'         would be to re-train the same recipe multiple times for each model
 #'         tuning parameter.
 #' }
@@ -62,7 +62,7 @@
 #' When provided, the grid should have column names for each parameter and
 #'  these should be named by the parameter name or `id`. For example, if a
 #'  parameter is marked for optimization using `penalty = tune()`, there should
-#'  be a column names `tune`. If the optional identifier is used, such as
+#'  be a column named `penalty`. If the optional identifier is used, such as
 #'  `penalty = tune(id = 'lambda')`, then the corresponding column name should
 #'  be `lambda`.
 #'

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -77,7 +77,7 @@ parameters are equal).
 and/or post-processing parameters, the minimum number of fits are
 used. For example, if the number of PCA components in a recipe step
 are being tuned over three values (along with model tuning
-parameters), only three recipes are are trained. The alternative
+parameters), only three recipes are trained. The alternative
 would be to re-train the same recipe multiple times for each model
 tuning parameter.
 }
@@ -100,7 +100,7 @@ combinations.
 When provided, the grid should have column names for each parameter and
 these should be named by the parameter name or \code{id}. For example, if a
 parameter is marked for optimization using \code{penalty = tune()}, there should
-be a column names \code{tune}. If the optional identifier is used, such as
+be a column named \code{penalty}. If the optional identifier is used, such as
 \code{penalty = tune(id = 'lambda')}, then the corresponding column name should
 be \code{lambda}.
 


### PR DESCRIPTION
I found 2 small typos in the documentation of `tune_grid()` and I fixed them here.

Those are:
1- For example, if a parameter is marked for optimization using penalty = tune(), there should be a column **names tune**. ==> there should be a column **named penalty**
2- For example, if the number of PCA components in a recipe step are being tuned over three values (along with model tuning parameters), only three recipes **are are** trained ==> double are