### PR TITLE
Support yardstick `event_level`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     glue,
     cli (>= 2.0.0),
     crayon,
-    yardstick,
+    yardstick (>= 0.0.7),
     rsample (>= 0.0.7.9000),
     tidyr,
     GPfit,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Other Changes
 
+* tune now supports setting the `event_level` option from yardstick through the control objects (i.e. `control_grid(event_level = "second")`) (#240, #249).
+
 * tune now supports workflows created with the new `workflows::add_variables()` preprocessor.
 
 * Better control the random number streams in parallel for `tune_grid()` and `fit_resamples()` (#11)

--- a/R/checks.R
+++ b/R/checks.R
@@ -350,7 +350,11 @@ check_initial <- function(x, pset, wflow, resamples, metrics, ctrl) {
       grid = x,
       metrics = metrics,
       param_info = pset,
-      control = control_grid(extract = ctrl$extract, save_pred = ctrl$save_pred)
+      control = control_grid(
+        extract = ctrl$extract,
+        save_pred = ctrl$save_pred,
+        event_level = ctrl$event_level
+      )
     )
 
     if (ctrl$verbose) {

--- a/R/control.R
+++ b/R/control.R
@@ -30,13 +30,15 @@
 #' @export
 control_grid <- function(verbose = FALSE, allow_par = TRUE,
                          extract = NULL, save_pred = FALSE,
-                         pkgs = NULL, save_workflow = FALSE) {
+                         pkgs = NULL, save_workflow = FALSE,
+                         event_level = "first") {
   # add options for  seeds per resample
 
   val_class_and_single(verbose, "logical", "control_grid()")
   val_class_and_single(allow_par, "logical", "control_grid()")
   val_class_and_single(save_pred, "logical", "control_grid()")
   val_class_and_single(save_workflow, "logical", "control_grid()")
+  val_class_and_single(event_level, "character", "control_grid()")
   val_class_or_null(pkgs, "character", "control_grid()")
   val_class_or_null(extract, "function", "control_grid()")
 
@@ -46,7 +48,8 @@ control_grid <- function(verbose = FALSE, allow_par = TRUE,
               extract = extract,
               save_pred = save_pred,
               pkgs = pkgs,
-              save_workflow = save_workflow)
+              save_workflow = save_workflow,
+              event_level = event_level)
 
   class(res) <- c("control_grid", "control_resamples")
   res
@@ -98,6 +101,11 @@ control_resamples <- control_grid
 #'  `tempdir()` with names `gp_candidates_{i}.RData` where `i` is the iteration.
 #'  These results are deleted when the R session ends. This option is only
 #'  useful for teaching purposes.
+#' @param event_level A single string containing either `"first"` or `"second"`.
+#'   This argument is passed on to yardstick metric functions when any type
+#'   of class prediction is made, and specifies which level of the outcome
+#'   is considered the "event".
+#'
 #' @details
 #'
 #' For `extract`, this function can be used to output the model object, the
@@ -129,7 +137,8 @@ control_bayes <-
            time_limit = NA,
            pkgs = NULL,
            save_workflow = FALSE,
-           save_gp_scoring = FALSE) {
+           save_gp_scoring = FALSE,
+           event_level = "first") {
     # add options for seeds per resample
 
     val_class_and_single(verbose, "logical", "control_bayes()")
@@ -142,6 +151,7 @@ control_bayes <-
     val_class_or_null(extract, "function", "control_bayes()")
     val_class_and_single(time_limit, c("logical", "numeric"), "control_bayes()")
     val_class_or_null(pkgs, "character", "control_bayes()")
+    val_class_and_single(event_level, "character", "control_bayes()")
 
     if (!is.infinite(uncertain) && uncertain > no_improve) {
       cli::cli_alert_warning(
@@ -160,7 +170,8 @@ control_bayes <-
         time_limit = time_limit,
         pkgs = pkgs,
         save_workflow = save_workflow,
-        save_gp_scoring = save_gp_scoring
+        save_gp_scoring = save_gp_scoring,
+        event_level = event_level
       )
 
     class(res) <- "control_bayes"

--- a/R/extract.R
+++ b/R/extract.R
@@ -139,11 +139,11 @@ pull_notes <- function(resamples, res, control) {
 
 # ------------------------------------------------------------------------------
 
-append_metrics <- function(collection, predictions, workflow, metrics, split, .config = NULL) {
+append_metrics <- function(collection, predictions, workflow, metrics, split, event_level, .config = NULL) {
   if (inherits(predictions, "try-error")) {
     return(collection)
   }
-  tmp_est <- estimate_metrics(predictions, metrics, workflow)
+  tmp_est <- estimate_metrics(predictions, metrics, workflow, event_level)
   tmp_est <- cbind(tmp_est, labels(split))
   if (!rlang::is_null(.config)) {
     tmp_est <- cbind(tmp_est, .config)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -44,6 +44,8 @@ iter_model_with_preprocessor <- function(rs_iter, resamples, grid, workflow, met
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
 
+  event_level <- control$event_level
+
   split <- resamples$splits[[rs_iter]]
   metric_est <- NULL
   extracted <- NULL
@@ -146,7 +148,7 @@ iter_model_with_preprocessor <- function(rs_iter, resamples, grid, workflow, met
       next
     }
 
-    metric_est  <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, mod_id)
+    metric_est  <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, event_level, mod_id)
     config_id <- extract_config(workflow, metric_est)
     pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
   } # end model loop
@@ -169,6 +171,8 @@ iter_model_and_recipe <- function(rs_iter, resamples, grid, workflow, metrics, c
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
+
+  event_level <- control$event_level
 
   metric_est <- NULL
   extracted <- NULL
@@ -303,7 +307,7 @@ iter_model_and_recipe <- function(rs_iter, resamples, grid, workflow, metrics, c
         next
       }
 
-      metric_est <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, mod_id)
+      metric_est <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, event_level, mod_id)
       config_id <- extract_config(workflow, metric_est)
       pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
     } # end model loop
@@ -327,6 +331,8 @@ iter_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
+
+  event_level <- control$event_level
 
   metric_est <- NULL
   extracted <- NULL
@@ -401,7 +407,7 @@ iter_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
       next
     }
 
-    metric_est <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, rec_id)
+    metric_est <- append_metrics(metric_est, tmp_pred, workflow, metrics, split, event_level, rec_id)
     config_id <- extract_config(workflow, metric_est)
     pred_vals <- append_predictions(pred_vals, tmp_pred, split, control, config_id)
   } # end recipe loop

--- a/R/resample.R
+++ b/R/resample.R
@@ -201,6 +201,8 @@ iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
 
+  event_level <- control$event_level
+
   metric_est <- NULL
   extracted <- NULL
   pred_vals <- NULL
@@ -282,7 +284,7 @@ iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
     return(out)
   }
 
