### PR TITLE
Avoid `purrr::partial()`, which captures the calling environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* Parallel processing with PSOCK clusters is now more efficient, due to carefully avoiding sending extraneous information to each worker (#396).
+
 # tune 0.1.6
 
 * When using `load_pkgs()`, packages that use random numbers on start-up do not affect the state of the RNG. We also added more control of the RNGkind to make it consistent with the user's previous value (#389). 


### PR DESCRIPTION
Related to #384

While looking into #384, I learned that our usage of `purrr::partial()` in `tune_grid_loop()` is _really_ hurting performance. The "partialized" function captures its surrounding environment, and that includes the `resamples` object. This gets fully serialized and sent out to each worker, meaning that each worker was being sent an extra `n_resamples` copies of the data set (beyond what we were already doing by mistake that #384 pointed out).

For example, with the example from https://github.com/tidymodels/tune/issues/384#issue-912661358 (tweaked to have 5000 rows), each of my workers was peaking at around 12gb of memory, and with this PR they now peak at 6gb. That it still way too much per worker, but this is the first step in the right direction.

Since the iteration function is no longer defined in the environment where `foreach()` is called, we have to extract it with `getFromNamespace()` to be able to call it. We could also do `tune:::`, but R CMD Check gives us a warning about that.