### PR TITLE
handle missing metrics values before GP fit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * The engine arguments for xgboost `alpha`, `lambda`, and `scale_pos_weight` are now tunable.
 
+* When the Bayesian optimization data contain missing values, these are removed before fitting the GP model. If all metrics are missing, no GP is fit and the current results are returned. (#432)
+
 # tune 0.1.6
 
 * When using `load_pkgs()`, packages that use random numbers on start-up do not affect the state of the RNG. We also added more control of the RNGkind to make it consistent with the user's previous value (#389). 

--- a/R/checks.R
+++ b/R/checks.R
@@ -485,7 +485,7 @@ val_class_and_single <- function(x, cls = "numeric", where = NULL) {
 check_gp_data <- function(x) {
   met <- x$.metric[[1]]
 
-  miss_y <- sum(is.na(x$mean))
+  miss_y <- sum(is.nan(x$mean))
   if (miss_y > 0) {
 
     if (miss_y == nrow(x)) {
@@ -495,7 +495,7 @@ check_gp_data <- function(x) {
       message_wrap(msg, prefix = "!", color_text = get_tune_colors()$message$danger)
     } else {
       msg <- cli::pluralize(
-        "For the {met} estimates, {miss_y} {?value was/values were} found and removed before fitting the Gaussian process model."
+        "For the {met} estimates, {miss_y} missing {?value was/values were} found and removed before fitting the Gaussian process model."
       )
       message_wrap(msg, prefix = "!", color_text = get_tune_colors()$message$warning)
     }

--- a/R/checks.R
+++ b/R/checks.R
@@ -490,7 +490,7 @@ check_gp_data <- function(x) {
 
     if (miss_y == nrow(x)) {
       msg <- cli::pluralize(
-        "All of the {met} estimatess where missing. The Gaussian process model cannot be fit to the data."
+        "All of the {met} estimates were missing. The Gaussian process model cannot be fit to the data."
       )
       message_wrap(msg, prefix = "!", color_text = get_tune_colors()$message$danger)
     } else {

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -428,7 +428,7 @@ fit_gp <- function(dat, pset, metric, control, ...) {
 
   x <- encode_set(dat %>% dplyr::select(-mean), pset, as_matrix = TRUE)
 
-  if (nrow(x) <= ncol(x) + 1 & nrow(x) > 0) {
+  if (nrow(x) <= ncol(x) + 1 && nrow(x) > 0) {
     msg <-
       paste(
         "The Gaussian process model is being fit using ", ncol(x),

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -244,7 +244,7 @@ tune_bayes_workflow <-
       message_wrap(paste("Optimizing", metrics_name, "using", objective$label))
     }
 
-    gp_mod <- NULL
+    prev_gp_mod <- NULL
 
     for (i in (1:iter) + score_card$overall_iter) {
       .notes <-
@@ -254,7 +254,6 @@ tune_bayes_workflow <-
 
       check_time(start_time, control$time_limit)
 
-      prev_gp_mod <- gp_mod
       set.seed(control$seed[1] + i)
       gp_mod <-
         catch_and_log(
@@ -347,6 +346,7 @@ tune_bayes_workflow <-
         )
         break
       }
+      prev_gp_mod <- gp_mod
       check_time(start_time, control$time_limit)
     }
 

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -454,3 +454,53 @@ test_that('too few starting values', {
 
 })
 
+# ------------------------------------------------------------------------------
+
+test_that('missing performance values', {
+  data(ames, package = "modeldata")
+
+  mod <- decision_tree(cost_complexity = tune()) %>% set_mode("regression")
+
+  set.seed(1)
+  folds <- validation_split(ames, prop = .9)
+
+  expect_message(
+    expect_error({
+      set.seed(2)
+      res <-
+        mod %>%
+        tune_bayes(
+          Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type +
+            Latitude + Longitude,
+          resamples = folds,
+          initial = 3,
+          metrics = metric_set(rsq),
+          param_info = parameters(cost_complexity(c(-2, 0)))
+        )
+
+    },
+    regexp = NA
+    ),
+    regexp = "removed before fitting the Gaussian"
+  )
+
+  expect_message(
+    expect_error({
+      set.seed(2)
+      res_fail <-
+        mod %>%
+        tune_bayes(
+          Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type +
+            Latitude + Longitude,
+          resamples = folds,
+          initial = 5,
+          metrics = metric_set(rsq),
+          param_info = parameters(cost_complexity(c(0.5, 0)))
+        )
+    },
+    regexp = NA
+    ),
+    regexp = "Gaussian process model cannot be"
+  )
+
+})


### PR DESCRIPTION
Closes #436

Affects #432

* When the Bayesian optimization data contain missing values, these are removed before fitting the GP model. 
* If all metrics are missing (or the same), no GP is fit and the current results are returned.
