### PR TITLE
The Grand Unification of Tune

### DIFF
--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -50,8 +50,8 @@ utils::globalVariables(
     "delta", "sd_trunc", "snr", "z", "..val", "max_val", "has_submodel", "res",
     ".extracts", ".metrics", "value", ".notes", ".loss", ".bound",
     ".column", ".totals", ".value", "direction", ".config", "Freq", "Prediction",
-    "Truth", ".seed", ".order", ".iter_model", ".iter_recipe", ".iter_config",
-    ".msg_model")
+    "Truth", ".seed", ".order", ".iter_model", ".iter_preprocessor",
+    ".iter_config", ".msg_model")
   )
 
 # ------------------------------------------------------------------------------

--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -46,11 +46,12 @@ utils::globalVariables(
     "component", "component_id", "id", "control", ".pred", ".metric",
     ".estimator", ".estimate", "n", "note", "object", "splits", "grid",
     "resamples", ".iter", "mean", ".submodels", "metrics", "data", ".mean",
-    ".sd", "rs_iter", "pkg", ".pred_class", "std_err", "const", "objective",
+    ".sd", "iteration", "pkg", ".pred_class", "std_err", "const", "objective",
     "delta", "sd_trunc", "snr", "z", "..val", "max_val", "has_submodel", "res",
     ".extracts", ".metrics", "value", ".notes", ".loss", ".bound",
     ".column", ".totals", ".value", "direction", ".config", "Freq", "Prediction",
-    "Truth", ".seed", ".order", ".iter_model", ".iter_recipe")
+    "Truth", ".seed", ".order", ".iter_model", ".iter_recipe", ".iter_config",
+    ".msg_model")
   )
 
 # ------------------------------------------------------------------------------

