### PR TITLE
drop usage of deprecated `step_knnimpute()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     lifecycle (>= 1.0.0),
     parsnip (>= 0.1.4),
     purrr (>= 0.3.2),
-    recipes (>= 0.1.15),
+    recipes (>= 0.1.16),
     rlang (>= 0.4.0),
     rsample (>= 0.0.9),
     tibble (>= 3.1.0),

--- a/tests/helper-objects.R
+++ b/tests/helper-objects.R
@@ -18,7 +18,7 @@ spline_rec <-
   step_date(date) %>%
   step_holiday(date) %>%
   step_rm(date, ends_with("away")) %>%
-  step_knnimpute(all_predictors(), neighbors = tune("imputation")) %>%
+  step_impute_knn(all_predictors(), neighbors = tune("imputation")) %>%
   step_other(all_nominal(), threshold = tune()) %>%
   step_dummy(all_nominal()) %>%
   step_normalize(all_predictors()) %>%

--- a/tests/testthat/test-param_set.R
+++ b/tests/testthat/test-param_set.R
@@ -21,11 +21,7 @@ test_that('recipe with no tunable parameters', {
 test_that('recipe with tunable parameters', {
   spline_info <- dials::parameters(spline_rec)
   check_param_set_tibble(spline_info)
-  if (utils::packageVersion("recipes") <= "0.1.15") {
-    expected_cols <- c('step_knnimpute', 'step_other', 'step_bs', 'step_bs')
-  } else {
-    expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
-  }
+  expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
   expect_equal(
     spline_info$component,
     expected_cols,

--- a/tests/testthat/test-tunable.R
+++ b/tests/testthat/test-tunable.R
@@ -21,11 +21,7 @@ test_that('recipe with no tunable parameters', {
 test_that('recipe with tunable parameters', {
   spline_info <- tunable(spline_rec)
   check_tunable_tibble(spline_info)
-  if (utils::packageVersion("recipes") <= "0.1.15") {
-    expected_cols <- c('step_knnimpute', 'step_other', 'step_bs', 'step_bs')
-  } else {
-    expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
-  }
+  expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
   expect_equal(
     spline_info$component,
     expected_cols

--- a/tests/testthat/test-tune_args.R
+++ b/tests/testthat/test-tune_args.R
@@ -21,11 +21,7 @@ test_that('recipe with no tunable parameters', {
 test_that('recipe with tunable parameters', {
   spline_info <- tune_args(spline_rec)
   check_tune_args_tibble(spline_info)
-  if (utils::packageVersion("recipes") <= "0.1.15") {
-    expected_cols <- c('step_knnimpute', 'step_other', 'step_bs', 'step_bs')
-  } else {
-    expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
-  }
+  expected_cols <- c('step_impute_knn', 'step_other', 'step_bs', 'step_bs')
   expect_equal(
     spline_info$component,
     expected_cols,


### PR DESCRIPTION
This PR switches the use of  the deprecated `step_knnimpute()` to the new `step_impute_knn()` and ups the required version of recipes