### PR TITLE
Find SVG files for article

### DIFF
--- a/vignettes/acquisition_functions.Rmd
+++ b/vignettes/acquisition_functions.Rmd
@@ -6,6 +6,11 @@ vignette: >
 output:
   knitr:::html_vignette:
     toc: yes
+resource_files:
+  - figures/initial.svg
+  - figures/iter_1.svg
+  - figures/iter_20.svg  
+  - figures/trade_off_20.svg     
 ---
   
 ```{r setup, include=FALSE}


### PR DESCRIPTION
If you look at the pkgdown site for tune:

- [release](https://tune.tidymodels.org/articles/acquisition_functions.html)
- [dev](https://tune.tidymodels.org/dev/articles/acquisition_functions.html)

you'll notice that we have broken links to images on the acquisition functions article. I poked around in the pkgdown documentation, tried a few things, and discovered that setting these [as external resources](https://pkgdown.r-lib.org/dev/reference/build_articles.html#external-files) solves the problem.