### PR TITLE
Avoid sending full `resamples` to each worker

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # tune (development version)
 
-* Parallel processing with PSOCK clusters is now more efficient, due to carefully avoiding sending extraneous information to each worker (#396).
+* Parallel processing with PSOCK clusters is now more efficient, due to carefully avoiding sending extraneous information to each worker (#384, #396).
 
 # tune 0.1.6
 


### PR DESCRIPTION
Followup to #396 
Closes #384 
Closes #376 

Previously, we would send the entire `resamples` object to each worker and then slice out the `split` that was required for that iteration. That was very wasteful, as each worker was getting a deep copy of `resamples` (serializing `resamples` fully materializes the copy of the data set held in each rsplit).

Now, we only send each worker the `splits` that it is required to work on.

To get a sense of how this improved things, I tried running the example in https://github.com/tidymodels/tune/issues/384#issue-912661358, but with 5000 rows and 10000 columns (so 50 million total elements). I used 8 workers.

- Before this PR and before #396, each worker peaked around 12gb of memory and I had to terminate R
- After #396, each worker peaked around 6gb of memory
- After this PR, each worker peaked around 1.2gb of memory

I doubt this affects multicore processing much, but it should _greatly_ improve multisession / PSOCK processing.