### PR TITLE
Adjust grid iteration and add hidden `parallel_method` control option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools 
-Version: 0.1.1.9000
+Version: 0.1.1.9001
 Authors@R: c(
     person(given = "Max", family = "Kuhn", email = "max@rstudio.com", role = c("aut", "cre")),
     person("RStudio", role = "cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Other Changes
 
+* New `parallel_over` control argument to adjust the parallel processing method that tune uses.
+
 * The `.config` column that appears in the returned tibble from tuning and fitting resamples has changed slightly. It is now always of the form `"Preprocessor<i>_Model<j>"`.
 
 * `predict()` can now be called on the workflow returned from `last_fit()` (#294, #295, #296).

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -90,15 +90,16 @@ tune_grid_loop_iter <- function(iteration,
   # ----------------------------------------------------------------------------
   # Preprocessor loop
 
-  n_preprocessors <- nrow(grid_info)
+  iter_preprocessors <- grid_info[[".iter_preprocessor"]]
+
   workflow_original <- workflow
 
-  for (i in seq_len(n_preprocessors)) {
+  for (iter_preprocessor in iter_preprocessors) {
     workflow <- workflow_original
 
     iter_grid_info <- dplyr::filter(
       .data = grid_info,
-      .iter_preprocessor == i
+      .iter_preprocessor == iter_preprocessor
     )
 
     iter_grid_preprocessor <- dplyr::select(
@@ -129,16 +130,16 @@ tune_grid_loop_iter <- function(iteration,
     # Model loop
 
     iter_grid_info_models <- iter_grid_info[["data"]][[1L]]
-    n_models <- nrow(iter_grid_info_models)
+    iter_models <- iter_grid_info_models[[".iter_model"]]
 
     workflow_preprocessed <- workflow
 
-    for (i in seq_len(n_models)) {
+    for (iter_model in iter_models) {
       workflow <- workflow_preprocessed
 
       iter_grid_info_model <- dplyr::filter(
         .data = iter_grid_info_models,
-        .iter_model == i
+        .iter_model == iter_model
       )
 
       iter_grid_model <- dplyr::select(

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -14,9 +14,9 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control) {
   n_grid_info <- nrow(grid_info)
   rows <- seq_len(n_grid_info)
 
-  parallel_method <- control$parallel_method %||% "outer"
+  parallel_over <- control$parallel_over
 
-  if (identical(parallel_method, "outer")) {
+  if (identical(parallel_over, "resamples")) {
     results <- foreach::foreach(
       iteration = iterations,
       .packages = packages,
@@ -31,7 +31,7 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control) {
         control = control
       )
     }
-  } else if (identical(parallel_method, "flat")) {
+  } else if (identical(parallel_over, "everything")) {
     results <- foreach::foreach(
       iteration = iterations,
       .packages = packages,
@@ -55,7 +55,7 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control) {
         )
       }
   } else {
-    rlang::abort("Internal error: Invalid `parallel_method`.")
+    rlang::abort("Internal error: Invalid `parallel_over`.")
   }
 
   resamples <- pull_metrics(resamples, results, control)

--- a/man/control_bayes.Rd
+++ b/man/control_bayes.Rd
@@ -15,7 +15,8 @@ control_bayes(
   pkgs = NULL,
   save_workflow = FALSE,
   save_gp_scoring = FALSE,
-  event_level = "first"
+  event_level = "first",
+  parallel_over = "resamples"
 )
 }
 \arguments{
@@ -64,6 +65,20 @@ useful for teaching purposes.}
 This argument is passed on to yardstick metric functions when any type
 of class prediction is made, and specifies which level of the outcome
 is considered the "event".}
+
+\item{parallel_over}{A single string containing either \code{"resamples"} or
+\code{"everything"} describing how to use parallel processing.
+
+If \code{"resamples"}, then tuning will be performed in parallel over resamples
+alone. Within each resample, the preprocessor (i.e. recipe or formula) is
+processed once, and is then reused across all models that need to be fit.
+
+If \code{"everything"}, then tuning will be performed in parallel at two levels.
+An outer parallel loop will iterate over resamples. Additionally, an
+inner parallel loop will iterate over all unique combinations of
+preprocessor and model tuning parameters for that specific resample. This
+will result in the preprocessor being re-processed multiple times, but
+can be faster if that processing is extremely fast.}
 }
 \description{
 Control aspects of the Bayesian search process

--- a/man/control_grid.Rd
+++ b/man/control_grid.Rd
@@ -12,7 +12,8 @@ control_grid(
   save_pred = FALSE,
   pkgs = NULL,
   save_workflow = FALSE,
-  event_level = "first"
+  event_level = "first",
+  parallel_over = "resamples"
 )
 
 control_resamples(
@@ -22,7 +23,8 @@ control_resamples(
   save_pred = FALSE,
   pkgs = NULL,
   save_workflow = FALSE,
-  event_level = "first"
+  event_level = "first",
+  parallel_over = "resamples"
 )
 }
 \arguments{
@@ -52,6 +54,20 @@ to the output as an attribute.}
 This argument is passed on to yardstick metric functions when any type
 of class prediction is made, and specifies which level of the outcome
 is considered the "event".}
+
+\item{parallel_over}{A single string containing either \code{"resamples"} or
+\code{"everything"} describing how to use parallel processing.
+
+If \code{"resamples"}, then tuning will be performed in parallel over resamples
+alone. Within each resample, the preprocessor (i.e. recipe or formula) is
+processed once, and is then reused across all models that need to be fit.
+
+If \code{"everything"}, then tuning will be performed in parallel at two levels.
+An outer parallel loop will iterate over resamples. Additionally, an
+inner parallel loop will iterate over all unique combinations of
+preprocessor and model tuning parameters for that specific resample. This
+will result in the preprocessor being re-processed multiple times, but
+can be faster if that processing is extremely fast.}
 }
 \description{
 Control aspects of the grid search process


### PR DESCRIPTION
Fixes the issues that appear when trying to use the alternate parallel method, as described in https://github.com/tidymodels/tune/pull/304#issuecomment-712867325.

Basically we need to use the `.iter_*` columns for iteration and filtering, not the number of rows.

I've also gone ahead and added the alternate parallel method through a hidden control option `parallel_method = c("outer", "flat")`. If not set it just defaults to the old `"outer"` method (I have no idea what to call this). But the example below will set it to the new "flat" mode

We can talk about what it should be called and make those changes here if you want. But this is at least a POC.

```r
library(tidymodels)
library(modeldata)

data(cells)

cells <- cells %>% dplyr::select(-case)
folds <- vfold_cv(cells)

xgb_spec <- boost_tree(trees = 50, min_n = tune()) %>% 
  set_engine("xgboost") %>% 
  set_mode("classification")

xgb_grid <- expand.grid(min_n = 2:10)

control <- control_grid()
control$parallel_method <- "flat"

xgb_tune <- 
  xgb_spec %>% 
  tune_grid(class ~ ., folds, grid = xgb_grid, control = control)
```