### PR TITLE
parameterize initial grid requirements by tuning type

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -183,8 +183,8 @@ check_installs <- function(x) {
     is_inst <- purrr::map_lgl(deps, is_installed)
     if (any(!is_inst)) {
       stop("Some package installs are required: ",
-        paste0("'", deps[!is_inst], "'", collapse = ", "),
-        call. = FALSE
+           paste0("'", deps[!is_inst], "'", collapse = ", "),
+           call. = FALSE
       )
     }
   }
@@ -206,7 +206,8 @@ check_bayes_initial_size <- function(num_param, num_grid, race = FALSE) {
            "")
   if (num_grid == 1) {
     rlang::abort(
-      paste(tune_color$symbol$warning("!"), msg, "The GP model request 2+ initial points but there should",
+      paste(tune_color$symbol$warning("!"), msg,
+            "The GP model requires 2+ initial points but there should",
             "be more initial points than there are tuning paramters.", race_msg)
     )
   }
@@ -335,12 +336,12 @@ bayes_msg <- "`initial` should be a positive integer or the results of [tune_gri
 #' @param wflow A `workflow` object.
 #' @param resamples An `rset` object.
 #' @param ctrl A `control_grid` object.
-check_initial <- function(x, pset, wflow, resamples, metrics, ctrl) {
+check_initial <- function(x, pset, wflow, resamples, metrics, ctrl, checks = "grid") {
   if (is.null(x)) {
     rlang::abort(bayes_msg)
   }
   if (is.numeric(x)) {
-    x <- create_initial_set(pset, n = x)
+    x <- create_initial_set(pset, n = x, checks = checks)
     if (ctrl$verbose) {
       message()
       msg <- paste0(" Generating a set of ", nrow(x), " initial parameter results")
@@ -391,7 +392,10 @@ check_initial <- function(x, pset, wflow, resamples, metrics, ctrl) {
         dplyr::distinct(!!!rlang::syms(param_nms)) %>%
         nrow()
     }
-    check_bayes_initial_size(length(param_nms), num_grid, inherits(x, "tune_race"))
+    if (any(checks == "bayes")) {
+      check_bayes_initial_size(length(param_nms), num_grid,
+                               race = inherits(x, "tune_race"))
+    }
   }
   if (!any(names(x) == ".iter")) {
     x <- x %>% dplyr::mutate(.iter = 0L)

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -253,7 +253,8 @@ tune_bayes_workflow <-
     }
     check_workflow(object, check_dials = is.null(param_info), pset = param_info)
 
-    unsummarized <- check_initial(initial, param_info, object, resamples, metrics, control)
+    unsummarized <- check_initial(initial, param_info, object, resamples,
+                                  metrics, control, checks = "bayes")
 
     # Pull outcome names from initialization run
     outcomes <- peek_tune_results_outcomes(unsummarized)
@@ -402,12 +403,14 @@ tune_bayes_workflow <-
     )
   }
 
-create_initial_set <- function(param, n = NULL) {
+create_initial_set <- function(param, n = NULL, checks) {
   check_param_objects(param)
   if (is.null(n)) {
     n <- nrow(param) + 1
   }
-  check_bayes_initial_size(nrow(param), n)
+  if (any(checks == "bayes")) {
+    check_bayes_initial_size(nrow(param), n)
+  }
   dials::grid_latin_hypercube(param, size = n)
 }
 

--- a/man/empty_ellipses.Rd
+++ b/man/empty_ellipses.Rd
@@ -27,7 +27,7 @@ check_workflow(x, pset = NULL, check_dials = FALSE)
 
 check_metrics(x, object)
 
-check_initial(x, pset, wflow, resamples, metrics, ctrl)
+check_initial(x, pset, wflow, resamples, metrics, ctrl, checks = "grid")
 
 val_class_or_null(x, cls = "numeric", where = NULL)
 

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -431,12 +431,12 @@ test_that('too few starting values', {
 
   expect_error(
     tune:::check_bayes_initial_size(5, 1, FALSE),
-    "request 2+"
+    "requires 2+"
   )
 
   expect_error(
     tune:::check_bayes_initial_size(5, 1, TRUE),
-    "request 2+"
+    "requires 2+"
   )
   expect_error(
     tune:::check_bayes_initial_size(5, 1, TRUE),


### PR DESCRIPTION
Bayesian optimization has more stringent criteria for the initial results than other methods. A `checks` argument is added so that we can be more specific about what checks occur for different functions. 