### PR TITLE
use new dials objects for xgboost engine args

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,3 +54,5 @@ Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
+Remotes:
+  tidymodels/dials

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends:
     R (>= 2.10)
 Imports:
     cli (>= 2.0.0),
-    dials (>= 0.0.9),
+    dials (>= 0.0.10),
     dplyr (>= 1.0.0),
     foreach,
     generics (>= 0.1.0),
@@ -54,5 +54,3 @@ Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
-Remotes:
-  tidymodels/dials

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Parallel processing with PSOCK clusters is now more efficient, due to carefully avoiding sending extraneous information to each worker (#384, #396).
 
+* The engine arguments for xgboost `alpha`, `lambda`, and `scale_pos_weight` are now tunable.
+
 # tune 0.1.6
 
 * When using `load_pkgs()`, packages that use random numbers on start-up do not affect the state of the RNG. We also added more control of the RNGkind to make it consistent with the user's previous value (#389). 

--- a/R/tunable.R
+++ b/R/tunable.R
@@ -134,6 +134,23 @@ c5_tree_engine_args <-
 c5_boost_engine_args <- c5_tree_engine_args
 c5_boost_engine_args$component <- "boost_tree"
 
+xgboost_engine_args <-
+  tibble::tibble(
+    name = c(
+      "alpha",
+      "lambda",
+      "scale_pos_weight"
+    ),
+    call_info = list(
+      list(pkg = "dials", fun = "penalty_L1"),
+      list(pkg = "dials", fun = "penalty_L2"),
+      list(pkg = "dials", fun = "scale_pos_weight")
+    ),
+    source = "model_spec",
+    component = "boost_tree",
+    component_id = "engine"
+  )
+
 ranger_engine_args <-
   tibble::tibble(
     name = c(
@@ -224,6 +241,7 @@ tunable.multinomial_reg <- function(x, ...) {
 tunable.boost_tree <- function(x, ...) {
   res <- NextMethod()
   if (x$engine == "xgboost") {
+    res <- add_engine_parameters(res, xgboost_engine_args)
     res$call_info[res$name == "sample_size"] <-
       list(list(pkg = "dials", fun = "sample_prop"))
   } else {


### PR DESCRIPTION
Dials now contains new parameter object for xgboost-specific engine args so they are added to the result of `tunable()` here. 

Closes #402 for `alpha` and `lambda` - and I've added `scale_pos_weight` as well.