### PR TITLE
Error message for missing assessment set rows at prediction time

### DIFF
--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -12,7 +12,7 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
     msg <- paste0("Some assessment set rows are not available at ",
                   "prediction time. ")
 
-    if (names(workflow$pre$actions) == "recipe") {
+    if (has_preprocessor_recipe(workflow)) {
       msg <- paste0(
         msg,
         "Consider using `skip = TRUE` on any recipe steps that remove rows ",

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -8,6 +8,12 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
 
   orig_rows <- as.integer(split, data = "assessment")
 
+  if (length(orig_rows) != nrow(x_vals)) {
+    rlang::abort(paste0("Some assessment set rows are not available at ",
+                        "prediction time. Did your preprocessing steps ",
+                        "filter or remove rows?"))
+  }
+
   # Determine the type of prediction that is required
   type_info <- metrics_info(metrics)
   types <- unique(type_info$type)

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -9,9 +9,23 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
   orig_rows <- as.integer(split, data = "assessment")
 
   if (length(orig_rows) != nrow(x_vals)) {
-    rlang::abort(paste0("Some assessment set rows are not available at ",
-                        "prediction time. Did your preprocessing steps ",
-                        "filter or remove rows?"))
+    msg <- paste0("Some assessment set rows are not available at ",
+                  "prediction time. ")
+
+    if (names(workflow$pre$actions) == "recipe") {
+      msg <- paste0(
+        msg,
+        "Consider using `skip = TRUE` on any recipe steps that remove rows ",
+        "to avoid calling them on the assessment set."
+      )
+    } else {
+      msg <- paste0(
+        msg,
+        "Did your preprocessing steps filter or remove rows?"
+      )
+    }
+
+    rlang::abort(paste0(msg))
   }
 
   # Determine the type of prediction that is required

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -25,7 +25,7 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
       )
     }
 
-    rlang::abort(paste0(msg))
+    rlang::abort(msg)
   }
 
   # Determine the type of prediction that is required


### PR DESCRIPTION
Closes #241 

This PR adds an explicit check in `predict_model()` for whether all the original assessment rows are available, with a more direct error message:

``` r
library(tidymodels)

data(penguins)
set.seed(123)
peng_split <- initial_split(penguins, 
                            strata = species)

peng_train <- training(peng_split)
peng_test  <- testing(peng_split)

set.seed(345)
folds <- vfold_cv(peng_train, v = 6)
folds
#> #  6-fold cross-validation 
#> # A tibble: 6 x 2
#>   splits           id   
#>   <list>           <chr>
#> 1 <split [215/43]> Fold1
#> 2 <split [215/43]> Fold2
#> 3 <split [215/43]> Fold3
#> 4 <split [215/43]> Fold4
#> 5 <split [215/43]> Fold5
#> 6 <split [215/43]> Fold6

peng_rec <- 
  recipe(species ~ ., data=peng_train) %>%
  update_role(new_role = "id", island) %>%
  step_naomit(all_predictors(), all_outcomes()) %>%
  step_dummy(all_nominal(), -species)

peng_mod <- 
  multinom_reg(penalty = tune(), mixture = 1) %>%
  set_engine("glmnet")

peng_wflow <- 
  workflow() %>%
  add_model(peng_mod) %>%
  add_recipe(peng_rec)

peng_fit <- tune_grid(peng_wflow, resamples = folds)
#> Loading required package: Matrix
#> 
#> Attaching package: 'Matrix'
#> The following objects are masked from 'package:tidyr':
#> 
#>     expand, pack, unpack
#> Loaded glmnet 4.0-2
#> x Fold1: preprocessor 1/1, model 1/1 (predictions): Error: Some assessment set ro...
#> x Fold2: preprocessor 1/1, model 1/1 (predictions): Error: Some assessment set ro...
#> x Fold3: preprocessor 1/1, model 1/1 (predictions): Error: Some assessment set ro...
#> x Fold4: preprocessor 1/1, model 1/1 (predictions): Error: Some assessment set ro...
#> x Fold5: preprocessor 1/1, model 1/1 (predictions): Error: Some assessment set ro...
#> x Fold6: preprocessor 1/1, model 1/1 (predictions): Error: Some assessment set ro...
#> Warning: All models failed. See the `.notes` column.

peng_fit$.notes[[1]][[1]]
#> [1] "preprocessor 1/1, model 1/1 (predictions): Error: Some assessment set rows are not available at prediction time. Did your preprocessing steps filter or remove rows?"
```

<sup>Created on 2020-10-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

This has been a source of confusion for users who don't understand why their tuning is failing.

Thoughts on the error message? 🤔 