-  metric_est <- append_metrics(metric_est, predictions, workflow, metrics, split)
+  metric_est <- append_metrics(metric_est, predictions, workflow, metrics, split, event_level)
   pred_vals <- append_predictions(pred_vals, predictions, split, control)
 
   list(

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -620,8 +620,12 @@ more_results <- function(object, resamples, candidates, metrics, control, param_
         param_info = param_info,
         grid = candidates,
         metrics = metrics,
-        control = control_grid(verbose = FALSE, extract = control$extract,
-                               save_pred = control$save_pred)
+        control = control_grid(
+          verbose = FALSE,
+          extract = control$extract,
+          save_pred = control$save_pred,
+          event_level = control$event_level
+        )
       ),
       silent = TRUE
     )

--- a/man/control_bayes.Rd
+++ b/man/control_bayes.Rd
@@ -14,7 +14,8 @@ control_bayes(
   time_limit = NA,
   pkgs = NULL,
   save_workflow = FALSE,
-  save_gp_scoring = FALSE
+  save_gp_scoring = FALSE,
+  event_level = "first"
 )
 }
 \arguments{
@@ -58,6 +59,11 @@ models for each iteration of the search. These are saved to
 \code{tempdir()} with names \verb{gp_candidates_\{i\}.RData} where \code{i} is the iteration.
 These results are deleted when the R session ends. This option is only
 useful for teaching purposes.}
