### PR TITLE
replace deprecated functions

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -28,7 +28,7 @@ check_grid <- function(grid, workflow, pset = NULL) {
   }
 
   if (is.null(pset)) {
-    pset <- dials::parameters(workflow)
+    pset <- hardhat::extract_parameter_set_dials(workflow)
   }
 
   if (nrow(pset) == 0L) {
@@ -122,7 +122,7 @@ needs_finalization <- function(x, nms = character(0)) {
 
 check_parameters <- function(workflow, pset = NULL, data, grid_names = character(0)) {
   if (is.null(pset)) {
-    pset <- parameters(workflow)
+    pset <- hardhat::extract_parameter_set_dials(workflow)
   }
   unk <- purrr::map_lgl(pset$object, dials::has_unknowns)
   if (!any(unk)) {
@@ -256,7 +256,7 @@ check_workflow <- function(x, pset = NULL, check_dials = FALSE) {
 
   if (check_dials) {
     if (is.null(pset)) {
-      pset <- dials::parameters(x)
+      pset <- hardhat::extract_parameter_set_dials(x)
     }
 
     check_param_objects(pset)

--- a/R/collect.R
+++ b/R/collect.R
@@ -50,7 +50,7 @@
 #' \donttest{
 #' data("example_ames_knn")
 #' # The parameters for the model:
-#' parameters(ames_wflow)
+#' extract_parameter_set_dials(ames_wflow)
 #'
 #' # Summarized over resamples
 #' collect_metrics(ames_grid_search)

--- a/R/data.R
+++ b/R/data.R
@@ -51,7 +51,7 @@
 #'   add_model(knn_model)
 #'
 #' ames_set <-
-#'   parameters(ames_wflow) %>%
+#'   extract_parameter_set_dials(ames_wflow) %>%
 #'   update(K = neighbors(c(1, 50)))
 #'
 #' set.seed(7014)

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -35,7 +35,7 @@ finalize_model <- function(x, parameters) {
     stop("`x` should be a parsnip model specification.")
   }
   check_final_param(parameters)
-  pset <- parameters(x)
+  pset <- hardhat::extract_parameter_set_dials(x)
   if (tibble::is_tibble(parameters)) {
     parameters <- as.list(parameters)
   }
@@ -60,7 +60,7 @@ finalize_recipe <- function(x, parameters) {
   }
   check_final_param(parameters)
   pset <-
-    dials::parameters(x) %>%
+    hardhat::extract_parameter_set_dials(x) %>%
     dplyr::filter(id %in% names(parameters) & source == "recipe")
 
   if (tibble::is_tibble(parameters)) {

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -154,7 +154,7 @@ tune_grid_loop_iter <- function(split,
   out_notes <-
     tibble::tibble(location = character(0), type = character(0), note = character(0))
 
-  params <- dials::parameters(workflow)
+  params <- hardhat::extract_parameter_set_dials(workflow)
   model_params <- dplyr::filter(params, source == "model_spec")
   preprocessor_params <- dplyr::filter(params, source == "recipe")
 

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -199,7 +199,7 @@ compute_grid_info <- function(workflow, grid) {
 
   grid <- tibble::as_tibble(grid)
 
-  parameters <- dials::parameters(workflow)
+  parameters <- hardhat::extract_parameter_set_dials(workflow)
   parameters_model <- dplyr::filter(parameters, source == "model_spec")
   parameters_preprocessor <- dplyr::filter(parameters, source == "recipe")
 

--- a/R/merge.R
+++ b/R/merge.R
@@ -60,7 +60,7 @@
 #'
 #' set.seed(254)
 #' xgb_grid <-
-#'   dials::parameters(xgb_mod) %>%
+#'   extract_parameter_set_dials(xgb_mod) %>%
 #'   finalize(hpc_data) %>%
 #'   grid_max_entropy(size = 3)
 #'
@@ -115,7 +115,7 @@ merger <- function(x, y, ...) {
   if (!is.data.frame(y)) {
     stop("The second argument should be a data frame.", call. = FALSE)
   }
-  pset <- dials::parameters(x)
+  pset <- hardhat::extract_parameter_set_dials(x)
 
   if (nrow(pset) == 0) {
     res <- tibble::tibble(x = purrr::map(1:nrow(y), ~ x))

--- a/R/min_grid.R
+++ b/R/min_grid.R
@@ -57,7 +57,7 @@
 #'
 #' svm_grid <-
 #'   svm_spec %>%
-#'   parameters() %>%
+#'   extract_parameter_set_dials() %>%
 #'   grid_regular(levels = 3)
 #'
 #' min_grid(svm_spec, svm_grid)
@@ -72,7 +72,7 @@
 #'
 #' xgb_grid <-
 #'   xgb_spec %>%
-#'   parameters() %>%
+#'   extract_parameter_set_dials() %>%
 #'   grid_regular(levels = 3)
 #'
 #' min_grid(xgb_spec, xgb_grid)
@@ -110,7 +110,7 @@ get_submodel_info <- function(spec) {
     dplyr::filter(engine == spec$engine) %>%
     dplyr::select(name = parsnip, has_submodel) %>%
     dplyr::full_join(
-      dials::parameters(spec) %>% tibble::as_tibble() %>% dplyr::select(name, id),
+      hardhat::extract_parameter_set_dials(spec) %>% tibble::as_tibble() %>% dplyr::select(name, id),
       by = "name"
     ) %>%
     dplyr::mutate(id = ifelse(is.na(id), name, id)) %>%

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -205,7 +205,7 @@ tune_bayes_workflow <-
     maximize <- metrics_data$direction[metrics_data$.metric == metrics_name] == "maximize"
 
     if (is.null(param_info)) {
-      param_info <- dials::parameters(object)
+      param_info <- hardhat::extract_parameter_set_dials(object)
     }
     check_workflow(object, check_dials = is.null(param_info), pset = param_info)
 

--- a/man/collect_predictions.Rd
+++ b/man/collect_predictions.Rd
@@ -86,7 +86,7 @@ Obtain and format results produced by tuning functions
 \donttest{
 data("example_ames_knn")
 # The parameters for the model:
-parameters(ames_wflow)
+extract_parameter_set_dials(ames_wflow)
 
 # Summarized over resamples
 collect_metrics(ames_grid_search)

--- a/man/example_ames_knn.Rd
+++ b/man/example_ames_knn.Rd
@@ -62,7 +62,7 @@ ames_wflow <-
   add_model(knn_model)
 
 ames_set <-
-  parameters(ames_wflow) \%>\%
+  extract_parameter_set_dials(ames_wflow) \%>\%
   update(K = neighbors(c(1, 50)))
 
 set.seed(7014)

--- a/man/merge.recipe.Rd
+++ b/man/merge.recipe.Rd
@@ -72,7 +72,7 @@ xgb_mod <-
 
 set.seed(254)
 xgb_grid <-
-  dials::parameters(xgb_mod) \%>\%
+  extract_parameter_set_dials(xgb_mod) \%>\%
   finalize(hpc_data) \%>\%
   grid_max_entropy(size = 3)
 

--- a/man/min_grid.Rd
+++ b/man/min_grid.Rd
@@ -77,7 +77,7 @@ svm_spec <-
 
 svm_grid <-
   svm_spec \%>\%
-  parameters() \%>\%
+  extract_parameter_set_dials() \%>\%
   grid_regular(levels = 3)
 
 min_grid(svm_spec, svm_grid)
@@ -92,7 +92,7 @@ xgb_spec <-
 
 xgb_grid <-
   xgb_spec \%>\%
-  parameters() \%>\%
+  extract_parameter_set_dials() \%>\%
   grid_regular(levels = 3)
 
 min_grid(xgb_spec, xgb_grid)

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -15,7 +15,7 @@ rmse_test <- yardstick::rsq_vec(testing(split) %>% pull(mpg), test_pred)
 test_that("formula method", {
 
   res <- linear_reg() %>% set_engine("lm") %>% last_fit(f, split)
-  expect_equivalent(coef(extract_model(res$.workflow[[1]])), coef(lm_fit))
+  expect_equivalent(coef(extract_fit_engine(res$.workflow[[1]])), coef(lm_fit))
   expect_equal(res$.metrics[[1]]$.estimate[[2]], rmse_test)
   expect_equal(res$.predictions[[1]]$.pred, unname(test_pred))
   expect_true(res$.workflow[[1]]$trained)
@@ -26,7 +26,7 @@ test_that("recipe method", {
 
   rec <- recipe(mpg ~ ., data = mtcars) %>% step_poly(disp)
   res <- linear_reg() %>% set_engine("lm") %>% last_fit(rec, split)
-  expect_equivalent(sort(coef(extract_model(res$.workflow[[1]]))), sort(coef(lm_fit)))
+  expect_equivalent(sort(coef(extract_fit_engine(res$.workflow[[1]]))), sort(coef(lm_fit)))
   expect_equal(res$.metrics[[1]]$.estimate[[2]], rmse_test)
   expect_equal(res$.predictions[[1]]$.pred, unname(test_pred))
   expect_true(res$.workflow[[1]]$trained)


### PR DESCRIPTION
This PR replaces deprecated functions so that they don't produce warnings (at this stage of the deprecation process: mostly in the tests of other packages)

* use `extract_parameter_set_dials()` instead of `parameters()`
* use `extract_fit_engine()` instead of `extract_model()`