### PR TITLE
Add `workflows::add_variables()` support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     GPfit,
     foreach,
     parsnip (>= 0.0.4),
-    workflows (>= 0.1.0),
+    workflows (>= 0.1.3.9000),
     hardhat (>= 0.1.0),
     lifecycle,
     vctrs (>= 0.3.0)
@@ -49,4 +49,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Language: en-US
 Remotes:
-    tidymodels/rsample
+    tidymodels/rsample,
+    tidymodels/workflows

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     rlang (>= 0.4.0),
     tibble (>= 2.1.3),
     purrr (>= 0.3.2),
-    dials (>= 0.0.4),
+    dials (>= 0.0.8.9001),
     recipes (>= 0.1.9),
     utils,
     ggplot2,
@@ -50,4 +50,5 @@ RoxygenNote: 7.1.1
 Language: en-US
 Remotes:
     tidymodels/rsample,
-    tidymodels/workflows
+    tidymodels/workflows,
+    tidymodels/dials

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
 
 * Fixed two bugs in the acquisition function calculations.
 
+## Other Changes
+
+* tune now supports workflows created with the new `workflows::add_variables()`
+  preprocessor.
+
 # tune 0.1.1
 
 ## Breaking Changes

--- a/R/checks.R
+++ b/R/checks.R
@@ -209,15 +209,11 @@ check_workflow <- function(x, pset = NULL, check_dials = FALSE) {
     rlang::abort("The `object` argument should be a 'workflow' object.")
   }
 
-  has_preprocessor <- has_preprocessor_formula(x) || has_preprocessor_recipe(x)
-
-  if (!has_preprocessor) {
-    rlang::abort("A model formula or recipe are required.")
+  if (!has_preprocessor(x)) {
+    rlang::abort("A formula, recipe, or variables preprocessor is required.")
   }
 
-  has_spec <- has_spec(x)
-
-  if (!has_spec) {
+  if (!has_spec(x)) {
     rlang::abort("A parsnip model is required.")
   }
 

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -6,6 +6,10 @@ tune_nothing_with_formula <- function(resamples, grid, workflow, metrics, contro
   resample_with_formula(resamples, workflow, metrics, control)
 }
 
+tune_nothing_with_variables <- function(resamples, grid, workflow, metrics, control)  {
+  resample_with_variables(resamples, workflow, metrics, control)
+}
+
 # ------------------------------------------------------------------------------
 
 iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, control) {

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -591,7 +591,150 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
   )
 }
 
