### PR TITLE
Quiet doFuture warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools 
-Version: 0.1.5.9000
+Version: 0.1.5.9001
 Authors@R: c(
       person(given = "Max",
              family = "Kuhn",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools 
-Version: 0.1.5
+Version: 0.1.5.9000
 Authors@R: c(
       person(given = "Max",
              family = "Kuhn",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed a bug where the resampled confusion matrix is transposed when `conf_mat_resamped(tidy = FALSE)` (#372)
 
+* False positive warnings no longer occur when using the `doFuture` package for parallel processing (#377)
+
 # tune 0.1.4
 
 * Fixed an issue in `finalize_recipe()` which failed during tuning of recipe steps that contain multiple `tune()` parameters in an single step.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# tune (development version)
+
 # tune 0.1.5
 
 * Fixed a bug where the resampled confusion matrix is transposed when `conf_mat_resamped(tidy = FALSE)` (#372)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -17,59 +17,57 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control, rng) {
   parallel_over <- control$parallel_over
   parallel_over <- parallel_over_finalize(parallel_over, n_resamples)
 
+  rlang::local_options(doFuture.rng.onMisuse = "ignore")
+
   if (identical(parallel_over, "resamples")) {
     seeds <- generate_seeds(rng, n_resamples)
 
-    do_future_quietly(
-      suppressPackageStartupMessages(
-        results <- foreach::foreach(
-          iteration = iterations,
-          seed = seeds,
+    suppressPackageStartupMessages(
+      results <- foreach::foreach(
+        iteration = iterations,
+        seed = seeds,
+        .packages = packages,
+        .errorhandling = "pass"
+      ) %op% {
+        tune_grid_loop_iter_safely(
+          iteration = iteration,
+          resamples = resamples,
+          grid_info = grid_info,
+          workflow = workflow,
+          metrics = metrics,
+          control = control,
+          seed = seed
+        )
+      }
+    )
+  } else if (identical(parallel_over, "everything")) {
+    seeds <- generate_seeds(rng, n_resamples * n_grid_info)
+
+    suppressPackageStartupMessages(
+      results <- foreach::foreach(
+        iteration = iterations,
+        .packages = packages,
+        .errorhandling = "pass"
+      ) %:%
+        foreach::foreach(
+          row = rows,
+          seed = slice_seeds(seeds, iteration, n_grid_info),
           .packages = packages,
-          .errorhandling = "pass"
+          .errorhandling = "pass",
+          .combine = iter_combine
         ) %op% {
+          grid_info_row <- vctrs::vec_slice(grid_info, row)
+
           tune_grid_loop_iter_safely(
             iteration = iteration,
             resamples = resamples,
-            grid_info = grid_info,
+            grid_info = grid_info_row,
             workflow = workflow,
             metrics = metrics,
             control = control,
             seed = seed
           )
         }
-      )
-    )
-  } else if (identical(parallel_over, "everything")) {
-    seeds <- generate_seeds(rng, n_resamples * n_grid_info)
-
-    do_future_quietly(
-      suppressPackageStartupMessages(
-        results <- foreach::foreach(
-          iteration = iterations,
-          .packages = packages,
-          .errorhandling = "pass"
-        ) %:%
-          foreach::foreach(
-            row = rows,
-            seed = slice_seeds(seeds, iteration, n_grid_info),
-            .packages = packages,
-            .errorhandling = "pass",
-            .combine = iter_combine
-          ) %op% {
-            grid_info_row <- vctrs::vec_slice(grid_info, row)
-
-            tune_grid_loop_iter_safely(
-              iteration = iteration,
-              resamples = resamples,
-              grid_info = grid_info_row,
-              workflow = workflow,
-              metrics = metrics,
-              control = control,
-              seed = seed
-            )
-          }
-      )
     )
   } else {
     rlang::abort("Internal error: Invalid `parallel_over`.")

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -541,12 +541,3 @@ set_workflow_recipe <- function(workflow, recipe) {
   workflow$pre$actions$recipe$recipe <- recipe
   workflow
 }
-
-
-do_future_quietly <- function (code) {
-  old <- options()
-  options(doFuture.rng.onMisuse = "ignore")
-  on.exit(options(old))
-  force(code)
-}
-

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -541,3 +541,12 @@ set_workflow_recipe <- function(workflow, recipe) {
   workflow$pre$actions$recipe$recipe <- recipe
   workflow
 }
+
+
+do_future_quietly <- function (code) {
+  old <- options()
+  options(doFuture.rng.onMisuse = "ignore")
+  on.exit(options(old))
+  force(code)
+}
+


### PR DESCRIPTION
Closes #377 

Test will follow in `extratests`. 

``` r
# pak::pak("tidymodels/tune@quiet-future")
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
library(doFuture)
#> Loading required package: foreach
#> 
#> Attaching package: 'foreach'
#> The following objects are masked from 'package:purrr':
#> 
#>     accumulate, when
#> Loading required package: future

cores <- parallelly::availableCores()
registerDoFuture()
# Only option available on Macs, as I understand it:
plan("multisession")

data(cells)
set.seed(2369)
tr_te_split <- initial_split(cells %>% select(-case), prop = 3/4)
cell_train <- training(tr_te_split)
cell_test  <- testing(tr_te_split)

set.seed(1697)
folds <- vfold_cv(cell_train, v = 10)

cell_rec <- recipe(
  class ~ angle_ch_1 + total_inten_ch_2,
  data = cell_train
)

boost_forest_mod <- boost_tree(
  trees = tune(),
  min_n = tune(),
  learn_rate = tune(),
  tree_depth = tune(),
  loss_reduction = tune()
) %>%
  set_engine("xgboost") %>%
  set_mode("classification")

workflow_cells <- workflow() %>%
  add_recipe(cell_rec) %>%
  add_model(boost_forest_mod)

workflow_cells %>%
  tune_grid(
    folds,
    grid = 3,
    metrics = metric_set(roc_auc, precision, recall)
  )
#> # Tuning results
#> # 10-fold cross-validation 
#> # A tibble: 10 x 4
#>    splits             id     .metrics         .notes          
#>    <list>             <chr>  <list>           <list>          
#>  1 <split [1363/152]> Fold01 <tibble [9 × 9]> <tibble [0 × 1]>
#>  2 <split [1363/152]> Fold02 <tibble [9 × 9]> <tibble [0 × 1]>
#>  3 <split [1363/152]> Fold03 <tibble [9 × 9]> <tibble [0 × 1]>
#>  4 <split [1363/152]> Fold04 <tibble [9 × 9]> <tibble [0 × 1]>
#>  5 <split [1363/152]> Fold05 <tibble [9 × 9]> <tibble [0 × 1]>
#>  6 <split [1364/151]> Fold06 <tibble [9 × 9]> <tibble [0 × 1]>
#>  7 <split [1364/151]> Fold07 <tibble [9 × 9]> <tibble [0 × 1]>
#>  8 <split [1364/151]> Fold08 <tibble [9 × 9]> <tibble [0 × 1]>
#>  9 <split [1364/151]> Fold09 <tibble [9 × 9]> <tibble [0 × 1]>
#> 10 <split [1364/151]> Fold10 <tibble [9 × 9]> <tibble [0 × 1]>
```

<sup>Created on 2021-06-01 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0.9000)</sup>