--- a/R/checks.R
+++ b/R/checks.R
@@ -22,6 +22,11 @@ check_rset <- function(x) {
 grid_msg <- "`grid` should be a positive integer or a data frame."
 
 check_grid <- function(grid, workflow, pset = NULL) {
+  # `NULL` grid is the signal that we are using `fit_resamples()`
+  if (is.null(grid)) {
+    return(grid)
+  }
+
   if (is.null(pset)) {
     pset <- dials::parameters(workflow)
   }
@@ -36,10 +41,6 @@ check_grid <- function(grid, workflow, pset = NULL) {
 
     # Return `NULL` as the new `grid`, like what is used in `fit_resamples()`
     return(NULL)
-  }
-
-  if (is.null(grid)) {
-    rlang::abort(grid_msg)
   }
 
   if (!is.numeric(grid)) {

--- a/R/checks.R
+++ b/R/checks.R
@@ -21,9 +21,9 @@ check_rset <- function(x) {
 
 grid_msg <- "`grid` should be a positive integer or a data frame."
 
-check_grid <- function(x, object, pset = NULL) {
+check_grid <- function(grid, workflow, pset = NULL) {
   if (is.null(pset)) {
-    pset <- dials::parameters(object)
+    pset <- dials::parameters(workflow)
   }
 
   if (nrow(pset) == 0L) {
@@ -33,33 +33,35 @@ check_grid <- function(x, object, pset = NULL) {
       "Did you want to [tune()] parameters?"
     )
     rlang::warn(msg)
-    return(x)
+
+    # Return `NULL` as the new `grid`, like what is used in `fit_resamples()`
+    return(NULL)
   }
 
-  if (is.null(x)) {
+  if (is.null(grid)) {
     rlang::abort(grid_msg)
   }
 
-  if (!is.numeric(x)) {
-    if (!is.data.frame(x)) {
+  if (!is.numeric(grid)) {
+    if (!is.data.frame(grid)) {
       rlang::abort(grid_msg)
     }
 
-    grid_distinct <- distinct(x)
-    if (!identical(nrow(grid_distinct), nrow(x))) {
+    grid_distinct <- distinct(grid)
+    if (!identical(nrow(grid_distinct), nrow(grid))) {
       rlang::warn(
         "Duplicate rows in grid of tuning combinations found and removed."
       )
     }
-    x <- grid_distinct
+    grid <- grid_distinct
 
-    tune_tbl <- tune_args(object)
+    tune_tbl <- tune_args(workflow)
     tune_params <- tune_tbl$id
 
     # when called from [tune_bayes()]
     tune_params <- tune_params[tune_params != ".iter"]
 
-    grid_params <- names(x)
+    grid_params <- names(grid)
 
     extra_grid_params <- setdiff(grid_params, tune_params)
     extra_tune_params <- setdiff(tune_params, grid_params)
@@ -88,21 +90,21 @@ check_grid <- function(x, object, pset = NULL) {
       rlang::abort(msg)
     }
   } else {
-    x <- as.integer(x[1])
-    if (x < 1) {
+    grid <- as.integer(grid[1])
+    if (grid < 1) {
       rlang::abort(grid_msg)
     }
-    check_workflow(object, pset = pset, check_dials = TRUE)
+    check_workflow(workflow, pset = pset, check_dials = TRUE)
 
-    x <- dials::grid_latin_hypercube(pset, size = x)
-    x <- dplyr::distinct(x)
+    grid <- dials::grid_latin_hypercube(pset, size = grid)
+    grid <- dplyr::distinct(grid)
   }
 
-  if (!tibble::is_tibble(x)) {
-    x <- tibble::as_tibble(x)
+  if (!tibble::is_tibble(grid)) {
+    grid <- tibble::as_tibble(grid)
   }
 
-  x
+  grid
 }
 
 needs_finalization <- function(x, nms = character(0)) {
@@ -117,15 +119,15 @@ needs_finalization <- function(x, nms = character(0)) {
   any(dials::has_unknowns(x$object))
 }
 
-check_parameters <- function(object, pset = NULL, data, grid_names = character(0)) {
+check_parameters <- function(workflow, pset = NULL, data, grid_names = character(0)) {
   if (is.null(pset)) {
-    pset <- parameters(object)
+    pset <- parameters(workflow)
   }
   unk <- purrr::map_lgl(pset$object, dials::has_unknowns)
   if (!any(unk)) {
     return(pset)
   }
-  tune_param <- tune_args(object)
+  tune_param <- tune_args(workflow)
   tune_recipe <- tune_param$id[tune_param$source == "recipe"]
   tune_recipe <- length(tune_recipe) > 0
 
@@ -149,7 +151,7 @@ check_parameters <- function(object, pset = NULL, data, grid_names = character(0
 
     tune_log(list(verbose = TRUE), split = NULL, msg, type = "info")
 
-    x <- workflows::.fit_pre(object, data)$pre$mold$predictors
+    x <- workflows::.fit_pre(workflow, data)$pre$mold$predictors
     pset$object <- purrr::map(pset$object, dials::finalize, x = x)
   }
   pset

--- a/R/extract.R
+++ b/R/extract.R
@@ -176,12 +176,19 @@ append_predictions <- function(collection, predictions, split, control, .config 
     return(collection)
   }
 
-  predictions <- cbind(predictions, labels(split))
+  predictions <- vec_cbind(predictions, labels(split))
+
   if (!rlang::is_null(.config)) {
-    predictions <- inner_join(
-      predictions, .config, by = setdiff(names(.config), ".config")
-      )
+    by <- setdiff(names(.config), ".config")
+
+    if (length(by) == 0L) {
+      # Nothing to tune, just bind on config
+      predictions <- vec_cbind(predictions, .config)
+    } else{
+      predictions <- dplyr::inner_join(predictions, .config, by = by)
+    }
   }
+
   dplyr::bind_rows(collection, predictions)
 }
 

--- a/R/extract.R
+++ b/R/extract.R
@@ -206,10 +206,10 @@ append_outcome_names <- function(all_outcome_names, outcome_names) {
   c(all_outcome_names, list(outcome_names))
 }
 
-extract_config <- function(param_names, metrics) {
-  param_names <- c(param_names, ".config")
-  idx <- vctrs::vec_unique_loc(metrics[param_names])
-  metrics[idx, param_names]
+extract_metrics_config <- function(param_names, metrics) {
+  metrics_config_names <- c(param_names, ".config")
+  out <- metrics[metrics_config_names]
+  vec_unique(out)
 }
 
 #' Convenience functions to extract model or recipe

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -78,7 +78,7 @@ tune_grid_loop_iter <- function(iteration,
 
     iter_grid_info <- dplyr::filter(
       .data = grid_info,
-      .iter_recipe == i
+      .iter_preprocessor == i
     )
 
     iter_grid_preprocessor <- dplyr::select(

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -1,16 +1,3 @@
-tune_nothing <- function(resamples, grid, workflow, metrics, control)  {
-  tune_grid_loop(resamples, NULL, workflow, metrics, control)
-}
-tune_model_with_preprocessor <- function(resamples, grid, workflow, metrics, control) {
-  tune_grid_loop(resamples, grid, workflow, metrics, control)
-}
-tune_model_and_recipe <- function(resamples, grid, workflow, metrics, control) {
-  tune_grid_loop(resamples, grid, workflow, metrics, control)
-}
-tune_recipe <- function(resamples, grid, workflow, metrics, control) {
-  tune_grid_loop(resamples, grid, workflow, metrics, control)
-}
-
 tune_grid_loop <- function(resamples, grid, workflow, metrics, control) {
   n_resamples <- nrow(resamples)
 

--- a/R/logging.R
+++ b/R/logging.R
@@ -144,7 +144,7 @@ catch_and_log <- function(.expr, ..., bad_only = FALSE, notes) {
   tune_log(..., type = "info")
   tmp <- catcher(.expr)
   new_notes <- log_problems(notes, ..., tmp, bad_only = bad_only)
-  assign(".notes", new_notes, envir = parent.frame())
+  assign("out_notes", new_notes, envir = parent.frame())
   tmp$res
 }
 
@@ -159,7 +159,7 @@ catch_and_log_fit <- function(expr, ..., notes) {
     result_parsnip <- list(res = result, signals = list())
 
     new_notes <- log_problems(notes, ..., result_parsnip)
-    assign(".notes", new_notes, envir = parent.frame())
+    assign("out_notes", new_notes, envir = parent.frame())
     return(result)
   }
 
@@ -176,12 +176,12 @@ catch_and_log_fit <- function(expr, ..., notes) {
     result_fit <- list(res = fit, signals = list())
 
     new_notes <- log_problems(notes, ..., result_fit)
-    assign(".notes", new_notes, envir = parent.frame())
+    assign("out_notes", new_notes, envir = parent.frame())
     return(result)
   }
 
   new_notes <- log_problems(notes, ..., caught)
-  assign(".notes", new_notes, envir = parent.frame())
+  assign("out_notes", new_notes, envir = parent.frame())
 
   result
 }

--- a/R/resample.R
+++ b/R/resample.R
@@ -154,9 +154,12 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
   rset_info <- pull_rset_attributes(resamples)
   resamples <- new_bare_tibble(resamples)
 
+  # `NULL` is the signal that we have no grid to tune with
+  grid <- NULL
+
   resamples <- tune_grid_loop(
     resamples = resamples,
-    grid = NULL,
+    grid = grid,
     workflow = workflow,
     metrics = metrics,
     control = control

--- a/R/resample.R
+++ b/R/resample.R
@@ -154,7 +154,13 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
   rset_info <- pull_rset_attributes(resamples)
   resamples <- new_bare_tibble(resamples)
 
-  resamples <- resample_loop(resamples, workflow, metrics, control)
+  resamples <- tune_grid_loop(
+    resamples = resamples,
+    grid = NULL,
+    workflow = workflow,
+    metrics = metrics,
+    control = control
+  )
 
   if (is_cataclysmic(resamples)) {
     rlang::warn(
@@ -167,7 +173,8 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
 
   workflow_output <- set_workflow(workflow, control)
 
-  resamples <- resamples %>% dplyr::select(-.seed)
+  resamples <- dplyr::select(resamples, -.seed)
+
   new_resample_results(
     x = resamples,
     parameters = parameters(workflow),
@@ -176,184 +183,4 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
     rset_info = rset_info,
     workflow = workflow_output
   )
-}
-
-# ------------------------------------------------------------------------------
-
-resample_loop <- function(resamples, workflow, metrics, control) {
-  tune_grid_loop(
-    resamples = resamples,
-    grid = NULL,
-    workflow = workflow,
-    metrics = metrics,
-    control = control,
-    fn_iter = iter_resamples
-  )
-}
-
-# ------------------------------------------------------------------------------
-
-iter_resamples <- function(rs_iter, resamples, workflow, metrics, control) {
-  load_pkgs(workflow)
-  load_namespace(control$pkgs)
-  set.seed(resamples$.seed[[rs_iter]])
-
-  control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
-  control_workflow <- control_workflow(control_parsnip = control_parsnip)
-
-  event_level <- control$event_level
-
-  metric_est <- NULL
-  extracted <- NULL
-  pred_vals <- NULL
-  all_outcome_names <- list()
-  .notes <- NULL
-
-  param_names <- character()
-
-  split <- resamples$splits[[rs_iter]]
-  training <- rsample::analysis(split)
-
-  workflow <- catch_and_log(
-    .fit_pre(workflow, training),
-    control,
-    split,
-    "preprocessor",
-    notes = .notes
-  )
-
-  if (is_failure(workflow)) {
-    out <- list(
-      .metrics = metric_est,
-      .extracts = extracted,
-      .predictions = pred_vals,
-      .all_outcome_names = all_outcome_names,
-      .notes = .notes
-    )
-
-    return(out)
-  }
-
-  workflow <- catch_and_log_fit(
-    .fit_model(workflow, control_workflow),
-    control,
-    split,
-    "model",
-    notes = .notes
-  )
-
-  # check for parsnip level and model level failure
-  if (is_failure(workflow) || is_failure(workflow$fit$fit$fit)) {
-    out <- list(
-      .metrics = metric_est,
-      .extracts = extracted,
-      .predictions = pred_vals,
-      .all_outcome_names = all_outcome_names,
-      .notes = .notes
-    )
-
-    return(out)
-  }
-
-  workflow <- .fit_finalize(workflow)
-
-  # Extract names from the mold
-  outcome_names <- outcome_names(workflow)
-  all_outcome_names <- append_outcome_names(all_outcome_names, outcome_names)
-
-  # Dummy tbl with no columns but the correct number of rows to `bind_cols()`
-  # against in `append_extracts()`
-  split_label_tbl <- labels(split)
-  dummy_param_tbl <- tibble(.rows = nrow(split_label_tbl))
-
-  extracted <- append_extracts(extracted, workflow, dummy_param_tbl, split, control)
-
-  predictions <- catch_and_log(
-    predict_model_no_grid(split, workflow, metrics),
-    control,
-    split,
-    "model (predictions)",
-    bad_only = TRUE,
-    notes = .notes
-  )
-
-  if (is_failure(predictions)) {
-    out <- list(
-      .metrics = metric_est,
-      .extracts = extracted,
-      .predictions = pred_vals,
-      .all_outcome_names = all_outcome_names,
-      .notes = .notes
-    )
-
-    return(out)
-  }
-
-  metric_est <- append_metrics(
-    collection = metric_est,
-    predictions = predictions,
-    metrics = metrics,
-    param_names = param_names,
-    outcome_name = outcome_names,
-    event_level = event_level,
-    split = split
-  )
-
-  pred_vals <- append_predictions(pred_vals, predictions, split, control)
-
-  list(
-    .metrics = metric_est,
-    .extracts = extracted,
-    .predictions = pred_vals,
-    .all_outcome_names = all_outcome_names,
-    .notes = .notes
-  )
-}
-
-# ------------------------------------------------------------------------------
-# `resamples()` prediction
-
-predict_model_no_grid <- function(split, workflow, metrics) {
-  model <- workflows::pull_workflow_fit(workflow)
-
-  forged <- forge_from_workflow(split, workflow)
-
-  x_vals <- forged$predictors
-  y_vals <- forged$outcomes
-
-  orig_rows <- as.integer(split, data = "assessment")
-
-  # Determine the type of prediction that is required
-  type_info <- metrics_info(metrics)
-  types <- unique(type_info$type)
-
-  res <- NULL
-
-  for (type_iter in types) {
-    tmp_res <- predict(model, x_vals, type = type_iter) %>%
-      mutate(.row = orig_rows)
-
-    if (!is.null(res)) {
-      res <- dplyr::full_join(res, tmp_res, by = ".row")
-    } else {
-      res <- tmp_res
-    }
-
-    rm(tmp_res)
-  }
-
-  # Add outcome data
-  y_vals <- dplyr::mutate(y_vals, .row = orig_rows)
-  res <- dplyr::full_join(res, y_vals, by = ".row")
-
-  tibble::as_tibble(res)
-}
-
-forge_from_workflow <- function(split, workflow) {
-  new_data <- rsample::assessment(split)
-
-  blueprint <- workflow$pre$mold$blueprint
-  forged <- hardhat::forge(new_data, blueprint, outcomes = TRUE)
-
-  forged
 }

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -322,32 +322,44 @@ tune_grid.workflow <- function(object, resamples, ..., param_info = NULL,
 
 # ------------------------------------------------------------------------------
 
-tune_grid_workflow <- function(object,
+tune_grid_workflow <- function(workflow,
                                resamples,
                                grid = 10,
                                metrics = NULL,
                                pset = NULL,
                                control = control_grid()) {
   check_rset(resamples)
-  metrics <- check_metrics(metrics, object)
-  pset <-
-    check_parameters(object,
-                     pset = pset,
-                     data = resamples$splits[[1]]$data,
-                     grid_names = names(grid))
-  check_workflow(object, pset = pset)
+
+  metrics <- check_metrics(metrics, workflow)
+
+  pset <- check_parameters(
+    workflow = workflow,
+    pset = pset,
+    data = resamples$splits[[1]]$data,
+    grid_names = names(grid)
+  )
+
+  check_workflow(workflow, pset = pset)
 
   resamples <- dplyr::mutate(resamples, .seed = sample.int(10^5, nrow(resamples)))
 
-  grid <- check_grid(grid, object, pset)
+  grid <- check_grid(
+    grid = grid,
+    workflow = workflow,
+    pset = pset
+  )
 
   # Save rset attributes, then fall back to a bare tibble
   rset_info <- pull_rset_attributes(resamples)
   resamples <- new_bare_tibble(resamples)
 
-  code_path <- quarterback(object)
-
-  resamples <- rlang::eval_tidy(code_path)
+  resamples <- tune_grid_loop(
+    resamples = resamples,
+    grid = grid,
+    workflow = workflow,
+    metrics = metrics,
+    control = control
+  )
 
   if (is_cataclysmic(resamples)) {
     rlang::warn("All models failed in tune_grid(). See the `.notes` column.")
@@ -356,9 +368,10 @@ tune_grid_workflow <- function(object,
   outcomes <- reduce_all_outcome_names(resamples)
   resamples[[".all_outcome_names"]] <- NULL
 
-  workflow_output <- set_workflow(object, control)
+  workflow_output <- set_workflow(workflow, control)
 
   resamples <- resamples %>% dplyr::select(-.seed)
+
   new_tune_results(
     x = resamples,
     parameters = pset,
@@ -370,42 +383,6 @@ tune_grid_workflow <- function(object,
 }
 
 # ------------------------------------------------------------------------------
-
-quarterback <- function(x) {
-  y <- dials::parameters(x)
-  sources <- unique(y$source)
-
-  has_form <- has_preprocessor_formula(x)
-  has_rec <- has_preprocessor_recipe(x)
-  has_vars <- has_preprocessor_variables(x)
-
-  tune_rec <- has_rec && any(sources == "recipe")
-  tune_model <- any(sources == "model_spec")
-
-  args <- list(
-    resamples = expr(resamples),
-    grid = expr(grid),
-    workflow = expr(object),
-    metrics = expr(metrics),
-    control = expr(control)
-  )
-
-  fn <- dplyr::case_when(
-    has_form && tune_model ~ "tune_model_with_preprocessor",
-    has_vars && tune_model ~ "tune_model_with_preprocessor",
-    has_rec && !tune_rec && tune_model ~ "tune_model_with_preprocessor",
-
-    has_form && !tune_model ~ "tune_nothing",
-    has_vars && !tune_model ~ "tune_nothing",
-    has_rec && !tune_rec && !tune_model ~ "tune_nothing",
-
-    has_rec && tune_rec && tune_model ~ "tune_model_and_recipe",
-    has_rec && tune_rec && !tune_model ~ "tune_recipe"
-  )
-
-  rlang::call2(fn, !!!args)
-}
-
 
 #' @export
 #' @keywords internal

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -293,12 +293,12 @@ tune_grid.model_spec <- function(object, preprocessor, resamples, ...,
     wflow <- add_formula(wflow, preprocessor)
   }
 
-  tune_grid_workflow(
+  tune_grid(
     wflow,
     resamples = resamples,
+    param_info = param_info,
     grid = grid,
     metrics = metrics,
-    pset = param_info,
     control = control
   )
 }
@@ -309,6 +309,12 @@ tune_grid.workflow <- function(object, resamples, ..., param_info = NULL,
                                grid = 10, metrics = NULL, control = control_grid()) {
 
   empty_ellipses(...)
+
+  # Disallow `NULL` grids in `tune_grid()`, as this is the special signal
+  # used when no tuning is required
+  if (is.null(grid)) {
+    rlang::abort(grid_msg)
+  }
 
   tune_grid_workflow(
     object,
@@ -362,13 +368,13 @@ tune_grid_workflow <- function(workflow,
   )
 
   if (is_cataclysmic(resamples)) {
-    rlang::warn("All models failed in tune_grid(). See the `.notes` column.")
+    rlang::warn("All models failed. See the `.notes` column.")
   }
 
   outcomes <- reduce_all_outcome_names(resamples)
   resamples[[".all_outcome_names"]] <- NULL
 
-  workflow_output <- set_workflow(workflow, control)
+  workflow <- set_workflow(workflow, control)
 
   resamples <- resamples %>% dplyr::select(-.seed)
 
@@ -378,7 +384,7 @@ tune_grid_workflow <- function(workflow,
     metrics = metrics,
     outcomes = outcomes,
     rset_info = rset_info,
-    workflow = workflow_output
+    workflow = workflow
   )
 }
 

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -38,7 +38,7 @@ test_that("collect metrics of last fit", {
   res <- linear_reg() %>% set_engine("lm") %>% last_fit(f, split)
   met <- collect_metrics(res)
   expect_true(inherits(met, "tbl_df"))
-  expect_equal(names(met), c(".metric", ".estimator", ".estimate"))
+  expect_equal(names(met), c(".metric", ".estimator", ".estimate", ".config"))
 })
 
 


### PR DESCRIPTION
All grid code paths have been reduced down to a single loop. This includes the `fit_resample()` loop.

This removed A LOT of duplicate code! A number of helpers were removed, like `quarterback()`. We also used to have slightly different predict functions `predict_model()` and `predict_model_no_grid()`, but now everything just runs through `predict_model()`

Since I basically rewrote all the loop code, I also took the chance to refresh the variable names to make them a bit more consistent all around