-# ----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+
+tune_mod_with_variables <- function(resamples, grid, workflow, metrics, control) {
+  B <- nrow(resamples)
+
+  `%op%` <- get_operator(control$allow_par, workflow)
+
+  safely_iter_mod_with_variables <- super_safely_iterate(iter_mod_with_variables)
+
+  load_pkgs <- c(control$pkgs, required_pkgs(workflow))
+
+  results <- foreach::foreach(rs_iter = 1:B,
+                              .packages = load_pkgs,
+                              .errorhandling = "pass") %op% {
+    safely_iter_mod_with_variables(rs_iter, resamples, grid, workflow, metrics, control)
+  }
+
+  resamples <- pull_metrics(resamples, results, control)
+  resamples <- pull_notes(resamples, results, control)
+  resamples <- pull_extracts(resamples, results, control)
+  resamples <- pull_predictions(resamples, results, control)
+  resamples <- pull_all_outcome_names(resamples, results)
+
+  resamples
+}
+
+iter_mod_with_variables <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+  load_pkgs(workflow)
+  load_namespace(control$pkgs)
+
+  control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
+  control_workflow <- control_workflow(control_parsnip = control_parsnip)
+
+  split <- resamples$splits[[rs_iter]]
+  metric_est <- NULL
+  extracted <- NULL
+  pred_vals <- NULL
+  all_outcome_names <- list()
+  .notes <- NULL
+
+  # ----------------------------------------------------------------------------
+
+  workflow <- catch_and_log(
+    train_variables(split, workflow),
+    control,
+    split,
+    "variables",
+    notes = .notes
+  )
+
+  # check for failure
+  if (is_failure(workflow)) {
+    out <- list(
+      .metrics = metric_est,
+      .extracts = extracted,
+      .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
+      .notes = .notes
+    )
+
+    return(out)
+  }
+
+  # ----------------------------------------------------------------------------
+
+  # Determine the _minimal_ number of models to fit in order to get
+  # predictions on all models.
+  mod_grid_vals <- workflows::pull_workflow_spec(workflow) %>% min_grid(grid)
+
+  num_mod <- nrow(mod_grid_vals)
+  num_submodels <- mod_grid_vals %>%
+    unnest(.submodels, keep_empty = TRUE) %>%
+    pull(.submodels) %>%
+    map_int(length)
+
+  original_workflow <- workflow
+
+  for (mod_iter in 1:num_mod) {
+    workflow <- original_workflow
+
+    param_val <- mod_grid_vals[mod_iter, ]
+    submodel_id <- mod_iter + sum(vec_slice(num_submodels, 1:mod_iter))
+    mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
+    mod_id <- vec_slice(
+      recipes::names0(nrow(grid), "Model"),
+      (submodel_id - num_submodels[mod_iter]):submodel_id
+    )
+
+    workflow <- catch_and_log_fit(
+      train_model(workflow, param_val, control = control_workflow),
+      control,
+      split,
+      mod_msg,
+      notes = .notes
+    )
+
+    # check for parsnip level and model level failure
+    if (is_failure(workflow) || is_failure(workflow$fit$fit$fit)) {
+      next
+    }
+
+    # Extract names from the mold
+    all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
+
+    extracted <- append_extracts(
+      extracted,
+      workflow,
+      param_val,
+      split,
+      control,
+      mod_id
+    )
+
+    pred_msg <- paste(mod_msg, "(predictions)")
+
+    tmp_pred <- catch_and_log(
+      predict_model(split, workflow, param_val, metrics),
+      control,
+      split,
+      pred_msg,
+      bad_only = TRUE,
+      notes = .notes
+    )
+
+    # check for prediction level failure
+    if (is_failure(tmp_pred)) {
+      next
+    }
+
+    metric_est  <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, mod_id)
+    config_id <- extract_config(workflow, metric_est)
+    pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
+  } # end model loop
+
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
+}
+
+# ------------------------------------------------------------------------------
 
 super_safely_iterate <- function(fn) {
   purrr::partial(.f = super_safely_iterate_impl, fn = fn)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -353,7 +353,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
     notes = .notes
   )
 
