### PR TITLE
Don't set seeds in `last_fit()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Bug Fixes
 
+* `last_fit()` and `workflows::fit()` will now give identical results for the same workflow when the underlying model uses random number generation (#300).
+
 * Fixed an issue where recipe tuning parameters could be randomly matched to the tuning grid incorrectly (#316).
 
 * `last_fit()` no longer accidentally adjusts the random seed (#264).

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -1,4 +1,4 @@
-tune_grid_loop <- function(resamples, grid, workflow, metrics, control, seeds) {
+tune_grid_loop <- function(resamples, grid, workflow, metrics, control, rng) {
   `%op%` <- get_operator(control$allow_par, workflow)
   `%:%` <- foreach::`%:%`
 
@@ -15,6 +15,12 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control, seeds) {
   rows <- seq_len(n_grid_info)
 
   parallel_over <- control$parallel_over
+
+  if (rng) {
+    seeds <- sample.int(10^5, nrow(resamples))
+  } else {
+    seeds <- NULL
+  }
 
   if (identical(parallel_over, "resamples")) {
     results <- foreach::foreach(

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -1,4 +1,4 @@
-tune_grid_loop <- function(resamples, grid, workflow, metrics, control) {
+tune_grid_loop <- function(resamples, grid, workflow, metrics, control, seeds) {
   `%op%` <- get_operator(control$allow_par, workflow)
   `%:%` <- foreach::`%:%`
 
@@ -28,7 +28,8 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control) {
         grid_info = grid_info,
         workflow = workflow,
         metrics = metrics,
-        control = control
+        control = control,
+        seeds = seeds
       )
     }
   } else if (identical(parallel_over, "everything")) {
@@ -51,7 +52,8 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control) {
           grid_info = grid_info_row,
           workflow = workflow,
           metrics = metrics,
-          control = control
+          control = control,
+          seeds = seeds
         )
       }
   } else {
@@ -103,10 +105,15 @@ tune_grid_loop_iter <- function(iteration,
                                 grid_info,
                                 workflow,
                                 metrics,
-                                control) {
+                                control,
+                                seeds) {
   load_pkgs(workflow)
   load_namespace(control$pkgs)
-  set.seed(resamples$.seed[[iteration]])
+
+  # After package loading to avoid potential package RNG manipulation
+  if (!is.null(seeds)) {
+    set.seed(seeds[[iteration]])
+  }
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
   control_workflow <- control_workflow(control_parsnip = control_parsnip)
@@ -323,7 +330,8 @@ super_safely_iterate_impl <- function(fn,
                                       grid_info,
                                       workflow,
                                       metrics,
-                                      control) {
+                                      control,
+                                      seeds) {
   safely_iterate <- super_safely(fn)
 
   result <- safely_iterate(
@@ -332,7 +340,8 @@ super_safely_iterate_impl <- function(fn,
     grid_info,
     workflow,
     metrics,
-    control
+    control,
+    seeds
   )
 
   error <- result$error

--- a/R/last_fit.R
+++ b/R/last_fit.R
@@ -103,16 +103,22 @@ last_fit.workflow <- function(object, split, ..., metrics = NULL) {
 last_fit_workflow <- function(object, split, metrics) {
   extr <- function(x)
     x
-  ctrl <- control_resamples(save_pred = TRUE, extract = extr)
+  control <- control_resamples(save_pred = TRUE, extract = extr)
   splits <- list(split)
   resamples <- rsample::manual_rset(splits, ids = "train/test split")
-  res <-
-    fit_resamples(
-      object,
-      resamples = resamples,
-      metrics = metrics,
-      control = ctrl
-    )
+
+  # Turn off seed generation to ensure `last_fit()` and workflows `fit()`
+  # are reproducible
+  rng <- FALSE
+
+  res <- resample_workflow(
+    workflow = object,
+    resamples = resamples,
+    metrics = metrics,
+    control = control,
+    rng = rng
+  )
+
   res$.workflow <- res$.extracts[[1]][[1]]
   res$.extracts <- NULL
   class(res) <- c("last_fit", class(res))

--- a/R/resample.R
+++ b/R/resample.R
@@ -109,12 +109,18 @@ fit_resamples.workflow <- function(object,
 
   empty_ellipses(...)
 
-  resample_workflow(object, resamples, metrics, control)
+  resample_workflow(
+    workflow = object,
+    resamples = resamples,
+    metrics = metrics,
+    control = control,
+    rng = TRUE
+  )
 }
 
 # ------------------------------------------------------------------------------
 
-resample_workflow <- function(workflow, resamples, metrics, control) {
+resample_workflow <- function(workflow, resamples, metrics, control, rng) {
   # `NULL` is the signal that we have no grid to tune with
   grid <- NULL
   pset <- NULL
@@ -125,7 +131,8 @@ resample_workflow <- function(workflow, resamples, metrics, control) {
     grid = grid,
     metrics = metrics,
     pset = pset,
-    control = control
+    control = control,
+    rng = rng
   )
 
   attributes <- attributes(out)

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -320,12 +320,6 @@ tune_grid_workflow <- function(workflow,
 
   check_workflow(workflow, pset = pset)
 
-  if (rng) {
-    seeds <- sample.int(10^5, nrow(resamples))
-  } else {
-    seeds <- NULL
-  }
-
   grid <- check_grid(
     grid = grid,
     workflow = workflow,
@@ -342,7 +336,7 @@ tune_grid_workflow <- function(workflow,
     workflow = workflow,
     metrics = metrics,
     control = control,
-    seeds = seeds
+    rng = rng
   )
 
   if (is_cataclysmic(resamples)) {

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -305,7 +305,8 @@ tune_grid_workflow <- function(workflow,
                                grid = 10,
                                metrics = NULL,
                                pset = NULL,
-                               control = control_grid()) {
+                               control = control_grid(),
+                               rng = TRUE) {
   check_rset(resamples)
 
   metrics <- check_metrics(metrics, workflow)
@@ -319,7 +320,11 @@ tune_grid_workflow <- function(workflow,
 
   check_workflow(workflow, pset = pset)
 
-  resamples <- dplyr::mutate(resamples, .seed = sample.int(10^5, nrow(resamples)))
+  if (rng) {
+    seeds <- sample.int(10^5, nrow(resamples))
+  } else {
+    seeds <- NULL
+  }
 
   grid <- check_grid(
     grid = grid,
@@ -336,7 +341,8 @@ tune_grid_workflow <- function(workflow,
     grid = grid,
     workflow = workflow,
     metrics = metrics,
-    control = control
+    control = control,
+    seeds = seeds
   )
 
   if (is_cataclysmic(resamples)) {
@@ -347,8 +353,6 @@ tune_grid_workflow <- function(workflow,
   resamples[[".all_outcome_names"]] <- NULL
 
   workflow <- set_workflow(workflow, control)
-
-  resamples <- resamples %>% dplyr::select(-.seed)
 
   new_tune_results(
     x = resamples,

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -64,3 +64,30 @@ test_that("argument order gives errors for recipe/formula", {
     "should be either a model or workflow"
   )
 })
+
+test_that("same results of last_fit() and fit() (#300)", {
+  skip_if_not_installed("randomForest")
+
+  rf <- parsnip::rand_forest(mtry = 2, trees = 5) %>%
+    parsnip::set_engine("randomForest") %>%
+    parsnip::set_mode("regression")
+
+  wflow <- workflows::workflow() %>%
+    workflows::add_model(rf) %>%
+    workflows::add_formula(mpg ~ .)
+
+  set.seed(23598723)
+  split <- rsample::initial_split(mtcars)
+
+  set.seed(1)
+  lf_obj <- last_fit(wflow, split = split)
+
+  set.seed(1)
+  r_obj <- fit(wflow, data = analysis(split))
+  r_pred <- predict(r_obj, assessment(split))
+
+  expect_equal(
+    lf_obj$.predictions[[1]]$.pred,
+    r_pred$.pred
+  )
+})


### PR DESCRIPTION
Closes #300 

This takes a simpler approach than #319 

Only `last_fit()` has been special cased here. It passes through `rng = FALSE` to avoid setting the seed when we finally get into `tune_grid_loop_iter()`. This `rng` value just tells `tune_grid_loop()` whether or not to generate `seeds`.

I've also pushed the seed generation down into `tune_grid_loop()`, rather than having it in `tune_grid_workflow()`.