### PR TITLE
refresh extraction docs in `tune_*` help-files

### DIFF
--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -141,11 +141,14 @@
 #'  retain any model or recipe that was created within the resamples. This
 #'  argument should be a function with a single argument. The value of the
 #'  argument that is given to the function in each resample is a workflow
-#'  object (see [workflows::workflow()] for more information). There are two
-#'  helper functions that can be used to easily pull out the recipe (if any)
-#'  and/or the model: [extract_recipe()] and [extract_model()].
+#'  object (see [workflows::workflow()] for more information). Several
+#'  helper functions can be used to easily pull out the preprocessing
+#'  and/or model information from the workflow, such as
+#'  [`extract_preprocessor()`][workflows::extract_preprocessor.workflow()] and
+#'  [`extract_fit_parsnip()`][workflows::extract_fit_parsnip.workflow()].
 #'
-#' As an example, if there is interest in getting each model back, one could use:
+#' As an example, if there is interest in getting each parsnip model fit back,
+#' one could use:
 #' \preformatted{
 #'   extract = function (x) extract_fit_parsnip(x)
 #' }

--- a/man/control_last_fit.Rd
+++ b/man/control_last_fit.Rd
@@ -20,26 +20,7 @@ of class prediction is made, and specifies which level of the outcome
 is considered the "event".}
 
 \item{allow_par}{A logical to allow parallel processing (if a parallel
-backend is registered).
-
-If \code{"resamples"}, then tuning will be performed in parallel over resamples
-alone. Within each resample, the preprocessor (i.e. recipe or formula) is
-processed once, and is then reused across all models that need to be fit.
-
-If \code{"everything"}, then tuning will be performed in parallel at two levels.
-An outer parallel loop will iterate over resamples. Additionally, an
-inner parallel loop will iterate over all unique combinations of
-preprocessor and model tuning parameters for that specific resample. This
-will result in the preprocessor being re-processed multiple times, but
-can be faster if that processing is extremely fast.
-
-If \code{NULL}, chooses \code{"resamples"} if there are more than one resample,
-otherwise chooses \code{"everything"} to attempt to maximize core utilization.
-
-Note that switching between \code{parallel_over} strategies is not guaranteed
-to use the same random number generation schemes. However, re-tuning a
-model using the same \code{parallel_over} strategy is guaranteed to be
-reproducible between runs.}
+backend is registered).}
 }
 \description{
 Control aspects of the last fit process

--- a/man/fit_resamples.Rd
+++ b/man/fit_resamples.Rd
@@ -119,11 +119,14 @@ The control function contains an option (\code{extract}) that can be used to
 retain any model or recipe that was created within the resamples. This
 argument should be a function with a single argument. The value of the
 argument that is given to the function in each resample is a workflow
-object (see \code{\link[workflows:workflow]{workflows::workflow()}} for more information). There are two
-helper functions that can be used to easily pull out the recipe (if any)
-and/or the model: \code{\link[=extract_recipe]{extract_recipe()}} and \code{\link[=extract_model]{extract_model()}}.
+object (see \code{\link[workflows:workflow]{workflows::workflow()}} for more information). Several
+helper functions can be used to easily pull out the preprocessing
+and/or model information from the workflow, such as
+\code{\link[workflows:extract-workflow]{extract_preprocessor()}} and
+\code{\link[workflows:extract-workflow]{extract_fit_parsnip()}}.
 
-As an example, if there is interest in getting each model back, one could use:
+As an example, if there is interest in getting each parsnip model fit back,
+one could use:
 \preformatted{
   extract = function (x) extract_fit_parsnip(x)
 }

--- a/man/tune_bayes.Rd
+++ b/man/tune_bayes.Rd
@@ -197,11 +197,14 @@ The control function contains an option (\code{extract}) that can be used to
 retain any model or recipe that was created within the resamples. This
 argument should be a function with a single argument. The value of the
 argument that is given to the function in each resample is a workflow
-object (see \code{\link[workflows:workflow]{workflows::workflow()}} for more information). There are two
-helper functions that can be used to easily pull out the recipe (if any)
-and/or the model: \code{\link[=extract_recipe]{extract_recipe()}} and \code{\link[=extract_model]{extract_model()}}.
+object (see \code{\link[workflows:workflow]{workflows::workflow()}} for more information). Several
+helper functions can be used to easily pull out the preprocessing
+and/or model information from the workflow, such as
+\code{\link[workflows:extract-workflow]{extract_preprocessor()}} and
+\code{\link[workflows:extract-workflow]{extract_fit_parsnip()}}.
 
-As an example, if there is interest in getting each model back, one could use:
+As an example, if there is interest in getting each parsnip model fit back,
+one could use:
 \preformatted{
   extract = function (x) extract_fit_parsnip(x)
 }

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -185,11 +185,14 @@ The control function contains an option (\code{extract}) that can be used to
 retain any model or recipe that was created within the resamples. This
 argument should be a function with a single argument. The value of the
 argument that is given to the function in each resample is a workflow
-object (see \code{\link[workflows:workflow]{workflows::workflow()}} for more information). There are two
-helper functions that can be used to easily pull out the recipe (if any)
-and/or the model: \code{\link[=extract_recipe]{extract_recipe()}} and \code{\link[=extract_model]{extract_model()}}.
+object (see \code{\link[workflows:workflow]{workflows::workflow()}} for more information). Several
+helper functions can be used to easily pull out the preprocessing
+and/or model information from the workflow, such as
+\code{\link[workflows:extract-workflow]{extract_preprocessor()}} and
+\code{\link[workflows:extract-workflow]{extract_fit_parsnip()}}.
 
-As an example, if there is interest in getting each model back, one could use:
+As an example, if there is interest in getting each parsnip model fit back,
+one could use:
 \preformatted{
   extract = function (x) extract_fit_parsnip(x)
 }


### PR DESCRIPTION
The documentation in the `Extracting Information` doc sections shared by `tune_*` functions currently refers to deprecated functions—this PR updates to refer to the updated `extract_*` functions!