### PR TITLE
Set final workflow in last_fit() to `trained`

### DIFF
--- a/R/last_fit.R
+++ b/R/last_fit.R
@@ -136,6 +136,7 @@ last_fit_workflow <- function(object, split, metrics) {
       control = ctrl
     )
   res$.workflow <- res$.extracts[[1]][[1]]
+  res$.workflow[[1]]$trained <- TRUE
   res$.extracts <- NULL
   class(res) <- c("last_fit", class(res))
   class(res) <- unique(class(res))

--- a/R/last_fit.R
+++ b/R/last_fit.R
@@ -136,7 +136,6 @@ last_fit_workflow <- function(object, split, metrics) {
       control = ctrl
     )
   res$.workflow <- res$.extracts[[1]][[1]]
-  res$.workflow[[1]]$trained <- TRUE
   res$.extracts <- NULL
   class(res) <- c("last_fit", class(res))
   class(res) <- unique(class(res))

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -18,6 +18,8 @@ test_that("formula method", {
   expect_equivalent(coef(extract_model(res$.workflow[[1]])), coef(lm_fit))
   expect_equal(res$.metrics[[1]]$.estimate[[2]], rmse_test)
   expect_equal(res$.predictions[[1]]$.pred, unname(test_pred))
+  expect_equal(nrow(predict(res$.workflow[[1]], testing(split))), nrow(testing(split)))
+
 })
 
 test_that("recipe method", {
@@ -27,6 +29,7 @@ test_that("recipe method", {
   expect_equivalent(sort(coef(extract_model(res$.workflow[[1]]))), sort(coef(lm_fit)))
   expect_equal(res$.metrics[[1]]$.estimate[[2]], rmse_test)
   expect_equal(res$.predictions[[1]]$.pred, unname(test_pred))
+  expect_equal(nrow(predict(res$.workflow[[1]], testing(split))), nrow(testing(split)))
 })
 
 test_that("collect metrics of last fit", {


### PR DESCRIPTION
The objects that end up in the `.workflow` column of `last_fit()` output currently have `trained` as false, meaning you can't predict on them. This PR sets:

```r
res$.workflow[[1]]$trained <- TRUE
```
in the same way that `fit.workflow` does, so that these workflows can be used for prediction.

``` r
library(tidymodels)

set.seed(6735)
tr_te_split <- initial_split(mtcars)

lin_mod <- linear_reg() %>%
  set_engine("lm")

car_wf <-
  workflow() %>%
  add_formula(mpg ~  .) %>%
  add_model(lin_mod)

car_fit <- last_fit(car_wf, split = tr_te_split)

predict(car_fit$.workflow[[1]], new_data = training(tr_te_split))
#> # A tibble: 24 x 1
#>    .pred
#>    <dbl>
#>  1  21.9
#>  2  22.4
#>  3  25.4
#>  4  21.6
#>  5  21.9
#>  6  13.3
#>  7  24.5
#>  8  17.6
#>  9  19.4
#> 10  13.7
#> # … with 14 more rows
```

<sup>Created on 2020-10-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>