### PR TITLE
Move config id generation to grid-info

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Other Changes
 
+* The `.config` column that appears in the returned tibble from tuning and fitting resamples has changed slightly. It is now always of the form `"Preprocessor<i>_Model<j>"`.
+
 * `predict()` can now be called on the workflow returned from `last_fit()` (#294, #295, #296).
 
 * tune now supports setting the `event_level` option from yardstick through the control objects (i.e. `control_grid(event_level = "second")`) (#240, #249).


### PR DESCRIPTION
More simplification of the tune loop. This moves the config-id and message generation out of the loop and into the grid info object. Hopefully this makes it so that the loops can all collapse together

This slightly changes the output of the `.config` column, which is now always standardized to `Preprocessor<i>_Model<j>`, so I added a news bullet about that.