### PR TITLE
Streamline `fit_resamples()` internals

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -1,13 +1,13 @@
 tune_nothing_with_recipe <- function(resamples, grid, workflow, metrics, control)  {
-  resample_with_recipe(resamples, workflow, metrics, control)
+  resample_loop(resamples, workflow, metrics, control)
 }
 
 tune_nothing_with_formula <- function(resamples, grid, workflow, metrics, control)  {
-  resample_with_formula(resamples, workflow, metrics, control)
+  resample_loop(resamples, workflow, metrics, control)
 }
 
 tune_nothing_with_variables <- function(resamples, grid, workflow, metrics, control)  {
-  resample_with_variables(resamples, workflow, metrics, control)
+  resample_loop(resamples, workflow, metrics, control)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -1,27 +1,3 @@
-# recipe-oriented helpers
-
-train_recipe <- function(split, workflow, grid) {
-  original_recipe <- workflows::pull_workflow_preprocessor(workflow)
-
-  if (!is.null(grid)) {
-    updated_recipe <- merge(original_recipe, grid)$x[[1]]
-  } else {
-    updated_recipe <- original_recipe
-  }
-
-  workflow <- set_workflow_recipe(workflow, updated_recipe)
-
-  training <- rsample::analysis(split)
-
-  workflow <- .fit_pre(workflow, training)
-
-  # Always reset to the original recipe so `parameters()` can be used on this
-  # object. The prepped updated recipe is stored in the mold.
-  workflow <- set_workflow_recipe(workflow, original_recipe)
-
-  workflow
-}
-
 train_model <- function(workflow, grid, control) {
   original_spec <- workflows::pull_workflow_spec(workflow)
 
@@ -138,6 +114,30 @@ make_rename_arg <- function(grid, model) {
   res
 }
 
+# ------------------------------------------------------------------------------
+# Recipe-oriented helpers
+
+train_recipe <- function(split, workflow, grid) {
+  original_recipe <- workflows::pull_workflow_preprocessor(workflow)
+
+  if (!is.null(grid)) {
+    updated_recipe <- merge(original_recipe, grid)$x[[1]]
+  } else {
+    updated_recipe <- original_recipe
+  }
+
+  workflow <- set_workflow_recipe(workflow, updated_recipe)
+
+  training <- rsample::analysis(split)
+
+  workflow <- .fit_pre(workflow, training)
+
+  # Always reset to the original recipe so `parameters()` can be used on this
+  # object. The prepped updated recipe is stored in the mold.
+  workflow <- set_workflow_recipe(workflow, original_recipe)
+
+  workflow
+}
 
 # ------------------------------------------------------------------------------
 # Formula-oriented helpers

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -145,7 +145,7 @@ test_that("failure in recipe is caught elegantly", {
   expect_length(notes, 2L)
 
   # Known failure in the recipe
-  expect_true(any(grepl("recipe", note)))
+  expect_true(any(grepl("preprocessor", note)))
 
   expect_equivalent(extract, list(NULL, NULL))
   expect_equivalent(predictions, list(NULL, NULL))
@@ -178,7 +178,7 @@ test_that("failure in variables tidyselect specification is caught elegantly", {
   expect_length(notes, 2L)
 
   # Known failure in the variables part
-  expect_true(any(grepl("variables", note)))
+  expect_true(any(grepl("preprocessor", note)))
 
   expect_equivalent(extract, list(NULL, NULL))
   expect_equivalent(predictions, list(NULL, NULL))


### PR DESCRIPTION
Removes the function pairs of:

- `resample_with_formula()`, `iter_resample_with_formula()`

- `resample_with_recipe()`, `iter_resample_with_recipe()`

- `resample_with_variables()`, `iter_resample_with_variables()`

in favor of a unified `resample_loop()` and `iter_resamples()`