### PR TITLE
Default `parallel_over` to `NULL`

### DIFF
--- a/R/control.R
+++ b/R/control.R
@@ -32,7 +32,7 @@ control_grid <- function(verbose = FALSE, allow_par = TRUE,
                          extract = NULL, save_pred = FALSE,
                          pkgs = NULL, save_workflow = FALSE,
                          event_level = "first",
-                         parallel_over = "resamples") {
+                         parallel_over = NULL) {
   # add options for  seeds per resample
 
   val_class_and_single(verbose, "logical", "control_grid()")
@@ -109,7 +109,9 @@ control_resamples <- control_grid
 #'   of class prediction is made, and specifies which level of the outcome
 #'   is considered the "event".
 #' @param parallel_over A single string containing either `"resamples"` or
-#'   `"everything"` describing how to use parallel processing.
+#'   `"everything"` describing how to use parallel processing. Alternatively,
+#'   `NULL` is allowed, which chooses between `"resamples"` and `"everything"`
+#'   automatically.
 #'
 #'   If `"resamples"`, then tuning will be performed in parallel over resamples
 #'   alone. Within each resample, the preprocessor (i.e. recipe or formula) is
@@ -121,6 +123,9 @@ control_resamples <- control_grid
 #'   preprocessor and model tuning parameters for that specific resample. This
 #'   will result in the preprocessor being re-processed multiple times, but
 #'   can be faster if that processing is extremely fast.
+#'
+#'   If `NULL`, chooses `"resamples"` if there are more than one resample,
+#'   otherwise chooses `"everything"` to attempt to maximize core utilization.
 #'
 #' @details
 #'
@@ -155,7 +160,7 @@ control_bayes <-
            save_workflow = FALSE,
            save_gp_scoring = FALSE,
            event_level = "first",
-           parallel_over = "resamples") {
+           parallel_over = NULL) {
     # add options for seeds per resample
 
     val_class_and_single(verbose, "logical", "control_bayes()")
@@ -205,7 +210,12 @@ print.control_bayes <- function(x, ...) {
 # ------------------------------------------------------------------------------
 
 val_parallel_over <- function(parallel_over, where) {
+  if (is.null(parallel_over)) {
+    return(invisible(NULL))
+  }
+
   val_class_and_single(parallel_over, "character", where)
   rlang::arg_match0(parallel_over, c("resamples", "everything"), "parallel_over")
+
   invisible(NULL)
 }

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -15,6 +15,7 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control, rng) {
   rows <- seq_len(n_grid_info)
 
   parallel_over <- control$parallel_over
+  parallel_over <- parallel_over_finalize(parallel_over, n_resamples)
 
   if (rng) {
     seeds <- sample.int(10^5, nrow(resamples))
@@ -426,4 +427,21 @@ super_safely <- function(fn) {
 
 is_failure <- function(x) {
   inherits(x, "try-error")
+}
+
+parallel_over_finalize <- function(parallel_over, n_resamples) {
+  # Always use user supplied option, even if not as efficient
+  if (!is.null(parallel_over)) {
+    return(parallel_over)
+  }
+
+  # Generally more efficient to parallelize over just resamples,
+  # but if there is only 1 resample we instead parallelize over
+  # "everything" (resamples and the hyperparameter grid) to maximize
+  # core utilization
+  if (n_resamples == 1L) {
+    "everything"
+  } else {
+    "resamples"
+  }
 }

--- a/man/control_bayes.Rd
+++ b/man/control_bayes.Rd
@@ -16,7 +16,7 @@ control_bayes(
   save_workflow = FALSE,
   save_gp_scoring = FALSE,
   event_level = "first",
-  parallel_over = "resamples"
+  parallel_over = NULL
 )
 }
 \arguments{
@@ -67,7 +67,9 @@ of class prediction is made, and specifies which level of the outcome
 is considered the "event".}
 
 \item{parallel_over}{A single string containing either \code{"resamples"} or
-\code{"everything"} describing how to use parallel processing.
+\code{"everything"} describing how to use parallel processing. Alternatively,
+\code{NULL} is allowed, which chooses between \code{"resamples"} and \code{"everything"}
+automatically.
 
 If \code{"resamples"}, then tuning will be performed in parallel over resamples
 alone. Within each resample, the preprocessor (i.e. recipe or formula) is
@@ -78,7 +80,10 @@ An outer parallel loop will iterate over resamples. Additionally, an
 inner parallel loop will iterate over all unique combinations of
 preprocessor and model tuning parameters for that specific resample. This
 will result in the preprocessor being re-processed multiple times, but
-can be faster if that processing is extremely fast.}
+can be faster if that processing is extremely fast.
+
+If \code{NULL}, chooses \code{"resamples"} if there are more than one resample,
+otherwise chooses \code{"everything"} to attempt to maximize core utilization.}
 }
 \description{
 Control aspects of the Bayesian search process

--- a/man/control_grid.Rd
+++ b/man/control_grid.Rd
@@ -13,7 +13,7 @@ control_grid(
   pkgs = NULL,
   save_workflow = FALSE,
   event_level = "first",
-  parallel_over = "resamples"
+  parallel_over = NULL
 )
 
 control_resamples(
@@ -24,7 +24,7 @@ control_resamples(
   pkgs = NULL,
   save_workflow = FALSE,
   event_level = "first",
-  parallel_over = "resamples"
+  parallel_over = NULL
 )
 }
 \arguments{
@@ -56,7 +56,9 @@ of class prediction is made, and specifies which level of the outcome
 is considered the "event".}
 
 \item{parallel_over}{A single string containing either \code{"resamples"} or
-\code{"everything"} describing how to use parallel processing.
+\code{"everything"} describing how to use parallel processing. Alternatively,
+\code{NULL} is allowed, which chooses between \code{"resamples"} and \code{"everything"}
+automatically.
 
 If \code{"resamples"}, then tuning will be performed in parallel over resamples
 alone. Within each resample, the preprocessor (i.e. recipe or formula) is
@@ -67,7 +69,10 @@ An outer parallel loop will iterate over resamples. Additionally, an
 inner parallel loop will iterate over all unique combinations of
 preprocessor and model tuning parameters for that specific resample. This
 will result in the preprocessor being re-processed multiple times, but
-can be faster if that processing is extremely fast.}
+can be faster if that processing is extremely fast.
+
+If \code{NULL}, chooses \code{"resamples"} if there are more than one resample,
+otherwise chooses \code{"everything"} to attempt to maximize core utilization.}
 }
 \description{
 Control aspects of the grid search process


### PR DESCRIPTION
Fairly straightforward.

Defaults `parallel_over` to `NULL`. Chooses `"resamples"` when there are >1 resample, otherwise chooses `"everything"` to try and maximize core utilization when there is 1 resample but multiple hyperparameters