### PR TITLE
Move extraction of `outcome_names`

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -316,10 +316,6 @@ check_initial <- function(x, pset, wflow, resamples, metrics, ctrl) {
       control = control_grid(extract = ctrl$extract, save_pred = ctrl$save_pred)
     )
 
-    # Strip off `tune_results` class since we add on an `iteration_results`
-    # class later.
-    x <- new_bare_tibble(x)
-
     if (ctrl$verbose) {
       tune_log(ctrl, split = NULL, "Initialization complete", type = "success")
       message()

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -18,6 +18,7 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, contro
   metric_est <- NULL
   extracted <- NULL
   pred_vals <- NULL
+  all_outcome_names <- list()
   .notes <- NULL
 
   split <- resamples$splits[[rs_iter]]
@@ -117,6 +118,9 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, contro
         next
       }
 
+      # Extract names from the mold
+      all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
+
       all_param <- dplyr::bind_cols(rec_grid_vals, mod_grid_vals[mod_iter, ])
 
       extracted <-
@@ -149,7 +153,13 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, contro
 
   } # end recipe loop
 
-  list(.metrics = metric_est, .extracts = extracted, .predictions = pred_vals, .notes = .notes)
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
 }
 
 tune_rec_and_mod <- function(resamples, grid, workflow, metrics, control) {
@@ -171,6 +181,7 @@ tune_rec_and_mod <- function(resamples, grid, workflow, metrics, control) {
   resamples <- pull_notes(resamples, results, control)
   resamples <- pull_extracts(resamples, results, control)
   resamples <- pull_predictions(resamples, results, control)
+  resamples <- pull_all_outcome_names(resamples, results)
 
   resamples
 }
@@ -188,6 +199,7 @@ iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
   metric_est <- NULL
   extracted <- NULL
   pred_vals <- NULL
+  all_outcome_names <- list()
   .notes <- NULL
 
   num_rec <- nrow(grid)
@@ -227,6 +239,9 @@ iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
       next
     }
 
+    # Extract names from the mold
+    all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
+
     extracted <-
       append_extracts(
         extracted,
@@ -258,8 +273,13 @@ iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
     pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
   } # recipe parameters
 
-  list(.metrics = metric_est, .extracts = extracted, .predictions = pred_vals, .notes = .notes)
-
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
 }
 
 tune_rec <- function(resamples, grid, workflow, metrics, control) {
@@ -279,6 +299,7 @@ tune_rec <- function(resamples, grid, workflow, metrics, control) {
   resamples <- pull_notes(resamples, results, control)
   resamples <- pull_extracts(resamples, results, control)
   resamples <- pull_predictions(resamples, results, control)
+  resamples <- pull_all_outcome_names(resamples, results)
 
   resamples
 }
@@ -303,6 +324,7 @@ tune_mod_with_recipe <- function(resamples, grid, workflow, metrics, control) {
   resamples <- pull_notes(resamples, results, control)
   resamples <- pull_extracts(resamples, results, control)
   resamples <- pull_predictions(resamples, results, control)
+  resamples <- pull_all_outcome_names(resamples, results)
 
   resamples
 }
@@ -318,6 +340,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
   metric_est <- NULL
   extracted <- NULL
   pred_vals <- NULL
+  all_outcome_names <- list()
   .notes <- NULL
 
   # ----------------------------------------------------------------------------
@@ -336,6 +359,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
       .metrics = metric_est,
       .extracts = extracted,
       .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
       .notes = .notes
     )
 
@@ -380,6 +404,9 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
       next
     }
 
+    # Extract names from the mold
+    all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
+
     extracted <-
       append_extracts(
         extracted,
@@ -409,7 +436,13 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
     pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
   } # end model loop
 
-  list(.metrics = metric_est, .extracts = extracted, .predictions = pred_vals, .notes = .notes)
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
 }
 
 # ------------------------------------------------------------------------------
@@ -431,6 +464,7 @@ tune_mod_with_formula <- function(resamples, grid, workflow, metrics, control) {
   resamples <- pull_notes(resamples, results, control)
   resamples <- pull_extracts(resamples, results, control)
   resamples <- pull_predictions(resamples, results, control)
+  resamples <- pull_all_outcome_names(resamples, results)
 
   resamples
 }
@@ -446,6 +480,7 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
   metric_est <- NULL
   extracted <- NULL
   pred_vals <- NULL
+  all_outcome_names <- list()
   .notes <- NULL
 
   # ----------------------------------------------------------------------------
