### PR TITLE
Tweak tune random number seed generation and usage

### DIFF
--- a/R/control.R
+++ b/R/control.R
@@ -127,6 +127,11 @@ control_resamples <- control_grid
 #'   If `NULL`, chooses `"resamples"` if there are more than one resample,
 #'   otherwise chooses `"everything"` to attempt to maximize core utilization.
 #'
+#'   Note that switching between `parallel_over` strategies is not guaranteed
+#'   to use the same random number generation schemes. However, re-tuning a
+#'   model using the same `parallel_over` strategy is guaranteed to be
+#'   reproducible between runs.
+#'
 #' @details
 #'
 #' For `extract`, this function can be used to output the model object, the

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -17,16 +17,13 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control, rng) {
   parallel_over <- control$parallel_over
   parallel_over <- parallel_over_finalize(parallel_over, n_resamples)
 
-  if (rng) {
-    seeds <- sample.int(10^5, nrow(resamples))
-  } else {
-    seeds <- NULL
-  }
-
   if (identical(parallel_over, "resamples")) {
+    seeds <- generate_seeds(rng, n_resamples)
+
     suppressPackageStartupMessages(
       results <- foreach::foreach(
         iteration = iterations,
+        seed = seeds,
         .packages = packages,
         .errorhandling = "pass"
       ) %op% {
@@ -37,11 +34,13 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control, rng) {
           workflow = workflow,
           metrics = metrics,
           control = control,
-          seeds = seeds
+          seed = seed
         )
       }
     )
   } else if (identical(parallel_over, "everything")) {
+    seeds <- generate_seeds(rng, n_resamples * n_grid_info)
+
     suppressPackageStartupMessages(
       results <- foreach::foreach(
         iteration = iterations,
@@ -50,6 +49,7 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control, rng) {
       ) %:%
         foreach::foreach(
           row = rows,
+          seed = slice_seeds(seeds, iteration, n_grid_info),
           .packages = packages,
           .errorhandling = "pass",
           .combine = iter_combine
@@ -63,7 +63,7 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control, rng) {
             workflow = workflow,
             metrics = metrics,
             control = control,
-            seeds = seeds
+            seed = seed
           )
         }
     )
@@ -117,13 +117,13 @@ tune_grid_loop_iter <- function(iteration,
                                 workflow,
                                 metrics,
                                 control,
-                                seeds) {
+                                seed) {
   load_pkgs(workflow)
   load_namespace(control$pkgs)
 
   # After package loading to avoid potential package RNG manipulation
-  if (!is.null(seeds)) {
-    set.seed(seeds[[iteration]])
+  if (!is.null(seed)) {
+    assign(".Random.seed", seed, envir = globalenv())
   }
 
   control_parsnip <- parsnip::control_parsnip(verbosity = 0, catch = TRUE)
@@ -342,7 +342,7 @@ super_safely_iterate_impl <- function(fn,
                                       workflow,
                                       metrics,
                                       control,
-                                      seeds) {
+                                      seed) {
   safely_iterate <- super_safely(fn)
 
   result <- safely_iterate(
@@ -352,7 +352,7 @@ super_safely_iterate_impl <- function(fn,
     workflow,
     metrics,
     control,
-    seeds
+    seed
   )
 
   error <- result$error
@@ -448,4 +448,39 @@ parallel_over_finalize <- function(parallel_over, n_resamples) {
   } else {
     "resamples"
   }
+}
+
+# Note:
+# We generate seeds in such a way that each call to `tune_grid_loop_iter()`
+# will get its own unique seed. It sets that seed once at the top of the
+# function call, then runs all the models in that loop iteration.
+generate_seeds <- function(rng, n) {
+  out <- vector("list", length = n)
+
+  if (!rng) {
+    # `NULL` elements are the signal to not fix the random seed
+    return(out)
+  }
+
+  original_algorithms <- RNGkind(kind = "L'Ecuyer-CMRG")
+  original_rng_algorithm <- original_algorithms[[1]]
+
+  on.exit(
+    RNGkind(kind = original_rng_algorithm),
+    add = TRUE
+  )
+
+  seed <- .Random.seed
+
+  for (i in seq_len(n)) {
+    out[[i]] <- seed
+    seed <- parallel::nextRNGStream(seed)
+  }
+
+  out
+}
+
+slice_seeds <- function(x, i, n) {
+  # Slice out the current iteration worth of seeds
+  x[(i - 1L) * n + seq_len(n)]
 }

--- a/man/control_bayes.Rd
+++ b/man/control_bayes.Rd
@@ -83,7 +83,12 @@ will result in the preprocessor being re-processed multiple times, but
 can be faster if that processing is extremely fast.
 
 If \code{NULL}, chooses \code{"resamples"} if there are more than one resample,
-otherwise chooses \code{"everything"} to attempt to maximize core utilization.}
+otherwise chooses \code{"everything"} to attempt to maximize core utilization.
+
+Note that switching between \code{parallel_over} strategies is not guaranteed
+to use the same random number generation schemes. However, re-tuning a
+model using the same \code{parallel_over} strategy is guaranteed to be
+reproducible between runs.}
 }
 \description{
 Control aspects of the Bayesian search process

--- a/man/control_grid.Rd
+++ b/man/control_grid.Rd
@@ -72,7 +72,12 @@ will result in the preprocessor being re-processed multiple times, but
 can be faster if that processing is extremely fast.
 
 If \code{NULL}, chooses \code{"resamples"} if there are more than one resample,
-otherwise chooses \code{"everything"} to attempt to maximize core utilization.}
+otherwise chooses \code{"everything"} to attempt to maximize core utilization.
+
+Note that switching between \code{parallel_over} strategies is not guaranteed
+to use the same random number generation schemes. However, re-tuning a
+model using the same \code{parallel_over} strategy is guaranteed to be
+reproducible between runs.}
 }
 \description{
 Control aspects of the grid search process


### PR DESCRIPTION
Closes #331 
Closes #332 

- Seeds are now generated with L'Ecuyer-CMRG, which is parallel safe.
- We now no longer repeatedly set the seed to the same value for each row of `rows` in the `"everything"` parallel loop

The strategy used here is slightly different from what we talked about in the group meeting. It was very difficult to generate and use 1 seed per row of `grid_info`. This was difficult to do because in `tune_grid_loop_iter()` we first loop over the preprocessors and fit them, then over the models. We _could_ just set the seed in that inner model loop, which is what we proposed in the group meeting. However, this would leave the preprocessor loop without a fixed seed, which I don't love because there could be randomness in some recipe steps that needs to be "fixed".

Because this was so difficult, I've just made a small tweak to the way we currently do things. Besides using the new type of random seeds, I've also just fixed the "bug" in the "everything" path where we were setting the seed to the same value repeatedly in the inner part of the nested loop. 

The way to explain our seed generation strategy now is: Every time `tune_grid_loop_iter()` is called, it sets a unique seed once at the top of the function call, then runs all the preprocessors and models in that particular iteration.

This means that the "everything" and "resamples" loop still don't use identical random seed strategies, but I'm honestly not sure how to fix that without a complete rewrite of the tune paths.