### PR TITLE
use main pkg refs in `Remotes`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
     testthat (>= 3.0.0),
     xml2
 Remotes:
-    tidymodels/parsnip@feature/case-weights,
+    tidymodels/parsnip,
     tidymodels/workflows,  
     tidymodels/hardhat,
     tidymodels/yardstick


### PR DESCRIPTION
Now that case weights branches have been merged, we can use the `main` refs in `Remotes` across all repos. :) Currently seeing:

```
pkgs <- c("hardhat", "parsnip", "recipes",
          "modeldata", "tune", "workflows", "yardstick")
pkgs <- paste0("tidymodels/", pkgs)
pak::pak(pkgs)
#> Error: Cannot install packages:                                                  
#> * tidymodels/tune: Can't install dependency tidymodels/parsnip@feature/case-weights
#> * tidymodels/parsnip@feature/case-weights: Conflicts with tidymodels/parsnip
```