### PR TITLE
Remove duplicate rows in tuning grid

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -45,6 +45,14 @@ check_grid <- function(x, object, pset = NULL) {
       rlang::abort(grid_msg)
     }
 
+    grid_distinct <- distinct(x)
+    if (!identical(x, grid_distinct)) {
+      rlang::warn(
+        "Duplicate rows in grid of tuning combinations found and removed."
+      )
+      x <- grid_distinct
+    }
+
     tune_tbl <- tune_args(object)
     tune_params <- tune_tbl$id
 

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -31,6 +31,9 @@ test_that('grid objects', {
 
   expect_equal(tune:::check_grid(grid_1, chi_wflow), grid_1)
 
+  expect_warning(tune:::check_grid(rbind(grid_1, grid_1), chi_wflow),
+                 "Duplicate rows in grid of tuning combinations")
+
   expect_error(tune:::check_grid(chi_wflow, chi_wflow),
                "`grid` should be a positive integer or a data frame")
 


### PR DESCRIPTION
This PR closes #259 by removing duplicate rows in a tuning grid, in the `check_grid()` function. A warning is generated:

``` r
library(tidymodels)

folds <- vfold_cv(mtcars, v = 3)
mod <- boost_tree(tree_depth = tune(), min_n = tune()) %>% 
  set_engine("xgboost") %>% 
  set_mode("regression")

dup_grid <- expand.grid(tree_depth = 1:3, min_n = c(1, 2, 1, 2))

mod %>%
  tune_grid(
    mpg ~ .,
    resamples = folds, 
    grid = dup_grid
  )
#> Warning: Duplicate rows in grid of tuning combinations found and removed.
#> 
#> Attaching package: 'xgboost'
#> The following object is masked from 'package:dplyr':
#> 
#>     slice
#> # Tuning results
#> # 3-fold cross-validation 
#> # A tibble: 3 x 4
#>   splits          id    .metrics          .notes          
#>   <list>          <chr> <list>            <list>          
#> 1 <split [21/11]> Fold1 <tibble [12 × 6]> <tibble [0 × 1]>
#> 2 <split [21/11]> Fold2 <tibble [12 × 6]> <tibble [0 × 1]>
#> 3 <split [22/10]> Fold3 <tibble [12 × 6]> <tibble [0 × 1]>
```

<sup>Created on 2020-08-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>