### PR TITLE
move from crayon text coloring functions to cli

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     ggplot2,
     glue,
     cli (>= 2.0.0),
-    crayon,
     yardstick (>= 0.0.7),
     rsample (>= 0.0.7.9000),
     tidyr,

--- a/R/logging.R
+++ b/R/logging.R
@@ -192,7 +192,7 @@ log_best <- function(control, iter, info, digits = 4) {
   }
 
   message("")
-  message(cli::rule(left = crayon::bold(paste("Iteration", iter))))
+  message(cli::rule(left = bold(paste("Iteration", iter))))
   message("")
 
   msg <-
@@ -246,9 +246,9 @@ log_progress <- function(control, x, maximize = TRUE, objective = NULL, digits =
   }
 
   if (bst_iter == max_iter) {
-    msg <- paste0(crayon::red(cli::symbol$heart), msg)
+    msg <- paste0(red(cli::symbol$heart), msg)
   } else {
-    msg <- paste0(crayon::silver(cli::symbol$circle_cross), msg)
+    msg <- paste0(silver(cli::symbol$circle_cross), msg)
   }
   message(msg)
 }

--- a/R/logging.R
+++ b/R/logging.R
@@ -82,6 +82,9 @@ siren <- function(x, type = "info") {
     type == "info" ~ tune_color$message$info(msg)
   )
 
+  if (inherits(msg, "character")) {
+    msg <- as.character(msg)
+  }
   message(paste(symb, msg))
 }
 

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -14,41 +14,56 @@ tune_symbol_ascii <- list(
   "success" = "v"
 )
 
+## -----------------------------------------------------------------------------
+
+# To remove the crayon dependency, use the cli analogs. However, these
+# produce ansi_string objects and some of our logging code needs
+# the character values.
+yellow <- function(...) as.character(cli::col_yellow(...))
+black  <- function(...) as.character(cli::col_black(...))
+white  <- function(...) as.character(cli::col_white(...))
+red    <- function(...) as.character(cli::col_red(...))
+yellow <- function(...) as.character(cli::col_yellow(...))
+green  <- function(...) as.character(cli::col_green(...))
+blue   <- function(...) as.character(cli::col_blue(...))
+silver <- function(...) as.character(cli::col_silver(...))
+bold   <- function(...) as.character(cli::style_bold(...))
+
 # ------------------------------------------------------------------------------
 
 # For use in setting the `tune_color` active binding in `.onLoad()`
 
 tune_color_dark <- list(
   symbol = list(
-    "warning" = crayon::yellow,
-    "go" = crayon::white,
-    "danger" = crayon::red,
-    "success" = crayon::green,
-    "info" = crayon::blue
+    "warning" = yellow,
+    "go" = white,
+    "danger" = red,
+    "success" = green,
+    "info" = blue
   ),
   message = list(
-    "warning" = crayon::yellow,
-    "go" = crayon::white,
-    "danger" = crayon::red,
-    "success" = crayon::white,
-    "info" = crayon::white
+    "warning" = yellow,
+    "go" = white,
+    "danger" = red,
+    "success" = white,
+    "info" = white
   )
 )
 
 tune_color_light <- list(
   symbol = list(
-    "warning" = crayon::yellow,
-    "go" = crayon::black,
-    "danger" = crayon::red,
-    "success" = crayon::green,
-    "info" = crayon::blue
+    "warning" = yellow,
+    "go" = black,
+    "danger" = red,
+    "success" = green,
+    "info" = blue
   ),
   message = list(
-    "warning" = crayon::yellow,
-    "go" = crayon::black,
-    "danger" = crayon::red,
-    "success" = crayon::black,
-    "info" = crayon::black
+    "warning" = yellow,
+    "go" = black,
+    "danger" = red,
+    "success" = black,
+    "info" = black
   )
 )
 