-  # check for recipe failure
+  # check for failure
   if (is_failure(workflow)) {
     out <- list(
       .metrics = metric_est,
@@ -392,7 +392,7 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
     )
 
     workflow <- catch_and_log_fit(
-      train_model(workflow, mod_grid_vals[mod_iter,], control_workflow),
+      train_model(workflow, param_val, control_workflow),
       control,
       split,
       mod_msg,
@@ -407,21 +407,22 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
     # Extract names from the mold
     all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
 
-    extracted <-
-      append_extracts(
-        extracted,
-        workflow,
-        mod_grid_vals[mod_iter, ],
-        split,
-        control,
-        mod_id
-      )
+    extracted <- append_extracts(
+      extracted,
+      workflow,
+      param_val,
+      split,
+      control,
+      mod_id
+    )
+
+    pred_msg <- paste(mod_msg, "(predictions)")
 
     tmp_pred <- catch_and_log(
-      predict_model(split, workflow, mod_grid_vals[mod_iter,], metrics),
+      predict_model(split, workflow, param_val, metrics),
       control,
       split,
-      paste(mod_msg, "(predictions)"),
+      pred_msg,
       bad_only = TRUE,
       notes = .notes
     )
@@ -493,7 +494,7 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
     notes = .notes
   )
 
-  # check for formula failure
+  # check for failure
   if (is_failure(workflow)) {
     out <- list(
       .metrics = metric_est,
@@ -547,24 +548,25 @@ iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, c
     # Extract names from the mold
     all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
 
-    extracted <-
-      append_extracts(extracted,
-                      workflow,
-                      param_val,
-                      split,
-                      control,
-                      mod_id)
+    extracted <- append_extracts(
+      extracted,
+      workflow,
+      param_val,
+      split,
+      control,
+      mod_id
+    )
 
     pred_msg <- paste(mod_msg, "(predictions)")
 
-    tmp_pred <-
-      catch_and_log(
-        predict_model(split, workflow, param_val, metrics),
-        control,
-        split,
-        mod_msg,
-        notes = .notes
-      )
+    tmp_pred <- catch_and_log(
+      predict_model(split, workflow, param_val, metrics),
+      control,
+      split,
+      pred_msg,
+      bad_only = TRUE,
+      notes = .notes
+    )
 
     # check for prediction level failure
     if (is_failure(tmp_pred)) {

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -148,6 +148,20 @@ train_formula <- function(split, workflow) {
 }
 
 # ------------------------------------------------------------------------------
+# Variables-oriented helpers
+
+train_variables <- function(split, workflow) {
+  training <- rsample::analysis(split)
+  .fit_pre(workflow, training)
+}
+
+# ------------------------------------------------------------------------------
+
+has_preprocessor <- function(workflow) {
+  has_preprocessor_recipe(workflow) ||
+    has_preprocessor_formula(workflow) ||
+    has_preprocessor_variables(workflow)
+}
 
 has_preprocessor_recipe <- function(workflow) {
   "recipe" %in% names(workflow$pre$actions)
@@ -155,6 +169,10 @@ has_preprocessor_recipe <- function(workflow) {
 
 has_preprocessor_formula <- function(workflow) {
   "formula" %in% names(workflow$pre$actions)
+}
+
+has_preprocessor_variables <- function(workflow) {
+  "variables" %in% names(workflow$pre$actions)
 }
 
 has_spec <- function(workflow) {

--- a/R/resample.R
+++ b/R/resample.R
@@ -137,16 +137,18 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
   check_workflow(workflow)
   metrics <- check_metrics(metrics, workflow)
 
-  has_formula <- has_preprocessor_formula(workflow)
-
   # Save rset attributes, then fall back to a bare tibble
   rset_info <- pull_rset_attributes(resamples)
   resamples <- new_bare_tibble(resamples)
 
-  if (has_formula) {
+  if (has_preprocessor_formula(workflow)) {
     resamples <- resample_with_formula(resamples, workflow, metrics, control)
-  } else {
+  } else if (has_preprocessor_recipe(workflow)) {
     resamples <- resample_with_recipe(resamples, workflow, metrics, control)
+  } else if (has_preprocessor_variables(workflow)) {
+    resamples <- resample_with_variables(resamples, workflow, metrics, control)
+  } else {
+    rlang::abort("Internal error: `workflow` should have been checked for a preprocessor by now.")
   }
 
   if (is_cataclysmic(resamples)) {
@@ -355,6 +357,135 @@ iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, co
     control,
     split,
     "formula",
+    notes = .notes
+  )
+
+  if (is_failure(workflow)) {
+    out <- list(
+      .metrics = metric_est,
+      .extracts = extracted,
+      .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
+      .notes = .notes
+    )
+
+    return(out)
+  }
+
+  workflow <- catch_and_log_fit(
+    train_model(workflow, NULL, control = control_workflow),
+    control,
+    split,
+    "model",
+    notes = .notes
+  )
+
+  # check for parsnip level and model level failure
+  if (is_failure(workflow) || is_failure(workflow$fit$fit$fit)) {
+    out <- list(
+      .metrics = metric_est,
+      .extracts = extracted,
+      .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
+      .notes = .notes
+    )
+
+    return(out)
+  }
+
+  # Extract names from the mold
+  all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
+
+  # Dummy tbl with no columns but the correct number of rows to `bind_cols()`
+  # against in `append_extracts()`
+  split_label_tbl <- labels(split)
+  dummy_param_tbl <- tibble(.rows = nrow(split_label_tbl))
+
+  extracted <- append_extracts(extracted, workflow, dummy_param_tbl, split, control)
+
+  predictions <- catch_and_log(
+    predict_model_no_grid(split, workflow, metrics),
+    control,
+    split,
+    "model (predictions)",
+    bad_only = TRUE,
+    notes = .notes
+  )
+
+  if (is_failure(predictions)) {
+    out <- list(
+      .metrics = metric_est,
+      .extracts = extracted,
+      .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
+      .notes = .notes
+    )
+
+    return(out)
+  }
+
+  metric_est <- append_metrics(metric_est, predictions, workflow, metrics, split)
+  pred_vals <- append_predictions(pred_vals, predictions, split, control)
+
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
+}
+
+# ------------------------------------------------------------------------------
+
+resample_with_variables <- function(resamples, workflow, metrics, control) {
+  B <- nrow(resamples)
+
+  `%op%` <- get_operator(control$allow_par, workflow)
+
+  safely_iter_resample_with_variables <- super_safely_iterate(iter_resample_with_variables)
+
+  results <- foreach::foreach(rs_iter = 1:B,
+                              .packages = required_pkgs(workflow),
+                              .errorhandling = "pass") %op% {
+    safely_iter_resample_with_variables(
+      rs_iter = rs_iter,
+      resamples = resamples,
+      grid = NULL,
+      workflow = workflow,
+      metrics = metrics,
+      control = control
+    )
+  }
+
+  resamples <- pull_metrics(resamples, results, control)
+  resamples <- pull_notes(resamples, results, control)
+  resamples <- pull_extracts(resamples, results, control)
+  resamples <- pull_predictions(resamples, results, control)
+  resamples <- pull_all_outcome_names(resamples, results)
+
+  resamples
+}
+
+iter_resample_with_variables <- function(rs_iter, resamples, workflow, metrics, control) {
+  load_pkgs(workflow)
+  load_namespace(control$pkgs)
+
+  control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
+  control_workflow <- control_workflow(control_parsnip = control_parsnip)
+
+  split <- resamples$splits[[rs_iter]]
+  metric_est <- NULL
+  extracted <- NULL
+  pred_vals <- NULL
+  all_outcome_names <- list()
+  .notes <- NULL
+
+  workflow <- catch_and_log(
+    train_variables(split, workflow),
+    control,
+    split,
+    "variables",
     notes = .notes
   )
 

--- a/R/resample.R
+++ b/R/resample.R
@@ -22,6 +22,7 @@
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)
+#' library(workflows)
 #'
 #' set.seed(6735)
 #' folds <- vfold_cv(mtcars, v = 5)
@@ -40,6 +41,16 @@
 #' spline_res
 #'
 #' show_best(spline_res, metric = "rmse")
+#'
+#' # You can also wrap up a preprocessor and a model into a workflow, and
+#' # supply that to `fit_resamples()` instead. Here, a workflows "variables"
+#' # preprocessor is used, which lets you supply terms using tidyselect.
+#' # The variables are used as-is, no preprocessing is done to them.
+#' wf <- workflow() %>%
+#'   add_variables(outcomes = mpg, predictors = everything()) %>%
+#'   add_model(lin_mod)
+#'
+#' wf_res <- fit_resamples(wf, folds)
 #' }
 #' @export
 fit_resamples <- function(object, ...) {

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -159,6 +159,7 @@
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)
+#' library(workflows)
 #' library(ggplot2)
 #'
 #' # ---------------------------------------------------------------------------
@@ -214,6 +215,21 @@
 #' autoplot(svm_res, metric = "rmse") +
 #'   scale_x_log10()
 #' }
+#'
+#' # ---------------------------------------------------------------------------
+#'
+#' # Using a variables preprocessor with a workflow
+#'
+#' # Rather than supplying a preprocessor (like a recipe) and a model directly
+#' # to `tune_grid()`, you can also wrap them up in a workflow and pass
+#' # that along instead (note that this doesn't do any preprocessing to
+#' # the variables, it passes them along as-is).
+#' wf <- workflow() %>%
+#'   add_variables(outcomes = mpg, predictors = everything()) %>%
+#'   add_model(svm_mod)
+#'
+#' set.seed(3254)
+#' svm_res_wf <- tune_grid(wf, resamples = folds, grid = 7)
 #' @export
 tune_grid <- function(object, ...) {
   UseMethod("tune_grid")

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -214,7 +214,6 @@
 #'
 #' autoplot(svm_res, metric = "rmse") +
 #'   scale_x_log10()
-#' }
 #'
 #' # ---------------------------------------------------------------------------
 #'
@@ -230,6 +229,7 @@
 #'
 #' set.seed(3254)
 #' svm_res_wf <- tune_grid(wf, resamples = folds, grid = 7)
+#' }
 #' @export
 tune_grid <- function(object, ...) {
   UseMethod("tune_grid")

--- a/man/fit_resamples.Rd
+++ b/man/fit_resamples.Rd
@@ -140,6 +140,7 @@ grid has a separate R object associated with it.
 library(recipes)
 library(rsample)
 library(parsnip)
+library(workflows)
 
 set.seed(6735)
 folds <- vfold_cv(mtcars, v = 5)
@@ -158,6 +159,16 @@ spline_res <- fit_resamples(lin_mod, spline_rec, folds, control = control)
 spline_res
 
 show_best(spline_res, metric = "rmse")
+
+# You can also wrap up a preprocessor and a model into a workflow, and
+# supply that to `fit_resamples()` instead. Here, a workflows "variables"
+# preprocessor is used, which lets you supply terms using tidyselect.
+# The variables are used as-is, no preprocessing is done to them.
+wf <- workflow() \%>\%
+  add_variables(outcomes = mpg, predictors = everything()) \%>\%
+  add_model(lin_mod)
+
+wf_res <- fit_resamples(wf, folds)
 }
 }
 \seealso{

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -205,6 +205,7 @@ grid has a separate R object associated with it.
 library(recipes)
 library(rsample)
 library(parsnip)
+library(workflows)
 library(ggplot2)
 
 # ---------------------------------------------------------------------------
@@ -260,6 +261,21 @@ show_best(svm_res, metric = "rmse")
 autoplot(svm_res, metric = "rmse") +
   scale_x_log10()
 }
+
+# ---------------------------------------------------------------------------
+
+# Using a variables preprocessor with a workflow
+
+# Rather than supplying a preprocessor (like a recipe) and a model directly
+# to `tune_grid()`, you can also wrap them up in a workflow and pass
+# that along instead (note that this doesn't do any preprocessing to
+# the variables, it passes them along as-is).
+wf <- workflow() \%>\%
+  add_variables(outcomes = mpg, predictors = everything()) \%>\%
+  add_model(svm_mod)
+
+set.seed(3254)
+svm_res_wf <- tune_grid(wf, resamples = folds, grid = 7)
 }
 \seealso{
 \code{\link[=control_grid]{control_grid()}}, \code{\link[=tune]{tune()}}, \code{\link[=fit_resamples]{fit_resamples()}},

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -260,7 +260,6 @@ show_best(svm_res, metric = "rmse")
 
 autoplot(svm_res, metric = "rmse") +
   scale_x_log10()
-}
 
 # ---------------------------------------------------------------------------
 
@@ -276,6 +275,7 @@ wf <- workflow() \%>\%
 
 set.seed(3254)
 svm_res_wf <- tune_grid(wf, resamples = folds, grid = 7)
+}
 }
 \seealso{
 \code{\link[=control_grid]{control_grid()}}, \code{\link[=tune]{tune()}}, \code{\link[=fit_resamples]{fit_resamples()}},

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -65,6 +65,38 @@ test_that('tune model only (with recipe)', {
 
 # ------------------------------------------------------------------------------
 
+test_that('tune model only (with variables)', {
+  set.seed(4400)
+
+  wflow <- workflow() %>%
+    add_variables(mpg, c(-mpg, everything())) %>%
+    add_model(svm_mod)
+
+  pset <- dials::parameters(wflow)
+
+  folds <- vfold_cv(mtcars)
+
+  res <- tune_bayes(
+    wflow,
+    resamples = folds,
+    param_info = pset,
+    initial = iter1,
+    iter = iter2
+  )
+
+  expect_equal(unique(res$id), folds$id)
+
+  res_est <- collect_metrics(res)
+
+  expect_equal(nrow(res_est), iterT * 2)
+  expect_equal(sum(res_est$.metric == "rmse"), iterT)
+  expect_equal(sum(res_est$.metric == "rsq"), iterT)
+  expect_equal(dplyr::n_distinct(res_est$.config), iterT)
+  expect_equal(res_est$n, rep(10, iterT * 2))
+})
+
+# ------------------------------------------------------------------------------
+
 test_that('tune model only (with recipe, multi-predict)', {
 
   skip_if_not(has_multi_predict())

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -69,7 +69,7 @@ test_that('tune model only (with variables)', {
   set.seed(4400)
 
   wflow <- workflow() %>%
-    add_variables(mpg, c(-mpg, everything())) %>%
+    add_variables(mpg, everything()) %>%
     add_model(svm_mod)
 
   pset <- dials::parameters(wflow)

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -122,7 +122,7 @@ test_that('workflow objects', {
     workflow() %>%
     add_model(glmn)
   expect_error(tune:::check_workflow(wflow_3),
-               "A model formula or recipe are required.")
+               "A formula, recipe, or variables preprocessor is required.")
 
   wflow_4 <-
     workflow() %>%

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -57,6 +57,32 @@ test_that('tune model only (with recipe)', {
 
 # ------------------------------------------------------------------------------
 
+test_that('tune model only (with variables)', {
+  set.seed(4400)
+
+  wflow <- workflow() %>%
+    add_variables(mpg, c(-mpg, everything())) %>%
+    add_model(svm_mod)
+
+  pset <- dials::parameters(wflow)
+  grid <- grid_regular(pset, levels = 3)
+
+  folds <- vfold_cv(mtcars)
+
+  res <- tune_grid(wflow, resamples = folds, grid = grid)
+
+  expect_equal(res$id, folds$id)
+
+  res_est <- collect_metrics(res)
+
+  expect_equal(nrow(res_est), nrow(grid) * 2)
+  expect_equal(sum(res_est$.metric == "rmse"), nrow(grid))
+  expect_equal(sum(res_est$.metric == "rsq"), nrow(grid))
+  expect_equal(res_est$n, rep(10, nrow(grid) * 2))
+})
+
+# ------------------------------------------------------------------------------
+
 test_that('tune model only (with recipe, multi-predict)', {
 
   set.seed(4400)

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -61,7 +61,7 @@ test_that('tune model only (with variables)', {
   set.seed(4400)
 
   wflow <- workflow() %>%
-    add_variables(mpg, c(-mpg, everything())) %>%
+    add_variables(mpg, everything()) %>%
     add_model(svm_mod)
 
   pset <- dials::parameters(wflow)

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -219,18 +219,38 @@ test_that("classification models generate correct error message", {
 # ------------------------------------------------------------------------------
 # tune_grid() fallback
 
-test_that("`tune_grid()` falls back to resamples if there are no tuning parameters", {
+test_that("`tune_grid()` falls back to `fit_resamples()` - formula", {
   set.seed(6735)
   folds <- vfold_cv(mtcars, v = 2)
 
   lin_mod <- linear_reg() %>%
     set_engine("lm")
 
-  expect <- lin_mod %>%
-    fit_resamples(mpg ~ ., folds)
+  expect <- fit_resamples(lin_mod, mpg ~ ., folds)
 
   expect_warning(
     result <- tune_grid(lin_mod, mpg ~ ., folds),
+    "No tuning parameters have been detected"
+  )
+
+  expect_equal(collect_metrics(expect), collect_metrics(result))
+})
+
+test_that("`tune_grid()` falls back to `fit_resamples()` - workflow variables", {
+  set.seed(6735)
+  folds <- vfold_cv(mtcars, v = 2)
+
+  lin_mod <- linear_reg() %>%
+    set_engine("lm")
+
+  wf <- workflow() %>%
+    add_model(lin_mod) %>%
+    add_variables(mpg, c(cyl, disp))
+
+  expect <- fit_resamples(wf, folds)
+
+  expect_warning(
+    result <- tune_grid(wf, folds),
     "No tuning parameters have been detected"
   )
 


### PR DESCRIPTION
Requires dev workflows

This PR adds support for `add_variables()` from workflows. This is a "new" preprocessor type, so it requires its own code paths. This makes things a little uglier in the short term, but I'm fairly optimistic that this can be collapsed back down in a future PR that tries to unifying the code paths.