+
+\item{event_level}{A single string containing either \code{"first"} or \code{"second"}.
+This argument is passed on to yardstick metric functions when any type
+of class prediction is made, and specifies which level of the outcome
+is considered the "event".}
 }
 \description{
 Control aspects of the Bayesian search process

--- a/man/control_grid.Rd
+++ b/man/control_grid.Rd
@@ -11,7 +11,8 @@ control_grid(
   extract = NULL,
   save_pred = FALSE,
   pkgs = NULL,
-  save_workflow = FALSE
+  save_workflow = FALSE,
+  event_level = "first"
 )
 
 control_resamples(
@@ -20,7 +21,8 @@ control_resamples(
   extract = NULL,
   save_pred = FALSE,
   pkgs = NULL,
-  save_workflow = FALSE
+  save_workflow = FALSE,
+  event_level = "first"
 )
 }
 \arguments{
@@ -45,6 +47,11 @@ loaded (by namespace) during parallel processing.}
 
 \item{save_workflow}{A logical for whether the workflow should be appended
 to the output as an attribute.}
+
+\item{event_level}{A single string containing either \code{"first"} or \code{"second"}.
+This argument is passed on to yardstick metric functions when any type
+of class prediction is made, and specifies which level of the outcome
+is considered the "event".}
 }
 \description{
 Control aspects of the grid search process

--- a/tests/testthat/test-event-level.R
+++ b/tests/testthat/test-event-level.R
@@ -1,0 +1,137 @@
+test_that("`event_level` is passed through in tune_grid()", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("randomForest")
+
+  set.seed(123)
+
+  data("two_class_dat", package = "modeldata")
+  dat <- two_class_dat[1:50,]
+
+  spec <- parsnip::rand_forest(mode = "classification", trees = tune()) %>%
+    parsnip::set_engine("randomForest")
+
+  control <- control_grid(event_level = "second", save_pred = TRUE)
+  resamples <- rsample::bootstraps(dat, times = 1)
+  set <- yardstick::metric_set(yardstick::roc_auc, yardstick::sens)
+  grid <- tibble::tibble(trees = 2L)
+
+  result <- tune_grid(
+    spec,
+    Class ~ .,
+    resamples = resamples,
+    metrics = set,
+    grid = grid,
+    control = control
+  )
+
+  metrics <- result$.metrics[[1]]
+  estimates <- metrics$.estimate
+  predictions <- result$.predictions[[1]]
+
+  expected_sens <- yardstick::sens_vec(
+    truth = predictions$Class,
+    estimate = predictions$.pred_class,
+    event_level = "second"
+  )
+
+  expected_roc_auc <- yardstick::roc_auc_vec(
+    truth = predictions$Class,
+    estimate = predictions$.pred_Class2,
+    event_level = "second"
+  )
+
+  expect_identical(estimates[metrics$.metric == "sens"], expected_sens)
+  expect_identical(estimates[metrics$.metric == "roc_auc"], expected_roc_auc)
+})
+
+test_that("`event_level` is passed through in fit_resamples()", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("randomForest")
+
+  set.seed(123)
+
+  data("two_class_dat", package = "modeldata")
+  dat <- two_class_dat[1:50,]
+
+  spec <- parsnip::rand_forest(mode = "classification", trees = 2) %>%
+    parsnip::set_engine("randomForest")
+
+  control <- control_resamples(event_level = "second", save_pred = TRUE)
+  resamples <- rsample::bootstraps(dat, times = 1)
+  set <- yardstick::metric_set(yardstick::roc_auc, yardstick::sens)
+
+  result <- fit_resamples(
+    spec,
+    Class ~ .,
+    resamples = resamples,
+    metrics = set,
+    control = control
+  )
+
+  metrics <- result$.metrics[[1]]
+  estimates <- metrics$.estimate
+  predictions <- result$.predictions[[1]]
+
+  expected_sens <- yardstick::sens_vec(
+    truth = predictions$Class,
+    estimate = predictions$.pred_class,
+    event_level = "second"
+  )
+
+  expected_roc_auc <- yardstick::roc_auc_vec(
+    truth = predictions$Class,
+    estimate = predictions$.pred_Class2,
+    event_level = "second"
+  )
+
+  expect_identical(estimates[metrics$.metric == "sens"], expected_sens)
+  expect_identical(estimates[metrics$.metric == "roc_auc"], expected_roc_auc)
+})
+
+test_that("`event_level` is passed through in tune_bayes()", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("randomForest")
+
+  set.seed(123)
+
+  data("two_class_dat", package = "modeldata")
+  dat <- two_class_dat[1:50,]
+
+  spec <- parsnip::rand_forest(mode = "classification", trees = tune()) %>%
+    parsnip::set_engine("randomForest")
+
+  control_grid <- control_grid(save_pred = TRUE)
+  control <- control_bayes(event_level = "second", save_pred = TRUE)
+  resamples <- rsample::bootstraps(dat, times = 1)
+  set <- yardstick::metric_set(yardstick::roc_auc, yardstick::sens)
+
+  result <- tune_bayes(
+    spec,
+    Class ~ .,
+    resamples = resamples,
+    metrics = set,
+    iter = 1,
+    control = control
+  )
+
+  result <- result[result$.iter == 1,]
+
+  metrics <- result$.metrics[[1]]
+  estimates <- metrics$.estimate
+  predictions <- result$.predictions[[1]]
+
+  expected_sens <- yardstick::sens_vec(
+    truth = predictions$Class,
+    estimate = predictions$.pred_class,
+    event_level = "second"
+  )
+
+  expected_roc_auc <- yardstick::roc_auc_vec(
+    truth = predictions$Class,
+    estimate = predictions$.pred_Class2,
+    event_level = "second"
+  )
+
+  expect_identical(estimates[metrics$.metric == "sens"], expected_sens)
+  expect_identical(estimates[metrics$.metric == "roc_auc"], expected_roc_auc)
+})


### PR DESCRIPTION
Fixes #240 
Fixes #249 

Note that this requires yardstick 0.0.7, but that should be fine

We are supporting an explicit `event_level` argument, but we are not supporting the now deprecated yardstick global option of `yardstick.event_first`