### PR TITLE
Explicit seed setting in worker processes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     rlang (>= 0.4.0),
     tibble (>= 2.1.3),
     purrr (>= 0.3.2),
-    dials (>= 0.0.4),
+    dials (>= 0.0.8.9001),
     recipes (>= 0.1.9),
     utils,
     ggplot2,
@@ -48,3 +48,5 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Language: en-US
+Remotes:
+    tidymodels/dials

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed two bugs in the acquisition function calculations.
 
+* Better control the random number streams in parallel for `tune_grid()` and `fit_resamples()` (#11)
+
 # tune 0.1.1
 
 ## Breaking Changes

--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -50,7 +50,7 @@ utils::globalVariables(
     "delta", "sd_trunc", "snr", "z", "..val", "max_val", "has_submodel", "res",
     ".extracts", ".metrics", "value", ".notes", ".loss", ".bound",
     ".column", ".totals", ".value", "direction", ".config", "Freq", "Prediction",
-    "Truth")
+    "Truth", ".seed")
   )
 
 # ------------------------------------------------------------------------------

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -622,6 +622,7 @@ tune_mod_with_variables <- function(resamples, grid, workflow, metrics, control)
 }
 
 iter_mod_with_variables <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -13,9 +13,9 @@ tune_nothing_with_variables <- function(resamples, grid, workflow, metrics, cont
 # ------------------------------------------------------------------------------
 
 iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, control) {
-  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
@@ -194,9 +194,9 @@ tune_rec_and_mod <- function(resamples, grid, workflow, metrics, control) {
 # ------------------------------------------------------------------------------
 
 iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
-  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
@@ -336,9 +336,9 @@ tune_mod_with_recipe <- function(resamples, grid, workflow, metrics, control) {
 }
 
 iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
-  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
@@ -478,9 +478,9 @@ tune_mod_with_formula <- function(resamples, grid, workflow, metrics, control) {
 }
 
 iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, control) {
-  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
@@ -622,9 +622,9 @@ tune_mod_with_variables <- function(resamples, grid, workflow, metrics, control)
 }
 
 iter_mod_with_variables <- function(rs_iter, resamples, grid, workflow, metrics, control) {
-  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -9,6 +9,7 @@ tune_nothing_with_formula <- function(resamples, grid, workflow, metrics, contro
 # ------------------------------------------------------------------------------
 
 iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 
@@ -189,6 +190,7 @@ tune_rec_and_mod <- function(resamples, grid, workflow, metrics, control) {
 # ------------------------------------------------------------------------------
 
 iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 
@@ -330,6 +332,7 @@ tune_mod_with_recipe <- function(resamples, grid, workflow, metrics, control) {
 }
 
 iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 
@@ -470,6 +473,7 @@ tune_mod_with_formula <- function(resamples, grid, workflow, metrics, control) {
 }
 
 iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 

--- a/R/resample.R
+++ b/R/resample.R
@@ -484,6 +484,7 @@ resample_with_variables <- function(resamples, workflow, metrics, control) {
 }
 
 iter_resample_with_variables <- function(rs_iter, resamples, workflow, metrics, control) {
+  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 

--- a/R/resample.R
+++ b/R/resample.R
@@ -176,8 +176,9 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
 
   workflow_output <- set_workflow(workflow, control)
 
+  resamples <- resamples %>% dplyr::select(-.seed)
   new_resample_results(
-    x = resamples %>% dplyr::select(-.seed),
+    x = resamples,
     parameters = parameters(workflow),
     metrics = metrics,
     outcomes = outcomes,
@@ -221,9 +222,9 @@ resample_with_recipe <- function(resamples, workflow, metrics, control) {
 }
 
 iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, control) {
-  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
@@ -354,9 +355,9 @@ resample_with_formula <- function(resamples, workflow, metrics, control) {
 }
 
 iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, control) {
-  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
@@ -484,9 +485,9 @@ resample_with_variables <- function(resamples, workflow, metrics, control) {
 }
 
 iter_resample_with_variables <- function(rs_iter, resamples, workflow, metrics, control) {
-  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)

--- a/R/resample.R
+++ b/R/resample.R
@@ -139,6 +139,8 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
 
   has_formula <- has_preprocessor_formula(workflow)
 
+  resamples <- dplyr::mutate(resamples, .seed = sample.int(10^5, nrow(resamples)))
+
   # Save rset attributes, then fall back to a bare tibble
   rset_info <- pull_rset_attributes(resamples)
   resamples <- new_bare_tibble(resamples)
@@ -161,7 +163,7 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
   workflow_output <- set_workflow(workflow, control)
 
   new_resample_results(
-    x = resamples,
+    x = resamples %>% dplyr::select(-.seed),
     parameters = parameters(workflow),
     metrics = metrics,
     outcomes = outcomes,
@@ -205,6 +207,7 @@ resample_with_recipe <- function(resamples, workflow, metrics, control) {
 }
 
 iter_resample_with_recipe <- function(rs_iter, resamples, workflow, metrics, control) {
+  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 
@@ -337,6 +340,7 @@ resample_with_formula <- function(resamples, workflow, metrics, control) {
 }
 
 iter_resample_with_formula <- function(rs_iter, resamples, workflow, metrics, control) {
+  set.seed(resamples$.seed[[rs_iter]])
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -320,6 +320,9 @@ tune_grid_workflow <- function(object,
                      data = resamples$splits[[1]]$data,
                      grid_names = names(grid))
   check_workflow(object, pset = pset)
+
+  resamples <- dplyr::mutate(resamples, .seed = sample.int(10^5, nrow(resamples)))
+
   grid <- check_grid(grid, object, pset)
 
   # Save rset attributes, then fall back to a bare tibble
@@ -340,7 +343,7 @@ tune_grid_workflow <- function(object,
   workflow_output <- set_workflow(object, control)
 
   new_tune_results(
-    x = resamples,
+    x = resamples %>% dplyr::select(-.seed),
     parameters = pset,
     metrics = metrics,
     outcomes = outcomes,

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -358,8 +358,9 @@ tune_grid_workflow <- function(object,
 
   workflow_output <- set_workflow(object, control)
 
+  resamples <- resamples %>% dplyr::select(-.seed)
   new_tune_results(
-    x = resamples %>% dplyr::select(-.seed),
+    x = resamples,
     parameters = pset,
     metrics = metrics,
     outcomes = outcomes,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -24,6 +24,7 @@ parallelizes
 param
 plaintext
 pre
+preprocessor
 reprex
 RBF
 stanford


### PR DESCRIPTION
For models that have `seed` arguments, parallel processing will result in inconsistent results because the worker seeds are not controlled. This PR generates a set of seeds immediately when `tune_grid()` or `fit_resamples()` are called, then sets them in the `iter_*()` functions. This is the same approach as `caret`. Unit tests will be in the `extratests` package. 

For example: 

```r
library(tidymodels)
data(ames)
ames <- mutate(ames, Sale_Price = log10(Sale_Price))

set.seed(123)
ames_split <- initial_split(ames, prob = 0.80, strata = Sale_Price)
ames_train <- training(ames_split)
ames_test  <-  testing(ames_split)

## -----------------------------------------------------------------------------

rf_model <-
  rand_forest(trees = 1000) %>%
  set_engine("ranger") %>%
  set_mode("regression")

rf_wflow <-
  workflow() %>%
  add_formula(
    Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type +
      Latitude + Longitude) %>%
  add_model(rf_model)

set.seed(55)
ames_folds <- vfold_cv(ames_train, v = 10)

keep_pred <- control_resamples(save_pred = TRUE)

## -----------------------------------------------------------------------------

set.seed(130)
rf_res_seq_1 <-
  rf_wflow %>%
  fit_resamples(resamples = ames_folds, control = keep_pred)

set.seed(130)
rf_res_seq_2 <-
  rf_wflow %>%
  fit_resamples(resamples = ames_folds, control = keep_pred)

## -----------------------------------------------------------------------------

library(doParallel)
cl <- makePSOCKcluster(10)
registerDoParallel(cl)

set.seed(130)
rf_res_par_1 <-
  rf_wflow %>%
  fit_resamples(resamples = ames_folds, control = keep_pred)

set.seed(130)
rf_res_par_2 <-
  rf_wflow %>%
  fit_resamples(resamples = ames_folds, control = keep_pred)

## -----------------------------------------------------------------------------

all.equal(bind_rows(rf_res_seq_1$.metrics),
          bind_rows(rf_res_seq_2$.metrics))
# CRAN tune results:
# [1] TRUE

# new results
# [1] TRUE

all.equal(bind_rows(rf_res_par_1$.metrics),
          bind_rows(rf_res_par_2$.metrics))
# CRAN tune results:
# [1] "Component “.estimate”: Mean relative difference: 0.001654902"

# new results
# [1] TRUE

all.equal(bind_rows(rf_res_seq_1$.metrics),
          bind_rows(rf_res_par_1$.metrics))

# CRAN tune results:
# [1] "Component “.estimate”: Mean relative difference: 0.001052047"

# new results
# [1] TRUE
```