### PR TITLE
Prompt user to tune() params

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -30,7 +30,7 @@ check_grid <- function(x, object, pset = NULL) {
     msg <- paste0(
       "No tuning parameters have been detected, ",
       "performance will be evaluated using the resamples with no tuning. ",
-      "Did you want [fit_resamples()]?"
+      "Did you want to [tune()] your model parameters?"
     )
     rlang::warn(msg)
     return(x)

--- a/R/checks.R
+++ b/R/checks.R
@@ -30,7 +30,7 @@ check_grid <- function(x, object, pset = NULL) {
     msg <- paste0(
       "No tuning parameters have been detected, ",
       "performance will be evaluated using the resamples with no tuning. ",
-      "Did you want to [tune()] your model parameters?"
+      "Did you want to [tune()] parameters?"
     )
     rlang::warn(msg)
     return(x)


### PR DESCRIPTION
Closes #212 

After thinking about it a while, I do think this is a better error message in this situation:

``` r
library(tidymodels)

set.seed(123)
car_bt <- bootstraps(mtcars)

lin_mod <- linear_reg() %>%
  set_engine("lm")

car_wf <-
  workflow() %>%
  add_formula(mpg ~  .) %>%
  add_model(linear_reg() %>% set_engine("lm"))

tune_grid(car_wf, resamples = car_bt)
#> Warning: No tuning parameters have been detected, performance will be evaluated
#> using the resamples with no tuning. Did you want to [tune()] parameters?
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 25 x 4
#>    splits          id          .metrics         .notes          
#>    <list>          <chr>       <list>           <list>          
#>  1 <split [32/11]> Bootstrap01 <tibble [2 × 3]> <tibble [0 × 1]>
#>  2 <split [32/9]>  Bootstrap02 <tibble [2 × 3]> <tibble [0 × 1]>
#>  3 <split [32/10]> Bootstrap03 <tibble [2 × 3]> <tibble [0 × 1]>
#>  4 <split [32/14]> Bootstrap04 <tibble [2 × 3]> <tibble [0 × 1]>
#>  5 <split [32/11]> Bootstrap05 <tibble [2 × 3]> <tibble [0 × 1]>
#>  6 <split [32/8]>  Bootstrap06 <tibble [2 × 3]> <tibble [0 × 1]>
#>  7 <split [32/12]> Bootstrap07 <tibble [2 × 3]> <tibble [0 × 1]>
#>  8 <split [32/13]> Bootstrap08 <tibble [2 × 3]> <tibble [0 × 1]>
#>  9 <split [32/15]> Bootstrap09 <tibble [2 × 3]> <tibble [0 × 1]>
#> 10 <split [32/12]> Bootstrap10 <tibble [2 × 3]> <tibble [0 × 1]>
#> # … with 15 more rows
```

<sup>Created on 2020-10-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>