@@ -464,6 +499,7 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
       .metrics = metric_est,
       .extracts = extracted,
       .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
       .notes = .notes
     )
 
@@ -508,6 +544,9 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
       next
     }
 
+    # Extract names from the mold
+    all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
+
     extracted <-
       append_extracts(extracted,
                       workflow,
@@ -537,7 +576,13 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
     pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
   } # end model loop
 
-  list(.metrics = metric_est, .extracts = extracted, .predictions = pred_vals, .notes = .notes)
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
 }
 
 # ----------------------------------------------------------------------------
@@ -586,6 +631,7 @@ super_safely_iterate_impl <- function(fn, rs_iter, resamples, grid, workflow, me
       .metrics = NULL,
       .extracts = NULL,
       .predictions = NULL,
+      .all_outcome_names = list(),
       .notes = NULL
     )
   }

--- a/R/resample.R
+++ b/R/resample.R
@@ -155,13 +155,16 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
     )
   }
 
+  outcomes <- reduce_all_outcome_names(resamples)
+  resamples[[".all_outcome_names"]] <- NULL
+
   workflow_output <- set_workflow(workflow, control)
 
   new_resample_results(
     x = resamples,
     parameters = parameters(workflow),
     metrics = metrics,
-    outcomes = outcome_names(workflow),
+    outcomes = outcomes,
     rset_info = rset_info,
     workflow = workflow_output
   )
@@ -196,6 +199,7 @@ resample_with_recipe <- function(resamples, workflow, metrics, control) {
   resamples <- pull_notes(resamples, results, control)
   resamples <- pull_extracts(resamples, results, control)
   resamples <- pull_predictions(resamples, results, control)
+  resamples <- pull_all_outcome_names(resamples, results)
 
   resamples
 }
@@ -211,6 +215,7 @@ iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, con
   metric_est <- NULL
   extracted <- NULL
   pred_vals <- NULL
+  all_outcome_names <- list()
   .notes <- NULL
 
   workflow <- catch_and_log(
@@ -226,6 +231,7 @@ iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, con
       .metrics = metric_est,
       .extracts = extracted,
       .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
       .notes = .notes
     )
 
@@ -246,11 +252,15 @@ iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, con
       .metrics = metric_est,
       .extracts = extracted,
       .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
       .notes = .notes
     )
 
     return(out)
   }
+
+  # Extract names from the mold
+  all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
 
   # Dummy tbl with no columns but the correct number of rows to `bind_cols()`
   # against in `append_extracts()`
@@ -273,6 +283,7 @@ iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, con
       .metrics = metric_est,
       .extracts = extracted,
       .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
       .notes = .notes
     )
 
@@ -282,7 +293,13 @@ iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, con
   metric_est <- append_metrics(metric_est, predictions, workflow, metrics, split)
   pred_vals <- append_predictions(pred_vals, predictions, split, control)
 
-  list(.metrics = metric_est, .extracts = extracted, .predictions = pred_vals, .notes = .notes)
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
 }
 
 # ------------------------------------------------------------------------------
@@ -314,6 +331,7 @@ resample_with_formula <- function(resamples, workflow, metrics, control) {
   resamples <- pull_notes(resamples, results, control)
   resamples <- pull_extracts(resamples, results, control)
   resamples <- pull_predictions(resamples, results, control)
+  resamples <- pull_all_outcome_names(resamples, results)
 
   resamples
 }
@@ -329,6 +347,7 @@ iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, co
   metric_est <- NULL
   extracted <- NULL
   pred_vals <- NULL
+  all_outcome_names <- list()
   .notes <- NULL
 
   workflow <- catch_and_log(
@@ -344,6 +363,7 @@ iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, co
       .metrics = metric_est,
       .extracts = extracted,
       .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
       .notes = .notes
     )
 
@@ -364,11 +384,15 @@ iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, co
       .metrics = metric_est,
       .extracts = extracted,
       .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
       .notes = .notes
     )
 
     return(out)
   }
+
+  # Extract names from the mold
+  all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
 
   # Dummy tbl with no columns but the correct number of rows to `bind_cols()`
   # against in `append_extracts()`
@@ -391,6 +415,7 @@ iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, co
       .metrics = metric_est,
       .extracts = extracted,
       .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
       .notes = .notes
     )
 
@@ -400,7 +425,13 @@ iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, co
   metric_est <- append_metrics(metric_est, predictions, workflow, metrics, split)
   pred_vals <- append_predictions(pred_vals, predictions, split, control)
 
