### PR TITLE
Workflow warning redux

### DIFF
--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -383,12 +383,21 @@ pull_rset_attributes <- function(x) {
 set_workflow <- function(workflow, control) {
   if (control$save_workflow) {
     if (!is.null(workflow$pre$actions$recipe)) {
-      rlang::inform(paste0(
-        "The workflow being saved contains a recipe, which is ",
-        format(object.size(workflow$pre$actions$recipe), units = "Mb", digits = 2),
-        " in memory. If this was not intentional, please set the control ",
-        "setting `save_workflow = FALSE`."
-      ))
+      w_size <- object.size(workflow$pre$actions$recipe)
+      # make 5MB cutoff
+      if (w_size/1024^2 > 5) {
+        msg <-
+          paste0(
+            "The workflow being saved contains a recipe, which is ",
+            format(w_size, units = "Mb", digits = 2),
+            " in memory. If this was not intentional, please set the control ",
+            "setting `save_workflow = FALSE`."
+          )
+        cols <- get_tune_colors()
+        msg <- strwrap(msg, prefix = paste0(cols$symbol$info(cli::symbol$info), " "))
+        msg <- cols$message$info(paste0(msg, collapse = "\n"))
+        rlang::inform(msg)
+      }
     }
     workflow
   } else {

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -400,7 +400,7 @@ test_that("retain extra attributes and saved GP candidates", {
     res2 <- tune_bayes(wflow, resamples = folds, param_info = pset,
                        initial = iter1, iter = iter2,
                        control = control_bayes(save_workflow = TRUE)),
-    "being saved contains a recipe, which is"
+    "Gaussian process model"
   )
   expect_null(attr(res, "workflow"))
   expect_true(inherits(attr(res2, "workflow"), "workflow"))

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -431,7 +431,7 @@ test_that("retain extra attributes", {
   expect_true(inherits(attr(res2, "workflow"), "workflow"))
 
   wflow2 <- workflow() %>%
-    add_recipe(recipes::recipe(mpg ~ ., mtcars)) %>%
+    add_recipe(recipes::recipe(mpg ~ ., mtcars[rep(1:32, 3000),])) %>%
     add_model(svm_mod)
   pset2 <- dials::parameters(wflow2)
   grid2 <- grid_regular(pset2, levels = 3)

--- a/tests/testthat/test-param_set.R
+++ b/tests/testthat/test-param_set.R
@@ -21,9 +21,14 @@ test_that('recipe with no tunable parameters', {
 test_that('recipe with tunable parameters', {
   spline_info <- dials::parameters(spline_rec)
   check_param_set_tibble(spline_info)
+  if (utils::packageVersion("recipes") <= "0.1.15") {
+    expected_cols <- c('step_knnimpute', 'step_other', 'step_bs', 'step_bs')
+  } else {
+    expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
+  }
   expect_equal(
     spline_info$component,
-    c('step_knnimpute', 'step_other', 'step_bs', 'step_bs'),
+    expected_cols,
   )
   expect_true(all(spline_info$source == "recipe"))
   nms <- c('neighbors', 'threshold', 'deg_free', 'degree')

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -376,7 +376,7 @@ test_that("retain extra attributes", {
   expect_message(
     fit_resamples(
       lin_mod,
-      recipes::recipe(mpg ~ ., mtcars),
+      recipes::recipe(mpg ~ ., mtcars[rep(1:32, 3000),]),
       folds,
       control = control_resamples(save_workflow = TRUE)
     ),

--- a/tests/testthat/test-tunable.R
+++ b/tests/testthat/test-tunable.R
@@ -21,9 +21,14 @@ test_that('recipe with no tunable parameters', {
 test_that('recipe with tunable parameters', {
   spline_info <- tunable(spline_rec)
   check_tunable_tibble(spline_info)
+  if (utils::packageVersion("recipes") <= "0.1.15") {
+    expected_cols <- c('step_knnimpute', 'step_other', 'step_bs', 'step_bs')
+  } else {
+    expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
+  }
   expect_equal(
     spline_info$component,
-    c('step_knnimpute', 'step_other', 'step_bs', 'step_bs'),
+    expected_cols
   )
   expect_true(all(spline_info$source == "recipe"))
   nms <- c('neighbors', 'threshold', 'deg_free', 'degree')

--- a/tests/testthat/test-tune_args.R
+++ b/tests/testthat/test-tune_args.R
@@ -21,9 +21,14 @@ test_that('recipe with no tunable parameters', {
 test_that('recipe with tunable parameters', {
   spline_info <- tune_args(spline_rec)
   check_tune_args_tibble(spline_info)
+  if (utils::packageVersion("recipes") <= "0.1.15") {
+    expected_cols <- c('step_knnimpute', 'step_other', 'step_bs', 'step_bs')
+  } else {
+    expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
+  }
   expect_equal(
     spline_info$component,
-    c('step_knnimpute', 'step_other', 'step_bs', 'step_bs'),
+    expected_cols,
   )
   expect_true(all(spline_info$source == "recipe"))
   nms <- c('neighbors', 'threshold', 'deg_free', 'degree')


### PR DESCRIPTION
Old message: 

```
The workflow being saved contains a recipe, which is 41.61 Mb in memory. If this was not intentional, please set the control setting `save_workflow = FALSE`.
```

New message (depending on console width): 

```
ℹ The workflow being saved contains a recipe, which is 41.61 Mb
ℹ in memory. If this was not intentional, please set the control
ℹ setting `save_workflow = FALSE`.
```

New message is only printed if the workflow will be more than 5MB. 