### PR TITLE
Streamline `tune_grid()` internals

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -4,20 +4,20 @@ tune_nothing <- function(resamples, grid, workflow, metrics, control)  {
 
 # ------------------------------------------------------------------------------
 
-tune_rec_and_mod <- function(resamples, grid, workflow, metrics, control) {
+tune_model_and_recipe <- function(resamples, grid, workflow, metrics, control) {
   B <- nrow(resamples)
 
   `%op%` <- get_operator(control$allow_par, workflow)
 
   lab_names <- names(labels(resamples$splits[[1]]))
 
-  safely_iter_rec_and_mod <- super_safely_iterate(iter_rec_and_mod)
+  safely_iter_model_and_recipe <- super_safely_iterate(iter_model_and_recipe)
 
   load_pkgs <- c(control$pkgs, required_pkgs(workflow))
 
   results <-
     foreach::foreach(rs_iter = 1:B, .packages = load_pkgs, .errorhandling = "pass") %op%
-    safely_iter_rec_and_mod(rs_iter, resamples, grid, workflow, metrics, control)
+    safely_iter_model_and_recipe(rs_iter, resamples, grid, workflow, metrics, control)
 
   resamples <- pull_metrics(resamples, results, control)
   resamples <- pull_notes(resamples, results, control)
@@ -28,7 +28,7 @@ tune_rec_and_mod <- function(resamples, grid, workflow, metrics, control) {
   resamples
 }
 
-iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+iter_model_and_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
   load_pkgs(workflow)
   load_namespace(control$pkgs)
   set.seed(resamples$.seed[[rs_iter]])
@@ -185,18 +185,18 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, contro
 
 # ------------------------------------------------------------------------------
 
-tune_rec <- function(resamples, grid, workflow, metrics, control) {
+tune_recipe <- function(resamples, grid, workflow, metrics, control) {
   B <- nrow(resamples)
 
   `%op%` <- get_operator(control$allow_par, workflow)
 
-  safely_iter_rec <- super_safely_iterate(iter_rec)
+  safely_iter_recipe <- super_safely_iterate(iter_recipe)
 
   load_pkgs <- c(control$pkgs, required_pkgs(workflow))
 
   results <-
     foreach::foreach(rs_iter = 1:B, .packages = load_pkgs, .errorhandling = "pass") %op%
-    safely_iter_rec(rs_iter, resamples, grid, workflow, metrics, control)
+    safely_iter_recipe(rs_iter, resamples, grid, workflow, metrics, control)
 
   resamples <- pull_metrics(resamples, results, control)
   resamples <- pull_notes(resamples, results, control)
@@ -207,7 +207,7 @@ tune_rec <- function(resamples, grid, workflow, metrics, control) {
   resamples
 }
 
-iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+iter_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
   load_pkgs(workflow)
   load_namespace(control$pkgs)
   set.seed(resamples$.seed[[rs_iter]])

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -2,22 +2,28 @@ tune_nothing <- function(resamples, grid, workflow, metrics, control)  {
   resample_loop(resamples, workflow, metrics, control)
 }
 
-# ------------------------------------------------------------------------------
-
+tune_model_with_preprocessor <- function(resamples, grid, workflow, metrics, control) {
+  tune_grid_loop(resamples, grid, workflow, metrics, control, iter_model_with_preprocessor)
+}
 tune_model_and_recipe <- function(resamples, grid, workflow, metrics, control) {
+  tune_grid_loop(resamples, grid, workflow, metrics, control, iter_model_and_recipe)
+}
+tune_recipe <- function(resamples, grid, workflow, metrics, control) {
+  tune_grid_loop(resamples, grid, workflow, metrics, control, iter_recipe)
+}
+
+tune_grid_loop <- function(resamples, grid, workflow, metrics, control, fn_iter) {
   B <- nrow(resamples)
 
   `%op%` <- get_operator(control$allow_par, workflow)
 
-  lab_names <- names(labels(resamples$splits[[1]]))
-
-  safely_iter_model_and_recipe <- super_safely_iterate(iter_model_and_recipe)
+  fn_iter_safely <- super_safely_iterate(fn_iter)
 
   load_pkgs <- c(control$pkgs, required_pkgs(workflow))
 
   results <-
     foreach::foreach(rs_iter = 1:B, .packages = load_pkgs, .errorhandling = "pass") %op%
-    safely_iter_model_and_recipe(rs_iter, resamples, grid, workflow, metrics, control)
+    fn_iter_safely(rs_iter, resamples, grid, workflow, metrics, control)
 
   resamples <- pull_metrics(resamples, results, control)
   resamples <- pull_notes(resamples, results, control)
@@ -27,6 +33,134 @@ tune_model_and_recipe <- function(resamples, grid, workflow, metrics, control) {
 
   resamples
 }
+
+# ------------------------------------------------------------------------------
+
+iter_model_with_preprocessor <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+  load_pkgs(workflow)
+  load_namespace(control$pkgs)
+  set.seed(resamples$.seed[[rs_iter]])
+
+  control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
+  control_workflow <- control_workflow(control_parsnip = control_parsnip)
+
+  split <- resamples$splits[[rs_iter]]
+  metric_est <- NULL
+  extracted <- NULL
+  pred_vals <- NULL
+  all_outcome_names <- list()
+  .notes <- NULL
+
+  # ----------------------------------------------------------------------------
+
+  split <- resamples$splits[[rs_iter]]
+  training <- rsample::analysis(split)
+
+  workflow <- catch_and_log(
+    .fit_pre(workflow, training),
+    control,
+    split,
+    "preprocessor",
+    notes = .notes
+  )
+
+  # check for failure
+  if (is_failure(workflow)) {
+    out <- list(
+      .metrics = metric_est,
+      .extracts = extracted,
+      .predictions = pred_vals,
+      .all_outcome_names = all_outcome_names,
+      .notes = .notes
+    )
+
+    return(out)
+  }
+
+  # ----------------------------------------------------------------------------
+
+  # Determine the _minimal_ number of models to fit in order to get
+  # predictions on all models.
+  model_spec <- workflows::pull_workflow_spec(workflow)
+  mod_grid_vals <- min_grid(model_spec, grid)
+
+  num_mod <- nrow(mod_grid_vals)
+  num_submodels <- mod_grid_vals %>%
+    unnest(.submodels, keep_empty = TRUE) %>%
+    pull(.submodels) %>%
+    map_int(length)
+
+  # ----------------------------------------------------------------------------
+
+  original_workflow <- workflow
+
+  for (mod_iter in 1:num_mod) {
+    workflow <- original_workflow
+
+    param_val <- mod_grid_vals[mod_iter, ]
+    submodel_id <- mod_iter + sum(vec_slice(num_submodels, 1:mod_iter))
+    mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
+    mod_id <- vec_slice(
+      recipes::names0(nrow(grid), "Model"),
+      (submodel_id - num_submodels[mod_iter]):submodel_id
+    )
+
+    workflow <- catch_and_log_fit(
+      train_model(workflow, param_val, control_workflow),
+      control,
+      split,
+      mod_msg,
+      notes = .notes
+    )
+
+    # check for parsnip level and model level failure
+    if (is_failure(workflow) || is_failure(workflow$fit$fit$fit)) {
+      next
+    }
+
+    # Extract names from the mold
+    all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
+
+    extracted <- append_extracts(
+      extracted,
+      workflow,
+      param_val,
+      split,
+      control,
+      mod_id
+    )
+
+    pred_msg <- paste(mod_msg, "(predictions)")
+
+    tmp_pred <- catch_and_log(
+      predict_model(split, workflow, param_val, metrics),
+      control,
+      split,
+      pred_msg,
+      bad_only = TRUE,
+      notes = .notes
+    )
+
+    # check for prediction level failure
+    if (is_failure(tmp_pred)) {
+      next
+    }
+
+    metric_est  <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, mod_id)
+    config_id <- extract_config(workflow, metric_est)
+    pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
+  } # end model loop
+
+  list(
+    .metrics = metric_est,
+    .extracts = extracted,
+    .predictions = pred_vals,
+    .all_outcome_names = all_outcome_names,
+    .notes = .notes
+  )
+}
+
+# ------------------------------------------------------------------------------
 
 iter_model_and_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
   load_pkgs(workflow)
@@ -185,28 +319,6 @@ iter_model_and_recipe <- function(rs_iter, resamples, grid, workflow, metrics, c
 
 # ------------------------------------------------------------------------------
 
-tune_recipe <- function(resamples, grid, workflow, metrics, control) {
-  B <- nrow(resamples)
-
-  `%op%` <- get_operator(control$allow_par, workflow)
-
-  safely_iter_recipe <- super_safely_iterate(iter_recipe)
-
-  load_pkgs <- c(control$pkgs, required_pkgs(workflow))
-
-  results <-
-    foreach::foreach(rs_iter = 1:B, .packages = load_pkgs, .errorhandling = "pass") %op%
-    safely_iter_recipe(rs_iter, resamples, grid, workflow, metrics, control)
-
-  resamples <- pull_metrics(resamples, results, control)
-  resamples <- pull_notes(resamples, results, control)
-  resamples <- pull_extracts(resamples, results, control)
-  resamples <- pull_predictions(resamples, results, control)
-  resamples <- pull_all_outcome_names(resamples, results)
-
-  resamples
-}
-
 iter_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
   load_pkgs(workflow)
   load_namespace(control$pkgs)
@@ -292,163 +404,6 @@ iter_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
     config_id <- extract_config(workflow, metric_est)
     pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
   } # recipe parameters
-
-  list(
-    .metrics = metric_est,
-    .extracts = extracted,
-    .predictions = pred_vals,
-    .all_outcome_names = all_outcome_names,
-    .notes = .notes
-  )
-}
-
-# ------------------------------------------------------------------------------
-
-tune_model_with_preprocessor <- function(resamples, grid, workflow, metrics, control) {
-  B <- nrow(resamples)
-
-  `%op%` <- get_operator(control$allow_par, workflow)
-
-  iter_mod_with_preprocessor_safely <- super_safely_iterate(iter_mod_with_preprocessor)
-
-  load_pkgs <- c(control$pkgs, required_pkgs(workflow))
-
-  results <- foreach::foreach(rs_iter = 1:B,
-                              .packages = load_pkgs,
-                              .errorhandling = "pass") %op% {
-    iter_mod_with_preprocessor_safely(
-      rs_iter,
-      resamples,
-      grid,
-      workflow,
-      metrics,
-      control
-    )
-  }
-
-  resamples <- pull_metrics(resamples, results, control)
-  resamples <- pull_notes(resamples, results, control)
-  resamples <- pull_extracts(resamples, results, control)
-  resamples <- pull_predictions(resamples, results, control)
-  resamples <- pull_all_outcome_names(resamples, results)
-
-  resamples
-}
-
-iter_mod_with_preprocessor <- function(rs_iter, resamples, grid, workflow, metrics, control) {
-  load_pkgs(workflow)
-  load_namespace(control$pkgs)
-  set.seed(resamples$.seed[[rs_iter]])
-
-  control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
-  control_workflow <- control_workflow(control_parsnip = control_parsnip)
-
-  split <- resamples$splits[[rs_iter]]
-  metric_est <- NULL
-  extracted <- NULL
-  pred_vals <- NULL
-  all_outcome_names <- list()
-  .notes <- NULL
-
-  # ----------------------------------------------------------------------------
-
-  split <- resamples$splits[[rs_iter]]
-  training <- rsample::analysis(split)
-
-  workflow <- catch_and_log(
-    .fit_pre(workflow, training),
-    control,
-    split,
-    "preprocessor",
-    notes = .notes
-  )
-
-  # check for failure
-  if (is_failure(workflow)) {
-    out <- list(
-      .metrics = metric_est,
-      .extracts = extracted,
-      .predictions = pred_vals,
-      .all_outcome_names = all_outcome_names,
-      .notes = .notes
-    )
-
-    return(out)
-  }
-
-  # ----------------------------------------------------------------------------
-
-  # Determine the _minimal_ number of models to fit in order to get
-  # predictions on all models.
-  model_spec <- workflows::pull_workflow_spec(workflow)
-  mod_grid_vals <- min_grid(model_spec, grid)
-
-  num_mod <- nrow(mod_grid_vals)
-  num_submodels <- mod_grid_vals %>%
-    unnest(.submodels, keep_empty = TRUE) %>%
-    pull(.submodels) %>%
-    map_int(length)
-
-  # ----------------------------------------------------------------------------
-
-  original_workflow <- workflow
-
-  for (mod_iter in 1:num_mod) {
-    workflow <- original_workflow
-
-    param_val <- mod_grid_vals[mod_iter, ]
-    submodel_id <- mod_iter + sum(vec_slice(num_submodels, 1:mod_iter))
-    mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
-    mod_id <- vec_slice(
-      recipes::names0(nrow(grid), "Model"),
-      (submodel_id - num_submodels[mod_iter]):submodel_id
-    )
-
-    workflow <- catch_and_log_fit(
-      train_model(workflow, param_val, control_workflow),
-      control,
-      split,
-      mod_msg,
-      notes = .notes
-    )
-
-    # check for parsnip level and model level failure
-    if (is_failure(workflow) || is_failure(workflow$fit$fit$fit)) {
-      next
-    }
-
-    # Extract names from the mold
-    all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
-
-    extracted <- append_extracts(
-      extracted,
-      workflow,
-      param_val,
-      split,
-      control,
-      mod_id
-    )
-
-    pred_msg <- paste(mod_msg, "(predictions)")
-
-    tmp_pred <- catch_and_log(
-      predict_model(split, workflow, param_val, metrics),
-      control,
-      split,
-      pred_msg,
-      bad_only = TRUE,
-      notes = .notes
-    )
-
-    # check for prediction level failure
-    if (is_failure(tmp_pred)) {
-      next
-    }
-
-    metric_est  <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, mod_id)
-    config_id <- extract_config(workflow, metric_est)
-    pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
-  } # end model loop
 
   list(
     .metrics = metric_est,

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -1,12 +1,4 @@
-tune_nothing_with_recipe <- function(resamples, grid, workflow, metrics, control)  {
-  resample_loop(resamples, workflow, metrics, control)
-}
-
-tune_nothing_with_formula <- function(resamples, grid, workflow, metrics, control)  {
-  resample_loop(resamples, workflow, metrics, control)
-}
-
-tune_nothing_with_variables <- function(resamples, grid, workflow, metrics, control)  {
+tune_nothing <- function(resamples, grid, workflow, metrics, control)  {
   resample_loop(resamples, workflow, metrics, control)
 }
 

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -61,7 +61,7 @@ iter_rec_and_mod <- function(rs_iter, resamples, grid, workflow, metrics, contro
       dplyr::select(-data)
 
     workflow <- catch_and_log(
-      train_recipe(split, workflow, rec_grid_vals),
+      train_recipe_grid(split, workflow, rec_grid_vals),
       control,
       split,
       rec_msg,
@@ -220,7 +220,7 @@ iter_rec <- function(rs_iter, resamples, grid, workflow, metrics, control) {
     rec_id <- vec_slice(recipes::names0(num_rec, "Recipe"), param_iter)
 
     workflow <- catch_and_log(
-      train_recipe(split, workflow, param_vals),
+      train_recipe_grid(split, workflow, param_vals),
       control,
       split,
       rec_msg,
@@ -310,21 +310,29 @@ tune_rec <- function(resamples, grid, workflow, metrics, control) {
   resamples
 }
 
-
 # ------------------------------------------------------------------------------
 
-tune_mod_with_recipe <- function(resamples, grid, workflow, metrics, control) {
+tune_model_with_preprocessor <- function(resamples, grid, workflow, metrics, control) {
   B <- nrow(resamples)
 
   `%op%` <- get_operator(control$allow_par, workflow)
 
-  safely_iter_mod_with_recipe <- super_safely_iterate(iter_mod_with_recipe)
+  iter_mod_with_preprocessor_safely <- super_safely_iterate(iter_mod_with_preprocessor)
 
   load_pkgs <- c(control$pkgs, required_pkgs(workflow))
 
-  results <-
-    foreach::foreach(rs_iter = 1:B, .packages = load_pkgs, .errorhandling = "pass") %op%
-    safely_iter_mod_with_recipe(rs_iter, resamples, grid, workflow, metrics, control)
+  results <- foreach::foreach(rs_iter = 1:B,
+                              .packages = load_pkgs,
+                              .errorhandling = "pass") %op% {
+    iter_mod_with_preprocessor_safely(
+      rs_iter,
+      resamples,
+      grid,
+      workflow,
+      metrics,
+      control
+    )
+  }
 
   resamples <- pull_metrics(resamples, results, control)
   resamples <- pull_notes(resamples, results, control)
@@ -335,7 +343,7 @@ tune_mod_with_recipe <- function(resamples, grid, workflow, metrics, control) {
   resamples
 }
 
-iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
+iter_mod_with_preprocessor <- function(rs_iter, resamples, grid, workflow, metrics, control) {
   load_pkgs(workflow)
   load_namespace(control$pkgs)
   set.seed(resamples$.seed[[rs_iter]])
@@ -352,11 +360,14 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
 
   # ----------------------------------------------------------------------------
 
+  split <- resamples$splits[[rs_iter]]
+  training <- rsample::analysis(split)
+
   workflow <- catch_and_log(
-    train_recipe(split, workflow, NULL),
+    .fit_pre(workflow, training),
     control,
     split,
-    "recipe",
+    "preprocessor",
     notes = .notes
   )
 
@@ -377,13 +388,16 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
 
   # Determine the _minimal_ number of models to fit in order to get
   # predictions on all models.
-  mod_grid_vals <- workflows::pull_workflow_spec(workflow) %>% min_grid(grid)
+  model_spec <- workflows::pull_workflow_spec(workflow)
+  mod_grid_vals <- min_grid(model_spec, grid)
 
   num_mod <- nrow(mod_grid_vals)
   num_submodels <- mod_grid_vals %>%
     unnest(.submodels, keep_empty = TRUE) %>%
     pull(.submodels) %>%
     map_int(length)
+
+  # ----------------------------------------------------------------------------
 
   original_workflow <- workflow
 
@@ -400,292 +414,6 @@ iter_mod_with_recipe <- function(rs_iter, resamples, grid, workflow, metrics, co
 
     workflow <- catch_and_log_fit(
       train_model(workflow, param_val, control_workflow),
-      control,
-      split,
-      mod_msg,
-      notes = .notes
-    )
-
-    # check for parsnip level and model level failure
-    if (is_failure(workflow) || is_failure(workflow$fit$fit$fit)) {
-      next
-    }
-
-    # Extract names from the mold
-    all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
-
-    extracted <- append_extracts(
-      extracted,
-      workflow,
-      param_val,
-      split,
-      control,
-      mod_id
-    )
-
-    pred_msg <- paste(mod_msg, "(predictions)")
-
-    tmp_pred <- catch_and_log(
-      predict_model(split, workflow, param_val, metrics),
-      control,
-      split,
-      pred_msg,
-      bad_only = TRUE,
-      notes = .notes
-    )
-
-    # check for prediction level failure
-    if (is_failure(tmp_pred)) {
-      next
-    }
-
-    metric_est  <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, mod_id)
-    config_id <- extract_config(workflow, metric_est)
-    pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
-  } # end model loop
-
-  list(
-    .metrics = metric_est,
-    .extracts = extracted,
-    .predictions = pred_vals,
-    .all_outcome_names = all_outcome_names,
-    .notes = .notes
-  )
-}
-
-# ------------------------------------------------------------------------------
-
-tune_mod_with_formula <- function(resamples, grid, workflow, metrics, control) {
-  B <- nrow(resamples)
-
-  `%op%` <- get_operator(control$allow_par, workflow)
-
-  safely_iter_mod_with_formula <- super_safely_iterate(iter_mod_with_formula)
-
-  load_pkgs <- c(control$pkgs, required_pkgs(workflow))
-
-  results <-
-    foreach::foreach(rs_iter = 1:B, .packages = load_pkgs, .errorhandling = "pass") %op%
-    safely_iter_mod_with_formula(rs_iter, resamples, grid, workflow, metrics, control)
-
-  resamples <- pull_metrics(resamples, results, control)
-  resamples <- pull_notes(resamples, results, control)
-  resamples <- pull_extracts(resamples, results, control)
-  resamples <- pull_predictions(resamples, results, control)
-  resamples <- pull_all_outcome_names(resamples, results)
-
-  resamples
-}
-
-iter_mod_with_formula <- function(rs_iter, resamples, grid, workflow, metrics, control) {
-  load_pkgs(workflow)
-  load_namespace(control$pkgs)
-  set.seed(resamples$.seed[[rs_iter]])
-
-  control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
-  control_workflow <- control_workflow(control_parsnip = control_parsnip)
-
-  split <- resamples$splits[[rs_iter]]
-  metric_est <- NULL
-  extracted <- NULL
-  pred_vals <- NULL
-  all_outcome_names <- list()
-  .notes <- NULL
-
-  # ----------------------------------------------------------------------------
-
-  workflow <- catch_and_log(
-    train_formula(split, workflow),
-    control,
-    split,
-    "formula",
-    notes = .notes
-  )
-
-  # check for failure
-  if (is_failure(workflow)) {
-    out <- list(
-      .metrics = metric_est,
-      .extracts = extracted,
-      .predictions = pred_vals,
-      .all_outcome_names = all_outcome_names,
-      .notes = .notes
-    )
-
-    return(out)
-  }
-
-  # ----------------------------------------------------------------------------
-
-  # Determine the _minimal_ number of models to fit in order to get
-  # predictions on all models.
-  mod_grid_vals <- workflows::pull_workflow_spec(workflow) %>% min_grid(grid)
-
-  num_mod <- nrow(mod_grid_vals)
-  num_submodels <- mod_grid_vals %>%
-    unnest(.submodels, keep_empty = TRUE) %>%
-    pull(.submodels) %>%
-    map_int(length)
-
-  original_workflow <- workflow
-
-  for (mod_iter in 1:num_mod) {
-    workflow <- original_workflow
-
-    param_val <- mod_grid_vals[mod_iter, ]
-    submodel_id <- mod_iter + sum(vec_slice(num_submodels, 1:mod_iter))
-    mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
-    mod_id <- vec_slice(
-      recipes::names0(nrow(grid), "Model"),
-      (submodel_id - num_submodels[mod_iter]):submodel_id
-      )
-
-    workflow <- catch_and_log_fit(
-      train_model(workflow, param_val, control = control_workflow),
-      control,
-      split,
-      mod_msg,
-      notes = .notes
-    )
-
-    # check for parsnip level and model level failure
-    if (is_failure(workflow) || is_failure(workflow$fit$fit$fit)) {
-      next
-    }
-
-    # Extract names from the mold
-    all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
-
-    extracted <- append_extracts(
-      extracted,
-      workflow,
-      param_val,
-      split,
-      control,
-      mod_id
-    )
-
-    pred_msg <- paste(mod_msg, "(predictions)")
-
-    tmp_pred <- catch_and_log(
-      predict_model(split, workflow, param_val, metrics),
-      control,
-      split,
-      pred_msg,
-      bad_only = TRUE,
-      notes = .notes
-    )
-
-    # check for prediction level failure
-    if (is_failure(tmp_pred)) {
-      next
-    }
-
-    metric_est  <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, mod_id)
-    config_id <- extract_config(workflow, metric_est)
-    pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
-  } # end model loop
-
-  list(
-    .metrics = metric_est,
-    .extracts = extracted,
-    .predictions = pred_vals,
-    .all_outcome_names = all_outcome_names,
-    .notes = .notes
-  )
-}
-
-# ------------------------------------------------------------------------------
-
-tune_mod_with_variables <- function(resamples, grid, workflow, metrics, control) {
-  B <- nrow(resamples)
-
-  `%op%` <- get_operator(control$allow_par, workflow)
-
-  safely_iter_mod_with_variables <- super_safely_iterate(iter_mod_with_variables)
-
-  load_pkgs <- c(control$pkgs, required_pkgs(workflow))
-
-  results <- foreach::foreach(rs_iter = 1:B,
-                              .packages = load_pkgs,
-                              .errorhandling = "pass") %op% {
-    safely_iter_mod_with_variables(rs_iter, resamples, grid, workflow, metrics, control)
-  }
-
-  resamples <- pull_metrics(resamples, results, control)
-  resamples <- pull_notes(resamples, results, control)
-  resamples <- pull_extracts(resamples, results, control)
-  resamples <- pull_predictions(resamples, results, control)
-  resamples <- pull_all_outcome_names(resamples, results)
-
-  resamples
-}
-
-iter_mod_with_variables <- function(rs_iter, resamples, grid, workflow, metrics, control) {
-  load_pkgs(workflow)
-  load_namespace(control$pkgs)
-  set.seed(resamples$.seed[[rs_iter]])
-
-  control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
-  control_workflow <- control_workflow(control_parsnip = control_parsnip)
-
-  split <- resamples$splits[[rs_iter]]
-  metric_est <- NULL
-  extracted <- NULL
-  pred_vals <- NULL
-  all_outcome_names <- list()
-  .notes <- NULL
-
-  # ----------------------------------------------------------------------------
-
-  workflow <- catch_and_log(
-    train_variables(split, workflow),
-    control,
-    split,
-    "variables",
-    notes = .notes
-  )
-
-  # check for failure
-  if (is_failure(workflow)) {
-    out <- list(
-      .metrics = metric_est,
-      .extracts = extracted,
-      .predictions = pred_vals,
-      .all_outcome_names = all_outcome_names,
-      .notes = .notes
-    )
-
-    return(out)
-  }
-
-  # ----------------------------------------------------------------------------
-
-  # Determine the _minimal_ number of models to fit in order to get
-  # predictions on all models.
-  mod_grid_vals <- workflows::pull_workflow_spec(workflow) %>% min_grid(grid)
-
-  num_mod <- nrow(mod_grid_vals)
-  num_submodels <- mod_grid_vals %>%
-    unnest(.submodels, keep_empty = TRUE) %>%
-    pull(.submodels) %>%
-    map_int(length)
-
-  original_workflow <- workflow
-
-  for (mod_iter in 1:num_mod) {
-    workflow <- original_workflow
-
-    param_val <- mod_grid_vals[mod_iter, ]
-    submodel_id <- mod_iter + sum(vec_slice(num_submodels, 1:mod_iter))
-    mod_msg <- paste0("model ", format(1:num_mod)[mod_iter], "/", num_mod)
-    mod_id <- vec_slice(
-      recipes::names0(nrow(grid), "Model"),
-      (submodel_id - num_submodels[mod_iter]):submodel_id
-    )
-
-    workflow <- catch_and_log_fit(
-      train_model(workflow, param_val, control = control_workflow),
       control,
       split,
       mod_msg,

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -117,14 +117,9 @@ make_rename_arg <- function(grid, model) {
 # ------------------------------------------------------------------------------
 # Recipe-oriented helpers
 
-train_recipe <- function(split, workflow, grid) {
+train_recipe_grid <- function(split, workflow, grid) {
   original_recipe <- workflows::pull_workflow_preprocessor(workflow)
-
-  if (!is.null(grid)) {
-    updated_recipe <- merge(original_recipe, grid)$x[[1]]
-  } else {
-    updated_recipe <- original_recipe
-  }
+  updated_recipe <- merge(original_recipe, grid)$x[[1]]
 
   workflow <- set_workflow_recipe(workflow, updated_recipe)
 
@@ -137,22 +132,6 @@ train_recipe <- function(split, workflow, grid) {
   workflow <- set_workflow_recipe(workflow, original_recipe)
 
   workflow
-}
-
-# ------------------------------------------------------------------------------
-# Formula-oriented helpers
-
-train_formula <- function(split, workflow) {
-  training <- rsample::analysis(split)
-  .fit_pre(workflow, training)
-}
-
-# ------------------------------------------------------------------------------
-# Variables-oriented helpers
-
-train_variables <- function(split, workflow) {
-  training <- rsample::analysis(split)
-  .fit_pre(workflow, training)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/resample.R
+++ b/R/resample.R
@@ -181,31 +181,17 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
 # ------------------------------------------------------------------------------
 
 resample_loop <- function(resamples, workflow, metrics, control) {
-  B <- nrow(resamples)
-  `%op%` <- get_operator(control$allow_par, workflow)
-  safely_iter_resamples <- super_safely_iterate(iter_resamples)
-
-  results <- foreach::foreach(rs_iter = 1:B,
-                              .packages = required_pkgs(workflow),
-                              .errorhandling = "pass") %op% {
-    safely_iter_resamples(
-      rs_iter = rs_iter,
-      resamples = resamples,
-      grid = NULL,
-      workflow = workflow,
-      metrics = metrics,
-      control = control
-    )
-  }
-
-  resamples <- pull_metrics(resamples, results, control)
-  resamples <- pull_notes(resamples, results, control)
-  resamples <- pull_extracts(resamples, results, control)
-  resamples <- pull_predictions(resamples, results, control)
-  resamples <- pull_all_outcome_names(resamples, results)
-
-  resamples
+  tune_grid_loop(
+    resamples = resamples,
+    grid = NULL,
+    workflow = workflow,
+    metrics = metrics,
+    control = control,
+    fn_iter = iter_resamples
+  )
 }
+
+# ------------------------------------------------------------------------------
 
 iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
   load_pkgs(workflow)

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -391,15 +391,15 @@ quarterback <- function(x) {
   )
 
   fn <- dplyr::case_when(
-    has_form && tune_model ~ "tune_mod_with_formula",
+    has_form && tune_model ~ "tune_model_with_preprocessor",
     has_form && !tune_model ~ "tune_nothing_with_formula",
 
     has_rec && tune_rec && tune_model ~ "tune_rec_and_mod",
     has_rec && tune_rec && !tune_model ~ "tune_rec",
-    has_rec && !tune_rec && tune_model ~ "tune_mod_with_recipe",
+    has_rec && !tune_rec && tune_model ~ "tune_model_with_preprocessor",
     has_rec && !tune_rec && !tune_model ~ "tune_nothing_with_recipe",
 
-    has_vars && tune_model ~ "tune_mod_with_variables",
+    has_vars && tune_model ~ "tune_model_with_preprocessor",
     has_vars && !tune_model ~ "tune_nothing_with_variables"
   )
 

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -395,9 +395,9 @@ quarterback <- function(x) {
     has_vars && tune_model ~ "tune_model_with_preprocessor",
     has_rec && !tune_rec && tune_model ~ "tune_model_with_preprocessor",
 
-    has_form && !tune_model ~ "tune_nothing_with_formula",
-    has_vars && !tune_model ~ "tune_nothing_with_variables",
-    has_rec && !tune_rec && !tune_model ~ "tune_nothing_with_recipe",
+    has_form && !tune_model ~ "tune_nothing",
+    has_vars && !tune_model ~ "tune_nothing",
+    has_rec && !tune_rec && !tune_model ~ "tune_nothing",
 
     has_rec && tune_rec && tune_model ~ "tune_rec_and_mod",
     has_rec && tune_rec && !tune_model ~ "tune_rec"

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -399,8 +399,8 @@ quarterback <- function(x) {
     has_vars && !tune_model ~ "tune_nothing",
     has_rec && !tune_rec && !tune_model ~ "tune_nothing",
 
-    has_rec && tune_rec && tune_model ~ "tune_rec_and_mod",
-    has_rec && tune_rec && !tune_model ~ "tune_rec"
+    has_rec && tune_rec && tune_model ~ "tune_model_and_recipe",
+    has_rec && tune_rec && !tune_model ~ "tune_recipe"
   )
 
   rlang::call2(fn, !!!args)

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -392,15 +392,15 @@ quarterback <- function(x) {
 
   fn <- dplyr::case_when(
     has_form && tune_model ~ "tune_model_with_preprocessor",
-    has_form && !tune_model ~ "tune_nothing_with_formula",
-
-    has_rec && tune_rec && tune_model ~ "tune_rec_and_mod",
-    has_rec && tune_rec && !tune_model ~ "tune_rec",
+    has_vars && tune_model ~ "tune_model_with_preprocessor",
     has_rec && !tune_rec && tune_model ~ "tune_model_with_preprocessor",
+
+    has_form && !tune_model ~ "tune_nothing_with_formula",
+    has_vars && !tune_model ~ "tune_nothing_with_variables",
     has_rec && !tune_rec && !tune_model ~ "tune_nothing_with_recipe",
 
-    has_vars && tune_model ~ "tune_model_with_preprocessor",
-    has_vars && !tune_model ~ "tune_nothing_with_variables"
+    has_rec && tune_rec && tune_model ~ "tune_rec_and_mod",
+    has_rec && tune_rec && !tune_model ~ "tune_rec"
   )
 
   rlang::call2(fn, !!!args)


### PR DESCRIPTION
Follow-up to https://github.com/tidymodels/tune/pull/276

- Removes the function pairs of:

  - `tune_mod_with_formula()`, `iter_mod_with_formula()`

  - `tune_mod_with_recipe()`, `iter_mod_with_recipe()`

  - `tune_mod_with_variables()`, `iter_mod_with_variables()`

  in favor of a unified `tune_model_with_preprocessor()` and `iter_model_with_preprocessor()`

- Simplifies all `tune_*()` paths to use the same `tune_grid_loop()` helper. Also made `resample_loop()` use it.

- Collapses `tune_nothing_with_*()` into just `tune_nothing()`

- Removes `train_formula()` and `train_variables()` as they are no longer needed

- Renames `train_recipe()` to `train_recipe_grid()` as it is only used when there is a tunable recipe

---

This leaves us with 3 tune paths that actually do something:

- `tune_model_with_preprocessor()`
- `tune_model_and_recipe()`
- `tune_recipe()`
