### PR TITLE
make code more robust to PSOCK parallel processing

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -43,7 +43,7 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control) {
         .errorhandling = "pass",
         .combine = iter_combine
       ) %op% {
-        grid_info_row <- vec_slice(grid_info, row)
+        grid_info_row <- vctrs::vec_slice(grid_info, row)
 
         tune_grid_loop_iter_safely(
           iteration = iteration,

--- a/R/load_ns.R
+++ b/R/load_ns.R
@@ -59,7 +59,8 @@ load_namespace <- function(x) {
 ## -----------------------------------------------------------------------------
 
 infra_pkgs <- c("tune", "recipes", "parsnip", "yardstick", "purrr", "dplyr",
-                "tibble", "dials", "rsample")
+                "tibble", "dials", "rsample", "workflows", "tidyr", "rlang",
+                "vctrs")
 
 #' Determine packages required by objects
 #'


### PR DESCRIPTION
`finetune::tune_race_anova()` calls `tune::tune_grid()` internally and was failing when PSOCK parallel processing was used do to all models failing. 

An approximate git-bisect showed that commits _before_ ce0eb2e6b did not have this issue. There's nothing in that commit that appeared to be the issue.  Since `finetune::tune_race_anova()`  works sequentially and using multicore, it was believe to be an issue around the availability of package namespaces. 

I finally figured it out by changing the `foreach()` option to `.errorhandling = "stop"` and found the error message:

```
Error in { : task 1 failed - "could not find function "vec_slice""
```

The fix was to use `vctrs::vec_slice` instead. 

So... let's remember to use namesapce calls in any external functions inside of code that would be called inside of parallel processing (despite using roxygen2 `@import` or `importFrom` directives). 

