### PR TITLE
Fix comparison with NA (produced by metrics due lack of data)

### DIFF
--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -529,7 +529,7 @@ update_score_card <- function(info, iter, results, control) {
     is_better <- current_val < info$best_val
   }
 
-  if (is_better) {
+  if (!is.na(is_better) & is_better) {
     info$last_impr <- 0
     info$best_val <- current_val
     info$best_iter <- iter


### PR DESCRIPTION
When improved metrics returns `NA`, `tune_bayes` fail with this message:

```
Error in if (is_better) { : missing value where TRUE/FALSE needed
Calls: %>% ... tune_bayes.workflow -> tune_bayes_workflow -> update_score_card
```

So it is need to check `is_better` value.