-  list(.metrics = metric_est, .extracts = extracted, .predictions = pred_vals, .notes = .notes)
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
 }
 
 # ------------------------------------------------------------------------------

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -247,7 +247,6 @@ tune_bayes_workflow <-
     start_time <- proc.time()[3]
 
     check_rset(resamples)
-    y_names <- outcome_names(object)
     rset_info <- pull_rset_attributes(resamples)
 
     metrics <- check_metrics(metrics, object)
@@ -262,14 +261,29 @@ tune_bayes_workflow <-
 
     unsummarized <- check_initial(initial, param_info, object, resamples, metrics, control)
 
+    # Pull outcome names from initialization run
+    outcomes <- peek_tune_results_outcomes(unsummarized)
+
+    # Strip off `tune_results` class and drop all attributes since
+    # we add on an `iteration_results` class later.
+    unsummarized <- new_bare_tibble(unsummarized)
+
     mean_stats <- estimate_tune_results(unsummarized)
 
     check_time(start_time, control$time_limit)
 
     on.exit({
       cli::cli_alert_danger("Optimization stopped prematurely; returning current results.")
-      out <- new_iteration_results(unsummarized, param_info, metrics, y_names,
-                                   rset_info, workflow = NULL)
+
+      out <- new_iteration_results(
+        x = unsummarized,
+        parameters = param_info,
+        metrics = metrics,
+        outcomes = outcomes,
+        rset_info = rset_info,
+        workflow = NULL
+      )
+
       return(out)
     })
 
@@ -385,7 +399,7 @@ tune_bayes_workflow <-
       x = unsummarized,
       parameters = param_info,
       metrics = metrics,
-      outcomes = y_names,
+      outcomes = outcomes,
       rset_info = rset_info,
       workflow = workflow_output
     )

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -334,13 +334,16 @@ tune_grid_workflow <- function(object,
     rlang::warn("All models failed in tune_grid(). See the `.notes` column.")
   }
 
+  outcomes <- reduce_all_outcome_names(resamples)
+  resamples[[".all_outcome_names"]] <- NULL
+
   workflow_output <- set_workflow(object, control)
 
   new_tune_results(
     x = resamples,
     parameters = pset,
     metrics = metrics,
-    outcomes = outcome_names(object),
+    outcomes = outcomes,
     rset_info = rset_info,
     workflow = workflow_output
   )

--- a/R/tune_results.R
+++ b/R/tune_results.R
@@ -92,3 +92,21 @@ new_tune_results <- function(x, parameters, metrics, outcomes = character(0), rs
     class = c(class, "tune_results")
   )
 }
+
+is_tune_results <- function(x) {
+  inherits(x, "tune_results")
+}
+
+peek_tune_results_outcomes <- function(x) {
+  if (!is_tune_results(x)) {
+    rlang::abort("Internal error: `outcomes` can only be extracted from 'tune_results'.")
+  }
+
+  out <- attr(x, "outcomes", exact = TRUE)
+
+  if (is.null(out)) {
+    rlang::abort("'tune_results' object doesn't have an 'outcomes' attribute.")
+  }
+
+  out
+}


### PR DESCRIPTION
We currently call `outcome_names()` on unfit workflows to construct resample_results/tune_results. While this is convenient, it won't work with `workflows::all_variables()` because the `outcomes` are supplied as a tidyselect specification. Until the preprocessing section of the workflow is done, we won't be able to determine the actual outcome variables.

This PR moves the extraction of `outcome_names` further down into the tune loop. They are now extracted after the model fit is done. That aligns with the current definition of `outcome_names.workflow()` which requires a fit to be present before pulling the outcomes off the preprocessed mold.

```r
> outcome_names.workflow
function(x, ...) {
  if (!is.null(x$fit$fit)) {
    y_vals <- workflows::pull_workflow_mold(x)$outcomes
    res <- colnames(y_vals)
  } else {
    preprocessor <- workflows::pull_workflow_preprocessor(x)
    res <- outcome_names(preprocessor)
  }
  res
}
```

This is more complicated than before, unfortunately, because now the outcomes are extracted from each model fit (so we end up with many vectors of the same outcome names, rather than just one). That said, it does allow us to add a few more sanity checks in. After all of the tuning has been done, we now collapse the vectors of outcome names down to just the unique ones. Ideally there is just 1 unique set of outcome names (all models were fit with the same outcomes). If this isn't the case, either all models failed or the user specified something very incorrectly, which we can warn them about.