@@ -76,4 +91,6 @@ is_windows <- function () {
 #' @export
 #' @rdname empty_ellipses
 get_tune_colors <- function() tune_color
+
+
 

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -16,18 +16,16 @@ tune_symbol_ascii <- list(
 
 ## -----------------------------------------------------------------------------
 
-# To remove the crayon dependency, use the cli analogs. However, these
-# produce ansi_string objects and some of our logging code needs
-# the character values.
-yellow <- function(...) as.character(cli::col_yellow(...))
-black  <- function(...) as.character(cli::col_black(...))
-white  <- function(...) as.character(cli::col_white(...))
-red    <- function(...) as.character(cli::col_red(...))
-yellow <- function(...) as.character(cli::col_yellow(...))
-green  <- function(...) as.character(cli::col_green(...))
-blue   <- function(...) as.character(cli::col_blue(...))
-silver <- function(...) as.character(cli::col_silver(...))
-bold   <- function(...) as.character(cli::style_bold(...))
+# To remove the crayon dependency, use the cli analogs.
+yellow <- function(...) cli::col_yellow(...)
+black  <- function(...) cli::col_black(...)
+white  <- function(...) cli::col_white(...)
+red    <- function(...) cli::col_red(...)
+yellow <- function(...) cli::col_yellow(...)
+green  <- function(...) cli::col_green(...)
+blue   <- function(...) cli::col_blue(...)
+silver <- function(...) cli::col_silver(...)
+bold   <- function(...) cli::style_bold(...)
 
 # ------------------------------------------------------------------------------
 

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -16,16 +16,18 @@ tune_symbol_ascii <- list(
 
 ## -----------------------------------------------------------------------------
 
-# To remove the crayon dependency, use the cli analogs.
-yellow <- function(...) cli::col_yellow(...)
-black  <- function(...) cli::col_black(...)
-white  <- function(...) cli::col_white(...)
-red    <- function(...) cli::col_red(...)
-yellow <- function(...) cli::col_yellow(...)
-green  <- function(...) cli::col_green(...)
-blue   <- function(...) cli::col_blue(...)
-silver <- function(...) cli::col_silver(...)
-bold   <- function(...) cli::style_bold(...)
+# To remove the crayon dependency, use the cli analogs. However, these
+# produce ansi_string objects and some of our logging code needs
+# the character values. Will not be needed for cli >= 2.1.0.9000
+yellow <- function(...) as.character(cli::col_yellow(...))
+black  <- function(...) as.character(cli::col_black(...))
+white  <- function(...) as.character(cli::col_white(...))
+red    <- function(...) as.character(cli::col_red(...))
+yellow <- function(...) as.character(cli::col_yellow(...))
+green  <- function(...) as.character(cli::col_green(...))
+blue   <- function(...) as.character(cli::col_blue(...))
+silver <- function(...) as.character(cli::col_silver(...))
+bold   <- function(...) as.character(cli::style_bold(...))
 
 # ------------------------------------------------------------------------------
 

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -526,7 +526,7 @@ pick_candidate <- function(results, info, control) {
     results <- results %>% dplyr::arrange(dplyr::desc(objective)) %>% dplyr::slice(1)
   } else {
     if (control$verbose) {
-      msg <- paste(crayon::blue(cli::symbol$circle_question_mark), "Uncertainty sample")
+      msg <- paste(blue(cli::symbol$circle_question_mark), "Uncertainty sample")
       message(msg)
     }
     results <-

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -4,12 +4,12 @@ test_that("Light mode / default `tune_color`s work", {
 
   expect_equal(
     tune:::tune_color$symbol$go("hi"),
-    crayon::black("hi")
+    black("hi")
   )
 
   expect_equal(
     tune:::tune_color$message$info("hi"),
-    crayon::black("hi")
+    black("hi")
   )
 })
 
@@ -19,12 +19,12 @@ test_that("Dark mode `tune_color`s work", {
 
   expect_equal(
     tune:::tune_color$symbol$go("hi"),
-    crayon::white("hi")
+    white("hi")
   )
 
   expect_equal(
     tune:::tune_color$message$info("hi"),
-    crayon::white("hi")
+    white("hi")
   )
 })
 
@@ -34,11 +34,11 @@ test_that("`tune_color` falls back to light mode with back `tidymodels.dark` opt
 
   expect_equal(
     tune:::tune_color$symbol$go("hi"),
-    crayon::black("hi")
+    black("hi")
   )
 
   expect_equal(
     tune:::tune_color$message$info("hi"),
-    crayon::black("hi")
+    black("hi")
   )
 })


### PR DESCRIPTION
Closes #311

The PR redefines crayon functions like `crayon::yellow()` to an internal function that uses `cli` via this pattern: 

```r
yellow <- function(...) as.character(cli::col_yellow(...))
```

The reason for the conversion is that some of the logging functions use character class objects (and `cli` gives us objects with class "ansi_string"). Perhaps @gaborcsardi  can tell me if this is the best way to go.
