### PR TITLE
silence join warnings

### DIFF
--- a/R/min_grid.R
+++ b/R/min_grid.R
@@ -151,12 +151,12 @@ submod_and_others <- function(grid, fixed_args) {
     dplyr::ungroup()
 
   min_grid_df <-
-    dplyr::full_join(fit_only, grid, by = fixed_args) %>%
+    dplyr::full_join(fit_only, grid, by = fixed_args, multiple = "all") %>%
     dplyr::filter(..val != max_val) %>%
     dplyr::group_by(!!!rlang::syms(fixed_args)) %>%
     dplyr::summarize(.submodels = list(tibble::lst(!!subm_nm := ..val))) %>%
     dplyr::ungroup() %>%
-    dplyr::full_join(fit_only, by = fixed_args) %>%
+    dplyr::full_join(fit_only, by = fixed_args, multiple = "all") %>%
     dplyr::rename(!!subm_nm := max_val)
 
   min_grid_df$.submodels <-


### PR DESCRIPTION
Closes #528. Needs tidymodels/parsnip#772 as well:

``` r
library(tidymodels)

spec <- linear_reg(engine = "glmnet", penalty = tune(), mixture = tune())
rec <- recipe(mpg ~ ., data = mtcars)
res <- bootstraps(mtcars)

tune_grid(spec, rec, res, grid = cross_df(list(penalty = 10^(-6:-1), mixture = 1)))
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 25 × 4
#>    splits          id          .metrics          .notes          
#>    <list>          <chr>       <list>            <list>          
#>  1 <split [32/12]> Bootstrap01 <tibble [12 × 6]> <tibble [0 × 3]>
#>  2 <split [32/15]> Bootstrap02 <tibble [12 × 6]> <tibble [0 × 3]>
#>  3 <split [32/10]> Bootstrap03 <tibble [12 × 6]> <tibble [0 × 3]>
#>  4 <split [32/13]> Bootstrap04 <tibble [12 × 6]> <tibble [0 × 3]>
#>  5 <split [32/12]> Bootstrap05 <tibble [12 × 6]> <tibble [0 × 3]>
#>  6 <split [32/9]>  Bootstrap06 <tibble [12 × 6]> <tibble [0 × 3]>
#>  7 <split [32/11]> Bootstrap07 <tibble [12 × 6]> <tibble [0 × 3]>
#>  8 <split [32/10]> Bootstrap08 <tibble [12 × 6]> <tibble [0 × 3]>
#>  9 <split [32/12]> Bootstrap09 <tibble [12 × 6]> <tibble [0 × 3]>
#> 10 <split [32/11]> Bootstrap10 <tibble [12 × 6]> <tibble [0 × 3]>
#> # … with 15 more rows
#> # ℹ Use `print(n = ...)` to see more rows
```

<sup>Created on 2022-07-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>