### PR TITLE
Ensure last_fit() uses RNG stream from main R process

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Fixed an issue where recipe tuning parameters could be randomly matched to the tuning grid incorrectly (#316).
 
-* `last_fit()` no longer accidentally adjusts the random seed (#264).
+* `last_fit()` no longer accidentally adjusts the random seed (#264) and will use sequential processing ()
 
 * Fixed two bugs in the acquisition function calculations.
 
@@ -34,7 +34,7 @@
 
 * `autoplot.tune_results()` now requires objects made by version 0.1.0 or higher of tune. 
 
-* `tune` objects no longer keep the `rset` class that they have from the `resamples` argument. 
+* tune objects no longer keep the `rset` class that they have from the `resamples` argument. 
 
 ## Other Changes
 
@@ -46,7 +46,7 @@
 
 * In other plotting news, `coord_obs_pred()` has been included for regression models. When plotting the observed and predicted values from a model, this forces the x- and y-axis to be the same range and uses an aspect ratio of 1. 
 
-* The outcome names are saved in an attribute called `outcomes` to objects with class `tune_results`. Also, several accessor functions (named `.get_tune_*()) were added to more easily access such attributes.  
+* The outcome names are saved in an attribute called `outcomes` to objects with class `tune_results`. Also, several accessor functions (named `.get_tune_*()`) were added to more easily access such attributes.  
 
 * `conf_mat_resampled()` computes the average confusion matrix across resampling statistics for a single model.  
 
@@ -54,7 +54,7 @@
 
 * `filter_parameters()` can trim the `.metrics` column of unwanted results (as well as columns `.predictions` and `.extracts`) from `tune_*` objects. 
 
-* In concert with `dials` > 0.0.7, tuning engine-specific arguments is possible. Many known engine-specific tuning parameters and handled automatically. 
+* In concert with dials > 0.0.7, tuning engine-specific arguments is possible. Many known engine-specific tuning parameters and handled automatically. 
 
 * If a grid is given, parameters do not need to be finalized to be used in the `tune_*()` functions. 
 

--- a/R/control.R
+++ b/R/control.R
@@ -122,6 +122,11 @@ control_resamples <- control_grid
 #'   will result in the preprocessor being re-processed multiple times, but
 #'   can be faster if that processing is extremely fast.
 #'
+#'   However, if a single resample is used (e.g., a validation set) and
+#'   `parallel_over = "resamples"`, this option is changed to "everything" (with
+#'   a message). This happens at the time of execution (rather than in
+#'   the control function).
+#'
 #' @details
 #'
 #' For `extract`, this function can be used to output the model object, the

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -5,9 +5,9 @@
 get_operator <- function(allow = TRUE, object, resamples, grid) {
   is_par <- foreach::getDoParWorkers() > 1
   pkgs <- required_pkgs(object)
-  blacklist <- c("keras", "rJava")
-  if (is_par & allow && any(pkgs %in% blacklist)) {
-    pkgs <- pkgs[pkgs %in% blacklist]
+  no_parallel <- c("keras", "rJava")
+  if (is_par & allow && any(pkgs %in% no_parallel)) {
+    pkgs <- pkgs[pkgs %in% no_parallel]
     msg <- paste0("'", pkgs, "'", collapse = ", ")
     msg <- paste("Some required packages prohibit parallel processing: ", msg)
     cli::cli_alert_warning(msg)

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -380,7 +380,7 @@ tune_grid_workflow <- function(workflow,
   workflow <- set_workflow(workflow, control)
 
   if (any(names(resamples) == ".seed")) {
-    resamples <- resamples %>% dplyr::select(-.seed)
+    resamples <- dplyr::select(resamples, -.seed)
   }
 
   new_tune_results(

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -347,13 +347,16 @@ tune_grid_workflow <- function(workflow,
 
   check_workflow(workflow, pset = pset)
 
-  resamples <- dplyr::mutate(resamples, .seed = sample.int(10^5, nrow(resamples)))
+  if (nrow(resamples) > 1 & !single_model(grid)) {
+    resamples <- dplyr::mutate(resamples, .seed = sample.int(10^5, nrow(resamples)))
+  }
 
   grid <- check_grid(
     grid = grid,
     workflow = workflow,
     pset = pset
   )
+
 
   # Save rset attributes, then fall back to a bare tibble
   rset_info <- pull_rset_attributes(resamples)
@@ -376,7 +379,9 @@ tune_grid_workflow <- function(workflow,
 
   workflow <- set_workflow(workflow, control)
 
-  resamples <- resamples %>% dplyr::select(-.seed)
+  if (any(names(resamples) == ".seed")) {
+    resamples <- resamples %>% dplyr::select(-.seed)
+  }
 
   new_tune_results(
     x = resamples,

--- a/man/control_bayes.Rd
+++ b/man/control_bayes.Rd
@@ -78,7 +78,12 @@ An outer parallel loop will iterate over resamples. Additionally, an
 inner parallel loop will iterate over all unique combinations of
 preprocessor and model tuning parameters for that specific resample. This
 will result in the preprocessor being re-processed multiple times, but
-can be faster if that processing is extremely fast.}
+can be faster if that processing is extremely fast.
+
+However, if a single resample is used (e.g., a validation set) and
+\code{parallel_over = "resamples"}, this option is changed to "everything" (with
+a message). This happens at the time of execution (rather than in
+the control function).}
 }
 \description{
 Control aspects of the Bayesian search process

--- a/man/control_grid.Rd
+++ b/man/control_grid.Rd
@@ -67,7 +67,12 @@ An outer parallel loop will iterate over resamples. Additionally, an
 inner parallel loop will iterate over all unique combinations of
 preprocessor and model tuning parameters for that specific resample. This
 will result in the preprocessor being re-processed multiple times, but
-can be faster if that processing is extremely fast.}
+can be faster if that processing is extremely fast.
+
+However, if a single resample is used (e.g., a validation set) and
+\code{parallel_over = "resamples"}, this option is changed to "everything" (with
+a message). This happens at the time of execution (rather than in
+the control function).}
 }
 \description{
 Control aspects of the grid search process

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -378,8 +378,11 @@ test_that("retain extra attributes and saved GP candidates", {
   pset <- dials::parameters(wflow) %>% update(num_comp = num_comp(c(1, 5)))
   folds <- vfold_cv(mtcars)
   ctrl <- control_bayes(save_gp_scoring = TRUE)
-  res <- tune_bayes(wflow, resamples = folds, param_info = pset,
-                    initial = iter1, iter = iter2, control = ctrl)
+  suppressMessages({
+    set.seed(1)
+    res <- tune_bayes(wflow, resamples = folds, param_info = pset,
+                      initial = 4, iter = iter2, control = ctrl)
+  })
 
   att <- attributes(res)
   att_names <- names(att)
@@ -396,10 +399,12 @@ test_that("retain extra attributes and saved GP candidates", {
   expect_true(length(files) == iter2)
 
 
-  expect_message(
+  expect_message({
+    set.seed(1)
     res2 <- tune_bayes(wflow, resamples = folds, param_info = pset,
-                       initial = iter1, iter = iter2,
-                       control = control_bayes(save_workflow = TRUE)),
+                       initial = 4, iter = iter2,
+                       control = control_bayes(save_workflow = TRUE))
+    },
     "being saved contains a recipe, which is"
   )
   expect_null(attr(res, "workflow"))

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -64,3 +64,27 @@ test_that("argument order gives warnings for recipe/formula", {
     "is deprecated as of lifecycle"
   )
 })
+
+test_that("same results of last_fit() and fit()", {
+  skip_on_cran()
+  skip_if_not_installed("randomForest")
+
+  rf <- rand_forest(mtry = 2, trees = 5) %>%
+    set_engine("randomForest") %>%
+    set_mode("regression")
+  wflow <- workflow() %>% add_model(rf) %>% add_formula(mpg ~ .)
+  set.seed(23598723)
+  split <- initial_split(mtcars)
+
+  set.seed(1)
+  lf_obj <- last_fit(wflow, split = split)
+
+  set.seed(1)
+  r_obj <- fit(wflow, data = analysis(split))
+  r_pred <- predict(r_obj, assessment(split))
+  expect_equal(
+    lf_obj$.predictions[[1]]$.pred,
+    r_pred$.pred
+  )
+
+})

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -16,8 +16,14 @@ test_that('model package lookup', {
 # ------------------------------------------------------------------------------
 
 test_that('determine foreach operator', {
-  expect_equal(tune:::get_operator(object = chi_wflow), foreach::`%do%`)
-  expect_equal(tune:::get_operator(FALSE, chi_wflow), foreach::`%do%`)
+  expect_equal(
+    tune:::get_operator(object = chi_wflow, resamples = vfold_cv(mtcars), grid = mtcars[1:2,]),
+    foreach::`%do%`
+  )
+  expect_equal(
+    tune:::get_operator(FALSE, chi_wflow, resamples = vfold_cv(mtcars), grid = mtcars[1:2,]),
+    foreach::`%do%`
+  )
 })
 
 # ------------------------------------------------------------------------------
@@ -114,3 +120,25 @@ test_that('required package lists', {
   expect_equal(required_pkgs(chi_wflow, FALSE), "glmnet")
 
 })
+
+
+## -----------------------------------------------------------------------------
+
+
+test_that('determine if a single model fit is requested', {
+
+  expect_true(tune:::single_model(NULL))
+  expect_true(tune:::single_model(mtcars[1,]))
+  expect_true(tune:::single_model(mtcars[0,]))
+  expect_true(
+    tune:::single_model(mtcars %>% as_tibble() %>% dplyr::slice(1) %>%
+                   mutate(.submodels = list(list())))
+  )
+
+  expect_false(tune:::single_model(mtcars))
+  expect_false(tune:::single_model(mtcars %>% as_tibble() %>% dplyr::slice(1) %>%
+                                     mutate(.submodels = list(1:10)))
+  )
+
+})
+


### PR DESCRIPTION
Fixes for #300 related to making sure that `last_fit()` and `fit.workflow()` produce the same results when a model uses random numbers. 

This PR also will change the `parallel_over` option form "resamples" to "everything" when a single resample is tested on multiple models (e.g. using a validation set). A message is issued when this occurs. 