### PR TITLE
Use Chicago dataset from modeldata instead of from dials

### DIFF
--- a/tests/helper-objects.R
+++ b/tests/helper-objects.R
@@ -6,10 +6,10 @@ library(workflows)
 library(dplyr)
 library(tidyr)
 library(kernlab)
-library(dials)
+library(modeldata)
 library(yardstick)
 
-data("Chicago", package = "dials")
+data("Chicago")
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is so that it can be removed from dials: https://github.com/tidymodels/dials/issues/166