### PR TITLE
No longer "reset" the workflow after preprocessing and model fitting

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -139,15 +139,32 @@ pull_notes <- function(resamples, res, control) {
 
 # ------------------------------------------------------------------------------
 
-append_metrics <- function(collection, predictions, workflow, metrics, split, event_level, .config = NULL) {
+append_metrics <- function(collection,
+                           predictions,
+                           metrics,
+                           param_names,
+                           outcome_name,
+                           event_level,
+                           split,
+                           .config = NULL) {
   if (inherits(predictions, "try-error")) {
     return(collection)
   }
-  tmp_est <- estimate_metrics(predictions, metrics, workflow, event_level)
+
+  tmp_est <- estimate_metrics(
+    dat = predictions,
+    metric = metrics,
+    param_names = param_names,
+    outcome_name = outcome_name,
+    event_level = event_level
+  )
+
   tmp_est <- cbind(tmp_est, labels(split))
+
   if (!rlang::is_null(.config)) {
     tmp_est <- cbind(tmp_est, .config)
   }
+
   dplyr::bind_rows(collection, tmp_est)
 }
 
@@ -189,10 +206,8 @@ append_extracts <- function(collection, workflow, param, split, ctrl, .config = 
   dplyr::bind_rows(collection, extracts)
 }
 
-append_outcome_names <- function(all_outcome_names, workflow) {
-  outcome_names <- outcome_names(workflow)
-  outcome_names <- list(outcome_names)
-  c(all_outcome_names, outcome_names)
+append_outcome_names <- function(all_outcome_names, outcome_names) {
+  c(all_outcome_names, list(outcome_names))
 }
 
 extract_config <- function(workflow, metrics) {

--- a/R/extract.R
+++ b/R/extract.R
@@ -210,8 +210,8 @@ append_outcome_names <- function(all_outcome_names, outcome_names) {
   c(all_outcome_names, list(outcome_names))
 }
 
-extract_config <- function(workflow, metrics) {
-  param_names <- c(dials::parameters(workflow)$id, ".config")
+extract_config <- function(param_names, metrics) {
+  param_names <- c(param_names, ".config")
   idx <- vctrs::vec_unique_loc(metrics[param_names])
   metrics[idx, param_names]
 }

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -1,23 +1,3 @@
-train_model <- function(workflow, grid, control) {
-  original_spec <- workflows::pull_workflow_spec(workflow)
-
-  if (!is.null(grid)) {
-    updated_spec <- merge(original_spec, grid)$x[[1]]
-  } else {
-    updated_spec <- original_spec
-  }
-
-  workflow <- set_workflow_spec(workflow, updated_spec)
-
-  workflow <- .fit_model(workflow, control)
-
-  # Always reset to the original spec so `parameters()` can be used on this
-  # object. The fit model is stored in `workflow$fit$fit`
-  workflow <- set_workflow_spec(workflow, original_spec)
-
-  workflow
-}
-
 predict_model <- function(split, workflow, grid, metrics) {
   model <- workflows::pull_workflow_fit(workflow)
 
@@ -115,23 +95,17 @@ make_rename_arg <- function(grid, model) {
 }
 
 # ------------------------------------------------------------------------------
-# Recipe-oriented helpers
 
-train_recipe_grid <- function(split, workflow, grid) {
-  original_recipe <- workflows::pull_workflow_preprocessor(workflow)
-  updated_recipe <- merge(original_recipe, grid)$x[[1]]
+finalize_workflow_spec <- function(workflow, grid) {
+  spec <- workflows::pull_workflow_spec(workflow)
+  spec <- merge(spec, grid)$x[[1]]
+  set_workflow_spec(workflow, spec)
+}
 
-  workflow <- set_workflow_recipe(workflow, updated_recipe)
-
-  training <- rsample::analysis(split)
-
-  workflow <- .fit_pre(workflow, training)
-
-  # Always reset to the original recipe so `parameters()` can be used on this
-  # object. The prepped updated recipe is stored in the mold.
-  workflow <- set_workflow_recipe(workflow, original_recipe)
-
-  workflow
+finalize_workflow_recipe <- function(workflow, grid) {
+  recipe <- workflows::pull_workflow_preprocessor(workflow)
+  recipe <- merge(recipe, grid)$x[[1]]
+  set_workflow_recipe(workflow, recipe)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/resample.R
+++ b/R/resample.R
@@ -209,6 +209,8 @@ iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
   all_outcome_names <- list()
   .notes <- NULL
 
+  param_names <- character()
+
   split <- resamples$splits[[rs_iter]]
   training <- rsample::analysis(split)
 
@@ -254,7 +256,8 @@ iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
   }
 
   # Extract names from the mold
-  all_outcome_names <- append_outcome_names(all_outcome_names, workflow)
+  outcome_names <- outcome_names(workflow)
+  all_outcome_names <- append_outcome_names(all_outcome_names, outcome_names)
 
   # Dummy tbl with no columns but the correct number of rows to `bind_cols()`
   # against in `append_extracts()`
@@ -284,7 +287,16 @@ iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
     return(out)
   }
 
-  metric_est <- append_metrics(metric_est, predictions, workflow, metrics, split, event_level)
+  metric_est <- append_metrics(
+    collection = metric_est,
+    predictions = predictions,
+    metrics = metrics,
+    param_names = param_names,
+    outcome_name = outcome_names,
+    event_level = event_level,
+    split = split
+  )
+
   pred_vals <- append_predictions(pred_vals, predictions, split, control)
 
   list(

--- a/R/resample.R
+++ b/R/resample.R
@@ -235,7 +235,7 @@ iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
   }
 
   workflow <- catch_and_log_fit(
-    train_model(workflow, grid = NULL, control = control_workflow),
+    .fit_model(workflow, control_workflow),
     control,
     split,
     "model",


### PR DESCRIPTION
Another step towards #294 

Previously we would reset the workflow after we finalized it for preprocessing / model fitting because we needed downstream calls to `parameters()` to work (i.e. the parameters needed to _not_ be finalized so we could detect which ones were tunable). I've refactored to avoid the need for this, which has two big benefits:

- Further unification between all of the code paths. Now we don't need `train_recipe_grid()` or `train_model()` anymore, we just call `.fit_pre()` and `.fit_model()` directly every time.

- The finalized workflow is now available for extraction by the `extract` function. Previously you could only extract a version of the workflow that didn't have finalized tunable parameters.

These changes will make it trivial for the code paths to call `workflows::.fit_finalize()`, which should fix the issues in #294 automatically.