### PR TITLE
Fix an encoding error

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -14,7 +14,7 @@
 #' Gaiman <-
 #'   paste(
 #'     '"Good point." Bod was pleased with himself, and glad he had thought of',
-#'     'asking the poet for advice. Really, he thought, if you couldn’t trust a',
+#'     'asking the poet for advice. Really, he thought, if you couldn\'t trust a',
 #'     'poet to offer sensible advice, who could you trust?',
 #'     collapse = ""
 #'   )

--- a/man/message_wrap.Rd
+++ b/man/message_wrap.Rd
@@ -33,7 +33,7 @@ library(cli)
 Gaiman <-
   paste(
     '"Good point." Bod was pleased with himself, and glad he had thought of',
-    'asking the poet for advice. Really, he thought, if you couldn’t trust a',
+    'asking the poet for advice. Really, he thought, if you couldn\'t trust a',
     'poet to offer sensible advice, who could you trust?',
     collapse = ""
   )


### PR DESCRIPTION
On one flavor of checks: 

```
Version: 0.1.2
Check: examples
Result: ERROR
    Running examples in 'tune-Ex.R' failed
    The error most likely occurred in:
    
    > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
    > ### Name: message_wrap
    > ### Title: Write a message that respects the line width
    > ### Aliases: message_wrap
    >
    > ### ** Examples
    >
    > library(cli)
    > Gaiman <-
    + paste(
    + '"Good point." Bod was pleased with himself, and glad he had thought of',
    + <ERROR: re-encoding failure from encoding 'UTF-8'>
     'asking the poet for advice. Really, he thought, if you couldn...
    + 'poet to offer sensible advice, who could you trust?',
    Error: unexpected symbol in:
    " 'asking the poet for advice. Really, he thought, if you couldn...
     'poet"
    Execution halted
Flavor: r-devel-linux-x86_64-debian-clang
```