### PR TITLE
Use `.fit_finalize()` in code paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     GPfit,
     foreach,
     parsnip (>= 0.0.4),
-    workflows (>= 0.1.3.9000),
+    workflows (>= 0.2.0.9000),
     hardhat (>= 0.1.0),
     lifecycle,
     vctrs (>= 0.3.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Other Changes
 
+* `predict()` can now be called on the workflow returned from `last_fit()` (#294, #295, #296).
+
 * tune now supports setting the `event_level` option from yardstick through the control objects (i.e. `control_grid(event_level = "second")`) (#240, #249).
 
 * tune now supports workflows created with the new `workflows::add_variables()` preprocessor.

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -124,6 +124,8 @@ iter_model_with_preprocessor <- function(rs_iter, resamples, grid, workflow, met
       next
     }
 
+    workflow <- .fit_finalize(workflow)
+
     # Extract names from the mold
     outcome_names <- outcome_names(workflow)
     all_outcome_names <- append_outcome_names(all_outcome_names, outcome_names)
@@ -298,6 +300,8 @@ iter_model_and_recipe <- function(rs_iter, resamples, grid, workflow, metrics, c
         next
       }
 
+      workflow <- .fit_finalize(workflow)
+
       # Extract names from the mold
       outcome_names <- outcome_names(workflow)
       all_outcome_names <- append_outcome_names(all_outcome_names, outcome_names)
@@ -416,6 +420,8 @@ iter_recipe <- function(rs_iter, resamples, grid, workflow, metrics, control) {
     if (is_failure(workflow) || is_failure(workflow$fit$fit$fit)) {
       next
     }
+
+    workflow <- .fit_finalize(workflow)
 
     # Extract names from the mold
     outcome_names <- outcome_names(workflow)

--- a/R/resample.R
+++ b/R/resample.R
@@ -255,6 +255,8 @@ iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
     return(out)
   }
 
+  workflow <- .fit_finalize(workflow)
+
   # Extract names from the mold
   outcome_names <- outcome_names(workflow)
   all_outcome_names <- append_outcome_names(all_outcome_names, outcome_names)

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -49,6 +49,7 @@ test_that('tune recipe only', {
   expect_equal(dplyr::n_distinct(res_est$.config), iterT)
   expect_equal(res_est$n, rep(10, iterT * 2))
   expect_false(identical(num_comp, expr(tune())))
+  expect_true(res_workflow$trained)
 
   expect_error(
     tune_bayes(wflow, resamples = folds, param_info = pset,

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -42,6 +42,7 @@ test_that('tune recipe only', {
   expect_equal(sum(res_est$.metric == "rsq"), nrow(grid))
   expect_equal(res_est$n, rep(10, nrow(grid) * 2))
   expect_false(identical(num_comp, expr(tune())))
+  expect_true(res_workflow$trained)
 })
 
 # ------------------------------------------------------------------------------
@@ -68,6 +69,7 @@ test_that('tune model only (with recipe)', {
   expect_equal(sum(res_est$.metric == "rsq"), nrow(grid))
   expect_equal(res_est$n, rep(10, nrow(grid) * 2))
   expect_false(identical(cost, expr(tune())))
+  expect_true(res_workflow$trained)
 })
 
 # ------------------------------------------------------------------------------
@@ -150,6 +152,7 @@ test_that('tune model and recipe', {
   expect_equal(res_est$n, rep(10, nrow(grid) * 2))
   expect_false(identical(cost, expr(tune())))
   expect_false(identical(num_comp, expr(tune())))
+  expect_true(res_workflow$trained)
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -18,6 +18,7 @@ test_that("formula method", {
   expect_equivalent(coef(extract_model(res$.workflow[[1]])), coef(lm_fit))
   expect_equal(res$.metrics[[1]]$.estimate[[2]], rmse_test)
   expect_equal(res$.predictions[[1]]$.pred, unname(test_pred))
+  expect_equal(nrow(predict(res$.workflow[[1]], testing(split))), nrow(testing(split)))
 })
 
 test_that("recipe method", {
@@ -27,6 +28,7 @@ test_that("recipe method", {
   expect_equivalent(sort(coef(extract_model(res$.workflow[[1]]))), sort(coef(lm_fit)))
   expect_equal(res$.metrics[[1]]$.estimate[[2]], rmse_test)
   expect_equal(res$.predictions[[1]]$.pred, unname(test_pred))
+  expect_equal(nrow(predict(res$.workflow[[1]], testing(split))), nrow(testing(split)))
 })
 
 test_that("collect metrics of last fit", {

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -18,6 +18,7 @@ test_that("formula method", {
   expect_equivalent(coef(extract_model(res$.workflow[[1]])), coef(lm_fit))
   expect_equal(res$.metrics[[1]]$.estimate[[2]], rmse_test)
   expect_equal(res$.predictions[[1]]$.pred, unname(test_pred))
+  expect_true(res$.workflow[[1]]$trained)
   expect_equal(nrow(predict(res$.workflow[[1]], testing(split))), nrow(testing(split)))
 })
 
@@ -28,6 +29,7 @@ test_that("recipe method", {
   expect_equivalent(sort(coef(extract_model(res$.workflow[[1]]))), sort(coef(lm_fit)))
   expect_equal(res$.metrics[[1]]$.estimate[[2]], rmse_test)
   expect_equal(res$.predictions[[1]]$.pred, unname(test_pred))
+  expect_true(res$.workflow[[1]]$trained)
   expect_equal(nrow(predict(res$.workflow[[1]], testing(split))), nrow(testing(split)))
 })
 

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -116,6 +116,25 @@ test_that("can use `fit_resamples()` with a workflow - formula", {
   expect_equal(collect_metrics(expect), collect_metrics(result))
 })
 
+test_that("extracted workflow is finalized", {
+  set.seed(6735)
+  folds <- vfold_cv(mtcars, v = 2)
+
+  lin_mod <- linear_reg() %>%
+    set_engine("lm")
+
+  workflow <- workflow() %>%
+    add_variables(mpg, c(cyl, disp)) %>%
+    add_model(lin_mod)
+
+  control <- control_resamples(extract = identity)
+
+  result <- fit_resamples(workflow, folds, control = control)
+  result_workflow <- result$.extracts[[1]]$.extracts[[1]]
+
+  expect_true(result_workflow$trained)
+})
+
 # ------------------------------------------------------------------------------
 # Error capture
 


### PR DESCRIPTION
Closes #294 

Now the workflows extracted from `tune_grid()`, `tune_bayes()`, and `fit_resamples()` are all "finalized". This propagates to `last_fit()` as well, which means that workflow can now be predicted from.