### PR TITLE
Nest the grid-info inside the iteration function

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -64,6 +64,26 @@ tune_grid_loop_iter <- function(iteration,
   model_param_names <- dplyr::pull(model_params, "id")
   preprocessor_param_names <- dplyr::pull(preprocessor_params, "id")
 
+  # Model related grid-info columns
+  cols <- rlang::expr(
+    c(
+      .iter_model,
+      .iter_config,
+      .msg_model,
+      tidyselect::all_of(model_param_names),
+      .submodels
+    )
+  )
+
+  # Nest grid_info:
+  # - Preprocessor info in the outer level
+  # - Model info in the inner level
+  if (tidyr_new_interface()) {
+    grid_info <- tidyr::nest(grid_info, data = !!cols)
+  } else {
+    grid_info <- tidyr::nest(grid_info, !!cols)
+  }
+
   split <- resamples$splits[[iteration]]
   training <- rsample::analysis(split)
 


### PR DESCRIPTION
This should allow for alternate parallel processing strategies that require an unnested grid-info object in the foreach() loop

@topepo it seems that this was easier than expected 😛 . I now keep the grid-info object in its unnested form until we actually get into the iteration function. This should mean that we can do something like:

```r
# outer resample loop
foreach::foreach(
  iteration = seq_len(n_resamples),
  .packages = load_pkgs,
  .errorhandling = "pass"
) %:% {
  # inner flat loop over recipe/model combinations
  foreach::foreach(
    row = seq_len(nrow(grid_info)),
    .packages = load_pkgs,
    .errorhandling = "pass"
  ) %op% {
    grid_info <- vec_slice(grid_info, row)
    
    tune_grid_loop_iter_safely(
      iteration = iteration,
      resamples = resamples,
      grid_info = grid_info,
      workflow = workflow,
      metrics = metrics,
      control = control
    )
  }
}
```