### PR TITLE
Move `min_grid()` computation out of the iteration loop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     workflows (>= 0.2.0.9000),
     hardhat (>= 0.1.0),
     lifecycle,
-    vctrs (>= 0.3.0)
+    vctrs (>= 0.3.0),
+    tidyselect (>= 1.1.0)
 Suggests: 
     testthat,
     knitr,

--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -50,7 +50,7 @@ utils::globalVariables(
     "delta", "sd_trunc", "snr", "z", "..val", "max_val", "has_submodel", "res",
     ".extracts", ".metrics", "value", ".notes", ".loss", ".bound",
     ".column", ".totals", ".value", "direction", ".config", "Freq", "Prediction",
-    "Truth", ".seed", ".order")
+    "Truth", ".seed", ".order", ".iter_model", ".iter_recipe")
   )
 
 # ------------------------------------------------------------------------------

--- a/R/extract.R
+++ b/R/extract.R
@@ -185,13 +185,9 @@ append_predictions <- function(collection, predictions, split, control, .config 
   dplyr::bind_rows(collection, predictions)
 }
 
-append_extracts <- function(collection, workflow, param, split, ctrl, .config = NULL) {
-  if (any(names(param) == ".submodels")) {
-    param <- param %>% dplyr::select(-.submodels)
-  }
-
+append_extracts <- function(collection, workflow, grid, split, ctrl, .config = NULL) {
   extracts <-
-    param %>%
+    grid %>%
     dplyr::bind_cols(labels(split)) %>%
     mutate(
       .extracts = list(

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -120,7 +120,7 @@ iter_model_with_preprocessor <- function(rs_iter,
     )
 
     grid_info_model_iter <- dplyr::filter(grid_info_model, .iter_model == mod_iter)
-    grid_model_iter <- dplyr::select(grid_info_model_iter, dplyr::all_of(model_param_names))
+    grid_model_iter <- dplyr::select(grid_info_model_iter, tidyselect::all_of(model_param_names))
     submodels_iter <- dplyr::pull(grid_info_model_iter, ".submodels")[[1L]]
 
     workflow <- finalize_workflow_spec(workflow, grid_model_iter)
@@ -240,7 +240,7 @@ iter_model_and_recipe <- function(rs_iter,
     rec_id <- vec_slice(recipes::names0(num_rec, "Recipe"), rec_iter)
 
     grid_info_recipe_iter <- dplyr::filter(grid_info, .iter_recipe == rec_iter)
-    grid_recipe_iter <- dplyr::select(grid_info_recipe_iter, dplyr::all_of(recipe_param_names))
+    grid_recipe_iter <- dplyr::select(grid_info_recipe_iter, tidyselect::all_of(recipe_param_names))
 
     workflow <- finalize_workflow_recipe(workflow, grid_recipe_iter)
 
@@ -283,7 +283,7 @@ iter_model_and_recipe <- function(rs_iter,
       mod_id <- paste0(rec_id, "_", mod_id)
 
       grid_info_model_iter <- dplyr::filter(grid_info_model, .iter_model == mod_iter)
-      grid_model_iter <- dplyr::select(grid_info_model_iter, dplyr::all_of(model_param_names))
+      grid_model_iter <- dplyr::select(grid_info_model_iter, tidyselect::all_of(model_param_names))
       submodels_iter <- dplyr::pull(grid_info_model_iter, ".submodels")[[1]]
 
       workflow <- finalize_workflow_spec(workflow, grid_model_iter)
@@ -403,7 +403,7 @@ iter_recipe <- function(rs_iter,
     rec_id <- vec_slice(recipes::names0(num_rec, "Recipe"), rec_iter)
 
     grid_info_recipe_iter <- dplyr::filter(grid_info, .iter_recipe == rec_iter)
-    grid_recipe_iter <- dplyr::select(grid_info_recipe_iter, dplyr::all_of(recipe_param_names))
+    grid_recipe_iter <- dplyr::select(grid_info_recipe_iter, tidyselect::all_of(recipe_param_names))
 
     workflow <- finalize_workflow_recipe(workflow, grid_recipe_iter)
 

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -41,7 +41,7 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
           eval_tidy(mp_call) %>%
           mutate(.row = orig_rows) %>%
           unnest(cols = dplyr::starts_with(".pred")) %>%
-          cbind(dplyr::select(grid, -dplyr::all_of(submod_param)), row.names = NULL) %>%
+          cbind(dplyr::select(grid, -tidyselect::all_of(submod_param)), row.names = NULL) %>%
           # go back to user-defined name
           dplyr::rename(!!!make_rename_arg(grid, model, submodels)) %>%
           dplyr::select(dplyr::one_of(names(tmp_res))) %>%
@@ -163,9 +163,9 @@ compute_grid_info_model <- function(workflow,
   out <- add_iter_model(out)
 
   if (tidyr_new_interface()) {
-    out <- tidyr::nest(out, data = c(.iter_model, dplyr::all_of(parameter_names_model), .submodels))
+    out <- tidyr::nest(out, data = c(.iter_model, tidyselect::all_of(parameter_names_model), .submodels))
   } else {
-    out <- tidyr::nest(out, c(.iter_model, dplyr::all_of(parameter_names_model), .submodels))
+    out <- tidyr::nest(out, c(.iter_model, tidyselect::all_of(parameter_names_model), .submodels))
   }
 
   out
@@ -180,9 +180,9 @@ compute_grid_info_model_and_recipe <- function(workflow,
 
   # Nest model parameters, keep recipe parameters outside
   if (tidyr_new_interface()) {
-    out <- tidyr::nest(grid, data = dplyr::all_of(parameter_names_model))
+    out <- tidyr::nest(grid, data = tidyselect::all_of(parameter_names_model))
   } else {
-    out <- tidyr::nest(grid, dplyr::all_of(parameter_names_model))
+    out <- tidyr::nest(grid, tidyselect::all_of(parameter_names_model))
   }
 
   spec <- workflows::pull_workflow_spec(workflow)

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -1,4 +1,4 @@
-predict_model <- function(split, workflow, grid, metrics) {
+predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
   model <- workflows::pull_workflow_fit(workflow)
 
   forged <- forge_from_workflow(split, workflow)
@@ -12,27 +12,22 @@ predict_model <- function(split, workflow, grid, metrics) {
   type_info <- metrics_info(metrics)
   types <- unique(type_info$type)
 
-  # Split `grid` from the parameters used to fit the model and any potential
-  # sub-model parameters
-  submod_col <- names(grid) == ".submodels"
-  fixed_param <- grid[, !submod_col]
-
   res <- NULL
-  merge_vars <- c(".row", names(fixed_param))
+  merge_vars <- c(".row", names(grid))
 
   for (type_iter in types) {
     # Regular predictions
     tmp_res <-
       predict(model, x_vals, type = type_iter) %>%
       mutate(.row = orig_rows) %>%
-      cbind(fixed_param, row.names = NULL)
+      cbind(grid, row.names = NULL)
 
-    if (any(submod_col)) {
-      submod_length <- purrr::map_int(grid$.submodels[[1]], length)
+    if (!is.null(submodels)) {
+      submod_length <- lengths(submodels)
       has_submodels <- any(submod_length > 0)
 
       if (has_submodels) {
-        submod_param <- names(grid$.submodels[[1]])
+        submod_param <- names(submodels)
         mp_call <-
           call2(
             "multi_predict",
@@ -40,16 +35,15 @@ predict_model <- function(split, workflow, grid, metrics) {
             object = expr(model),
             new_data = expr(x_vals),
             type = type_iter,
-            !!!make_submod_arg(grid, model)
+            !!!make_submod_arg(grid, model, submodels)
           )
         tmp_res <-
           eval_tidy(mp_call) %>%
           mutate(.row = orig_rows) %>%
           unnest(cols = dplyr::starts_with(".pred")) %>%
-          cbind(fixed_param %>% dplyr::select(-one_of(submod_param)),
-                row.names = NULL) %>%
+          cbind(dplyr::select(grid, -dplyr::all_of(submod_param)), row.names = NULL) %>%
           # go back to user-defined name
-          dplyr::rename(!!!make_rename_arg(grid, model)) %>%
+          dplyr::rename(!!!make_rename_arg(grid, model, submodels)) %>%
           dplyr::select(dplyr::one_of(names(tmp_res))) %>%
           dplyr::bind_rows(tmp_res)
       }
@@ -71,26 +65,24 @@ predict_model <- function(split, workflow, grid, metrics) {
   tibble::as_tibble(res)
 }
 
-make_submod_arg <- function(grid, model) {
+make_submod_arg <- function(grid, model, submodels) {
   # Assumes only one submodel parameter per model
   real_name <-
     parsnip::get_from_env(paste(class(model$spec)[1], "args", sep = "_")) %>%
     dplyr::filter(has_submodel & engine == model$spec$engine) %>%
     dplyr::pull(parsnip)
-  submods <- grid$.submodels[[1]]
-  names(submods) <- real_name
-  submods
+  names(submodels) <- real_name
+  submodels
 }
 
-make_rename_arg <- function(grid, model) {
+make_rename_arg <- function(grid, model, submodels) {
   # Assumes only one submodel parameter per model
   real_name <-
     parsnip::get_from_env(paste(class(model$spec)[1], "args", sep = "_")) %>%
     dplyr::filter(has_submodel & engine == model$spec$engine) %>%
     dplyr::pull(parsnip)
-  submods <- grid$.submodels[[1]]
   res <- list(real_name)
-  names(res) <- names(submods)
+  names(res) <- names(submodels)
   res
 }
 
@@ -106,6 +98,112 @@ finalize_workflow_recipe <- function(workflow, grid) {
   recipe <- workflows::pull_workflow_preprocessor(workflow)
   recipe <- merge(recipe, grid)$x[[1]]
   set_workflow_recipe(workflow, recipe)
+}
+
+# ------------------------------------------------------------------------------
+
+compute_grid_info <- function(workflow, grid) {
+  # For `fit_resamples()`
+  if (is.null(grid)) {
+    return(NULL)
+  }
+
+  grid <- tibble::as_tibble(grid)
+
+  parameters <- dials::parameters(workflow)
+  parameters_model <- dplyr::filter(parameters, source == "model_spec")
+  parameters_recipe <- dplyr::filter(parameters, source == "recipe")
+
+  any_parameters_model <- nrow(parameters_model) > 0
+  any_parameters_recipe <- nrow(parameters_recipe) > 0
+
+  if (any_parameters_model) {
+    if (any_parameters_recipe) {
+      compute_grid_info_model_and_recipe(workflow, grid, parameters_model, parameters_recipe)
+    } else {
+      compute_grid_info_model(workflow, grid, parameters_model, parameters_recipe)
+    }
+  } else {
+    if (any_parameters_recipe) {
+      compute_grid_info_recipe(workflow, grid, parameters_model, parameters_recipe)
+    } else {
+      rlang::abort("Internal error: `workflow` should have some tunable parameters if `grid` is not `NULL`.")
+    }
+  }
+}
+
+compute_grid_info_recipe <- function(workflow,
+                                     grid,
+                                     parameters_model,
+                                     parameters_recipe) {
+  out <- grid
+
+  out <- add_iter_recipe(out)
+  out <- dplyr::mutate(out, .iter_model = 1L)
+
+  if (tidyr_new_interface()) {
+    out <- tidyr::nest(out, data = .iter_model)
+  } else {
+    out <- tidyr::nest(out, .iter_model)
+  }
+
+  out
+}
+
+compute_grid_info_model <- function(workflow,
+                                    grid,
+                                    parameters_model,
+                                    parameters_recipe) {
+  spec <- workflows::pull_workflow_spec(workflow)
+  out <- min_grid(spec, grid)
+
+  parameter_names_model <- parameters_model[["id"]]
+
+  out <- dplyr::mutate(out, .iter_recipe = 1L)
+  out <- add_iter_model(out)
+
+  if (tidyr_new_interface()) {
+    out <- tidyr::nest(out, data = c(.iter_model, dplyr::all_of(parameter_names_model), .submodels))
+  } else {
+    out <- tidyr::nest(out, c(.iter_model, dplyr::all_of(parameter_names_model), .submodels))
+  }
+
+  out
+}
+
+compute_grid_info_model_and_recipe <- function(workflow,
+                                               grid,
+                                               parameters_model,
+                                               parameters_recipe) {
+  parameter_names_model <- parameters_model[["id"]]
+  parameter_names_recipe <- parameters_recipe[["id"]]
+
+  # Nest model parameters, keep recipe parameters outside
+  if (tidyr_new_interface()) {
+    out <- tidyr::nest(grid, data = dplyr::all_of(parameter_names_model))
+  } else {
+    out <- tidyr::nest(grid, dplyr::all_of(parameter_names_model))
+  }
+
+  spec <- workflows::pull_workflow_spec(workflow)
+
+  # Minify model grids
+  out$data <- purrr::map(out$data, min_grid, x = spec)
+
+  # Add model iteration
+  out$data <- purrr::map(out$data, add_iter_model)
+
+  # Add recipe iteration
+  out <- add_iter_recipe(out)
+
+  out
+}
+
+add_iter_recipe <- function(data) {
+  tibble::rowid_to_column(data, var = ".iter_recipe")
+}
+add_iter_model <- function(data) {
+  tibble::rowid_to_column(data, var = ".iter_model")
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-compat-dplyr.R
+++ b/tests/testthat/test-compat-dplyr.R
@@ -187,7 +187,7 @@ test_that("right_join() can keep tune_results class if tune_results structure is
       y_names <- c(y_names, x_names[col_equals_dot_iter(x_names)])
     }
 
-    y <- mutate(select(x, all_of(y_names)), x = 1)
+    y <- mutate(select(x, tidyselect::all_of(y_names)), x = 1)
     expect_s3_class_tune_results(right_join(x, y, by = y_names))
   }
 })


### PR DESCRIPTION
This PR introduces a new function that helps compute "grid info" - a nested tibble of information about that grid that has information about recipe parameters on the outside, and information about model parameters in the nested part (including submodel info).

We compute all this information up front, allowing us to lift the min grid computation out of the iteration loop. This helps us get a step closer to a "flat" parallel loop over the recipe and model because we can just unnest this information to end up with a tibble where each row corresponds to one iteration of the "flat" loop

The grid info object looks like this:

``` r
grid_info1 <- tune:::compute_grid_info(wflow1, grid1)
grid_info2 <- tune:::compute_grid_info(wflow2, grid2)

# grid info about a grid that has both recipe and model tunable parameters
grid_info1
#> # A tibble: 3 x 3
#>   .iter_recipe num_comp data            
#>          <int>    <int> <list>          
#> 1            1        1 <tibble [3 × 3]>
#> 2            2        2 <tibble [3 × 3]>
#> 3            3        3 <tibble [3 × 3]>

# grid info about a grid that only tunes the model
# we still return the outer recipe part for consistency
grid_info2
#> # A tibble: 1 x 2
#>   .iter_recipe data            
#>          <int> <list>          
#> 1            1 <tibble [3 × 3]>

# Each row of the unnested grid would be 1 iteration of the "flat" loop
tidyr::unnest(grid_info1, data)
#> # A tibble: 9 x 5
#>   .iter_recipe num_comp .iter_model      cost .submodels
#>          <int>    <int>       <int>     <dbl> <list>    
#> 1            1        1           1  0.000977 <list [0]>
#> 2            1        1           2  0.177    <list [0]>
#> 3            1        1           3 32        <list [0]>
#> 4            2        2           1  0.000977 <list [0]>
#> 5            2        2           2  0.177    <list [0]>
#> 6            2        2           3 32        <list [0]>
#> 7            3        3           1  0.000977 <list [0]>
#> 8            3        3           2  0.177    <list [0]>
#> 9            3        3           3 32        <list [0]>

# Even though we are only tuning the model, we return the recipe iter info for consistency
tidyr::unnest(grid_info2, data)
#> # A tibble: 3 x 4
#>   .iter_recipe .iter_model      cost .submodels
#>          <int>       <int>     <dbl> <list>    
#> 1            1           1  0.000977 <list [0]>
#> 2            1           2  0.177    <list [0]>
#> 3            1           3 32        <list [0]>
```

<sup>Created on 2020-10-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>