### PR TITLE
small autoplot() updates

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -472,7 +472,7 @@ plot_regular_grid <- function(x, metric = NULL, ...) {
   # ----------------------------------------------------------------------------
 
   if (g > 5) {
-    return(autoplot(x, metric = metric))
+    return(plot_marginals(x, metric))
   }
 
   # ----------------------------------------------------------------------------

--- a/R/plots.R
+++ b/R/plots.R
@@ -554,14 +554,16 @@ plot_regular_grid <- function(x, metric = NULL, ...) {
     p <- p + geom_point(size = 1)
   }
 
-
   if (multi_metrics) {
     p <- p + ylab("")
   } else {
     dat$.metric[1]
     p <- p + ylab(dat$.metric[1])
   }
-
+  if (nrow(pset) == 1) {
+    x_lab <- pset$object[[1]]$label
+    p <- p + xlab(x_lab)
+  }
 
   if (any(is_num)) {
     p <- p + geom_line()

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -224,3 +224,13 @@ test_that("coord_obs_pred",{
 
 
 
+test_that("1D regular grid x labels",{
+  set.seed(1)
+  res <-
+    svm_rbf(cost = tune()) %>% set_engine("kernlab") %>% set_mode("regression") %>%
+    tune_grid(mpg ~ ., resamples = vfold_cv(mtcars, v = 5), grid = 3)
+  expect_equal(autoplot(res)$labels$x, c(cost = "Cost"))
+})
+
+
+


### PR DESCRIPTION
* Fix a missing x-axis label when one parameter is tuned. 
* With 6+ parameters, `autoplot()` was calling `autoplot()` infinitely. 