### PR TITLE
changes for RNG consistency in #389

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Imports:
     tibble (>= 3.1.0),
     tidyr,
     vctrs (>= 0.3.0),
+    withr,
     workflows (>= 0.2.2),
     yardstick (>= 0.0.7)
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* When using `load_pkgs()`, packages that use random numbers on start-up do not affect the state of the RNG. We also added more control of the RNGkind to make it consistent with the user's previous value (#389). 
+
 # tune 0.1.5
 
 * Fixed a bug where the resampled confusion matrix is transposed when `conf_mat_resamped(tidy = FALSE)` (#372)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -2,6 +2,12 @@ tune_grid_loop <- function(resamples, grid, workflow, metrics, control, rng) {
   `%op%` <- get_operator(control$allow_par, workflow)
   `%:%` <- foreach::`%:%`
 
+  current_rng_kind <- RNGkind()[[1]]
+  on.exit(
+    RNGkind(kind = current_rng_kind),
+    add = TRUE
+  )
+
   tune_grid_loop_iter_safely <- super_safely_iterate(tune_grid_loop_iter)
 
   packages <- c(control$pkgs, required_pkgs(workflow))

--- a/R/load_ns.R
+++ b/R/load_ns.R
@@ -13,7 +13,7 @@ load_pkgs <- function(x, ...) {
 
 #' @export
 load_pkgs.character <- function(x, ...) {
-  load_namespace(x)
+  withr::with_preserve_seed(load_namespace(x))
 }
 
 #' @export

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -28,6 +28,7 @@ pre
 preprocessor
 reprex
 RBF
+RNGkind
 stanford
 tibble
 tibbles

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -28,6 +28,7 @@ test_that('tune recipe only', {
   extr_1_1 <- function(x) {
     extract_recipe(x) %>% tidy(number = 2)
   }
+  before_kind <- RNGkind()[[1]]
   expect_error(
     res_1_1 <-
       workflow() %>%
@@ -36,6 +37,8 @@ test_that('tune recipe only', {
       tune_grid(resamples = mt_folds, control = control_grid(extract = extr_1_1)),
     NA
   )
+  after_kind <- RNGkind()[[1]]
+  expect_equal(before_kind, after_kind)
   expect_error(extract_1_1 <- dplyr::bind_rows(res_1_1$.extracts), NA)
 
   expect_true(all(names(extract_1_1) == c("num_comp", ".extracts", ".config")))

--- a/tests/testthat/test-tunable.R
+++ b/tests/testthat/test-tunable.R
@@ -70,11 +70,6 @@ test_that('model with main and engine parameters', {
 
 test_that('bad model inputs', {
   skip_if_not_installed("parsnip")
-  expect_error(
-    tunable(no_engine),
-    "Please declare an engine first using"
-  )
-
   bad_class <- lm_model
   class(bad_class) <- c("potato", "model_spec")
   expect_error(


### PR DESCRIPTION
`load_namespace()` was altered to reset the RNG state in case packages use random numbers on startup. 

We also added an additional `on.exit()` to `tune_grid_loop()` so that RNGkind stays consistent. 

closes #389