### PR TITLE
Change `conf_mat_resampled()` return object for `tidy = FALSE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Fixed an issue in `finalize_recipe()` which failed during tuning of recipe steps that contain multiple `tune()` parameters in an single step.
 
-* Changed `conf_mat_resampled()` to return the same type of object as `yardstick::conf_mat()` when `tidy = FALSE`.
+* Changed `conf_mat_resampled()` to return the same type of object as `yardstick::conf_mat()` when `tidy = FALSE` (#370).
 
 # tune 0.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # tune (development version)
 
-* Fixed an issue in `finalize_recipe()` which failed during tuning of recipe steps that contain multiple `tune()` parameters
-in an single step.
+* Fixed an issue in `finalize_recipe()` which failed during tuning of recipe steps that contain multiple `tune()` parameters in an single step.
+
+* Changed `conf_mat_resampled()` to return the same type of object as `yardstick::conf_mat()` when `tidy = FALSE`.
 
 # tune 0.1.3
 
@@ -16,6 +17,7 @@ in an single step.
  * `collect_predictions()` was made generic. 
  
  * The default tuning parameter for the SVM polynomial degree was switched from `dials::degree()` to `dials::prod_degree()` since it must be an integer. 
+
 ## Bug Fixes
 
 * `last_fit()` and `workflows::fit()` will now give identical results for the same workflow when the underlying model uses random number generation (#300).

--- a/R/conf_mat_resampled.R
+++ b/R/conf_mat_resampled.R
@@ -7,8 +7,9 @@
 #' classification model that was run with `control_*(save_pred = TRUE)`.
 #' @param parameters A tibble with a single tuning parameter combination. Only
 #' one tuning parameter combination (if any were used) is allowed here.
-#' @param tidy Should the results come back in a tibble (`TRUE`) or a matrix.
-#' @return A tibble or matrix with the average cell count across resamples.
+#' @param tidy Should the results come back in a tibble (`TRUE`) or a `conf_mat`
+#' object like `yardstick::conf_mat()` (`FALSE`)?
+#' @return A tibble or `conf_mat` with the average cell count across resamples.
 #' @examples
 #' library(parsnip)
 #' library(rsample)
@@ -93,6 +94,7 @@ conf_mat_resampled <- function(x, parameters = NULL, tidy = TRUE) {
     res <- matrix(res$Freq, ncol = length(lvls))
     colnames(res) <- lvls
     rownames(res) <- lvls
+    res <- as.table(res) %>% yardstick::conf_mat()
   }
   res
 }

--- a/man/conf_mat_resampled.Rd
+++ b/man/conf_mat_resampled.Rd
@@ -13,10 +13,11 @@ classification model that was run with \code{control_*(save_pred = TRUE)}.}
 \item{parameters}{A tibble with a single tuning parameter combination. Only
 one tuning parameter combination (if any were used) is allowed here.}
 
-\item{tidy}{Should the results come back in a tibble (\code{TRUE}) or a matrix.}
+\item{tidy}{Should the results come back in a tibble (\code{TRUE}) or a \code{conf_mat}
+object like \code{yardstick::conf_mat()} (\code{FALSE})?}
 }
 \value{
-A tibble or matrix with the average cell count across resamples.
+A tibble or \code{conf_mat} with the average cell count across resamples.
 }
 \description{
 For classification problems, \code{conf_mat_resampled()} computes a separate

--- a/tests/testthat/test-conf-mat-resampled.R
+++ b/tests/testthat/test-conf-mat-resampled.R
@@ -18,7 +18,7 @@ test_that('appropriate return values', {
     cm_2 <- conf_mat_resampled(svm_results, select_best(svm_results, "accuracy"), tidy = FALSE),
     regex = NA
   )
-  expect_true(is.matrix(cm_2))
+  expect_equal(class(cm_2), "conf_mat")
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #256 

This PR changes what `conf_mat_resampled(tidy = FALSE)` returns, so that it returns the same kind of `conf_mat` object as `yardstick::conf_mat()`.

``` r
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip

data(two_class_dat, package = "modeldata")

set.seed(2393)
res <-
  logistic_reg() %>%
  set_engine("glm") %>%
  fit_resamples(Class ~ ., resamples = vfold_cv(two_class_dat, v = 3),
                control = control_resamples(save_pred = TRUE))

conf_mat_resampled(res)
#> # A tibble: 4 x 3
#>   Prediction Truth   Freq
#>   <fct>      <fct>  <dbl>
#> 1 Class1     Class1 123  
#> 2 Class1     Class2  25.7
#> 3 Class2     Class1  22.7
#> 4 Class2     Class2  92.3
conf_mat_resampled(res, tidy = FALSE)
#>           Class1    Class2
#> Class1 123.00000  22.66667
#> Class2  25.66667  92.33333

conf_mat_resampled(res, tidy = FALSE) %>%
  autoplot()
```

![](https://i.imgur.com/3B9fBPz.png)

<sup>Created on 2021-04-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>