### PR TITLE
add checks for non-standard roles in recipes

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -324,15 +324,8 @@ check_workflow <- function(x, pset = NULL, check_dials = FALSE) {
           call = NULL
         )
       }
-
     }
-
-
-
-
-    x$pre$actions$recipe$blueprint$bake_dependent_roles
   }
-
 
   mod <- extract_spec_parsnip(x)
   check_installs(mod)


### PR DESCRIPTION
This PR will eventually close #494 

The checking code was adding inside `check_workflow()` which feels like a good fit. And it happens early, before any actual calculations take place.

It would be nice if there was an exported function in {recipes} that would return non-standard roles that we could use here.

Todo:

- [ ] Add documentation page
- [ ] Add tests
- [ ] make error message clearer


# Reprex

<details>
  <summary>fit_resamples</summary>

``` r
library(tidymodels)

rec_no_tune_1 <-
  recipe(mpg ~ ., data = mtcars) %>%
  update_role(disp, new_role = "id") %>%
  update_role(vs, new_role = "crazy") %>%
  step_normalize(all_predictors())

set.seed(363)
mt_folds <- vfold_cv(mtcars, v = 2)

tree_mod_no_tune <- decision_tree(min_n = 3) %>% 
  set_mode("regression") %>%
  set_engine("rpart")

# No blueprint
tree_wf_no_tune <- workflow() %>%
  add_recipe(rec_no_tune_1) %>%
  add_model(tree_mod_no_tune)

tree_wf_no_tune %>%
  fit_resamples(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ No blueprint were specfied for the recipe.
#> ℹ See ... for how for more information on how use non-standard recipe roles.

# Wrong blueprint - both
bp <- hardhat::default_recipe_blueprint(bake_dependent_roles = "happy")

tree_wf_no_tune <- workflow() %>%
  add_recipe(rec_no_tune_1, blueprint = bp) %>%
  add_model(tree_mod_no_tune)

tree_wf_no_tune %>%
  fit_resamples(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ A blueprint were specfied for the recipe.
#> ℹ But didn't have `bake_dependant_roles` correctly specified.

# Wrong blueprint - one
bp <- hardhat::default_recipe_blueprint(bake_dependent_roles = "id")

tree_wf_no_tune <- workflow() %>%
  add_recipe(rec_no_tune_1, blueprint = bp) %>%
  add_model(tree_mod_no_tune)

tree_wf_no_tune %>%
  fit_resamples(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ A blueprint were specfied for the recipe.
#> ℹ But didn't have `bake_dependant_roles` correctly specified.
```

</details>

<details>
  <summary>tune_grid</summary>

``` r
library(tidymodels)

rec_no_tune_1 <-
  recipe(mpg ~ ., data = mtcars) %>%
  update_role(disp, new_role = "id") %>%
  update_role(vs, new_role = "crazy") %>%
  step_normalize(all_predictors())

set.seed(363)
mt_folds <- vfold_cv(mtcars, v = 2)

tree_mod_no_tune <- decision_tree(min_n = 3) %>% 
  set_mode("regression") %>%
  set_engine("rpart")

tree_mod_tune <- tree_mod_no_tune %>% 
  set_args(tree_depth = tune())

# No blueprint
tree_wf_tune <- workflow() %>%
  add_recipe(rec_no_tune_1) %>%
  add_model(tree_mod_tune)

tree_wf_tune %>%
  tune_grid(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ No blueprint were specfied for the recipe.
#> ℹ See ... for how for more information on how use non-standard recipe roles.

# Wrong blueprint - both
bp <- hardhat::default_recipe_blueprint(bake_dependent_roles = "happy")

tree_wf_tune <- workflow() %>%
  add_recipe(rec_no_tune_1, blueprint = bp) %>%
  add_model(tree_mod_tune)

tree_wf_tune %>%
  tune_grid(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ A blueprint were specfied for the recipe.
#> ℹ But didn't have `bake_dependant_roles` correctly specified.

# Wrong blueprint - one
bp <- hardhat::default_recipe_blueprint(bake_dependent_roles = "id")

tree_wf_tune <- workflow() %>%
  add_recipe(rec_no_tune_1, blueprint = bp) %>%
  add_model(tree_mod_tune)

tree_wf_tune %>%
  tune_grid(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ A blueprint were specfied for the recipe.
#> ℹ But didn't have `bake_dependant_roles` correctly specified.
```

</details>

<details>
  <summary>tune_bayes</summary>

``` r
library(tidymodels)

rec_no_tune_1 <-
  recipe(mpg ~ ., data = mtcars) %>%
  update_role(disp, new_role = "id") %>%
  update_role(vs, new_role = "crazy") %>%
  step_normalize(all_predictors())

set.seed(363)
mt_folds <- vfold_cv(mtcars, v = 2)

tree_mod_no_tune <- decision_tree(min_n = 3) %>% 
  set_mode("regression") %>%
  set_engine("rpart")

tree_mod_tune <- tree_mod_no_tune %>% 
  set_args(tree_depth = tune())

# No blueprint
tree_wf_tune <- workflow() %>%
  add_recipe(rec_no_tune_1) %>%
  add_model(tree_mod_tune)

tree_wf_tune %>%
  tune_bayes(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ No blueprint were specfied for the recipe.
#> ℹ See ... for how for more information on how use non-standard recipe roles.

# Wrong blueprint - both
bp <- hardhat::default_recipe_blueprint(bake_dependent_roles = "happy")

tree_wf_tune <- workflow() %>%
  add_recipe(rec_no_tune_1, blueprint = bp) %>%
  add_model(tree_mod_tune)

tree_wf_tune %>%
  tune_bayes(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ A blueprint were specfied for the recipe.
#> ℹ But didn't have `bake_dependant_roles` correctly specified.

# Wrong blueprint - one
bp <- hardhat::default_recipe_blueprint(bake_dependent_roles = "id")

tree_wf_tune <- workflow() %>%
  add_recipe(rec_no_tune_1, blueprint = bp) %>%
  add_model(tree_mod_tune)

tree_wf_tune %>%
  tune_bayes(mt_folds)
#> Error:
#> ! The following columns in the recipe have non-standard roles: disp, and vs.
#> ℹ A blueprint were specfied for the recipe.
#> ℹ But didn't have `bake_dependant_roles` correctly specified.
```

</details>

