### PR TITLE
re-route references for extraction functions from generic to `tune_results` methods

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -4,28 +4,35 @@
 #' These functions extract various elements from a tune object. If they do
 #' not exist yet, an error is thrown.
 #'
-#' - `extract_preprocessor()` returns the formula, recipe, or variable
+#' - [`extract_preprocessor()`][extract_preprocessor.tune_results()] returns
+#'   the formula, recipe, or variable
 #'   expressions used for preprocessing.
 #'
-#' - `extract_spec_parsnip()` returns the parsnip model specification.
+#' - [`extract_spec_parsnip()`][extract_spec_parsnip.tune_results()] returns
+#'   the parsnip model specification.
 #'
-#' - `extract_fit_parsnip()` returns the parsnip model fit object.
+#' - [`extract_fit_parsnip()`][extract_fit_parsnip.tune_results()] returns the
+#'   parsnip model fit object.
 #'
-#' - `extract_fit_engine()` returns the engine specific fit embedded within
+#' - [`extract_fit_engine()`][extract_fit_engine.tune_results()] returns the
+#'   engine specific fit embedded within
 #'   a parsnip model fit. For example, when using [parsnip::linear_reg()]
 #'   with the `"lm"` engine, this returns the underlying `lm` object.
 #'
-#' - `extract_mold()` returns the preprocessed "mold" object returned
+#' - [`extract_mold()`][extract_mold.tune_results()] returns the preprocessed
+#'   "mold" object returned
 #'   from [hardhat::mold()]. It contains information about the preprocessing,
 #'   including either the prepped recipe, the formula terms object, or
 #'   variable selectors.
 #'
-#' - `extract_recipe()` returns the recipe. The `estimated` argument specifies
-#'    whether the fitted or original recipe is returned.
+#' - [`extract_recipe()`][extract_recipe.tune_results()] returns the recipe.
+#'   The `estimated` argument specifies
+#'   whether the fitted or original recipe is returned.
 #'
-#' - `extract_workflow()` returns the workflow object if the control option
-#'    `save_workflow = TRUE` was used. The workflow will only have been
-#'    estimated for objects produced by [last_fit()].
+#' - [`extract_workflow()`][extract_workflow.tune_results()] returns the
+#'   workflow object if the control option
+#'   `save_workflow = TRUE` was used. The workflow will only have been
+#'   estimated for objects produced by [last_fit()].
 #'
 #' @param x A `tune_results` object.
 #' @param estimated A logical for whether the original (unfit) recipe or the

--- a/R/pull.R
+++ b/R/pull.R
@@ -221,7 +221,7 @@ extract_metrics_config <- function(param_names, metrics) {
 #'
 #' `r lifecycle::badge("soft-deprecated")`
 #'
-#' Use [extract_fit_engine()] instead of `extract_model()`.
+#' Use [`extract_fit_engine()`][extract_fit_engine.tune_results()] instead of `extract_model()`.
 #'
 #' When extracting the fitted results, the workflow is easily accessible. If
 #' there is only interest in the model, this functions can be used

--- a/man/control_last_fit.Rd
+++ b/man/control_last_fit.Rd
@@ -20,26 +20,7 @@ of class prediction is made, and specifies which level of the outcome
 is considered the "event".}
 
 \item{allow_par}{A logical to allow parallel processing (if a parallel
-backend is registered).
-
-If \code{"resamples"}, then tuning will be performed in parallel over resamples
-alone. Within each resample, the preprocessor (i.e. recipe or formula) is
-processed once, and is then reused across all models that need to be fit.
-
-If \code{"everything"}, then tuning will be performed in parallel at two levels.
-An outer parallel loop will iterate over resamples. Additionally, an
-inner parallel loop will iterate over all unique combinations of
-preprocessor and model tuning parameters for that specific resample. This
-will result in the preprocessor being re-processed multiple times, but
-can be faster if that processing is extremely fast.
-
-If \code{NULL}, chooses \code{"resamples"} if there are more than one resample,
-otherwise chooses \code{"everything"} to attempt to maximize core utilization.
-
-Note that switching between \code{parallel_over} strategies is not guaranteed
-to use the same random number generation schemes. However, re-tuning a
-model using the same \code{parallel_over} strategy is guaranteed to be
-reproducible between runs.}
+backend is registered).}
 }
 \description{
 Control aspects of the last fit process

--- a/man/extract-tune.Rd
+++ b/man/extract-tune.Rd
@@ -44,20 +44,27 @@ description section.
 These functions extract various elements from a tune object. If they do
 not exist yet, an error is thrown.
 \itemize{
-\item \code{extract_preprocessor()} returns the formula, recipe, or variable
+\item \code{\link[=extract_preprocessor.tune_results]{extract_preprocessor()}} returns
+the formula, recipe, or variable
 expressions used for preprocessing.
-\item \code{extract_spec_parsnip()} returns the parsnip model specification.
-\item \code{extract_fit_parsnip()} returns the parsnip model fit object.
-\item \code{extract_fit_engine()} returns the engine specific fit embedded within
+\item \code{\link[=extract_spec_parsnip.tune_results]{extract_spec_parsnip()}} returns
+the parsnip model specification.
+\item \code{\link[=extract_fit_parsnip.tune_results]{extract_fit_parsnip()}} returns the
+parsnip model fit object.
+\item \code{\link[=extract_fit_engine.tune_results]{extract_fit_engine()}} returns the
+engine specific fit embedded within
 a parsnip model fit. For example, when using \code{\link[parsnip:linear_reg]{parsnip::linear_reg()}}
 with the \code{"lm"} engine, this returns the underlying \code{lm} object.
-\item \code{extract_mold()} returns the preprocessed "mold" object returned
+\item \code{\link[=extract_mold.tune_results]{extract_mold()}} returns the preprocessed
+"mold" object returned
 from \code{\link[hardhat:mold]{hardhat::mold()}}. It contains information about the preprocessing,
 including either the prepped recipe, the formula terms object, or
 variable selectors.
-\item \code{extract_recipe()} returns the recipe. The \code{estimated} argument specifies
+\item \code{\link[=extract_recipe.tune_results]{extract_recipe()}} returns the recipe.
+The \code{estimated} argument specifies
 whether the fitted or original recipe is returned.
-\item \code{extract_workflow()} returns the workflow object if the control option
+\item \code{\link[=extract_workflow.tune_results]{extract_workflow()}} returns the
+workflow object if the control option
 \code{save_workflow = TRUE} was used. The workflow will only have been
 estimated for objects produced by \code{\link[=last_fit]{last_fit()}}.
 }

--- a/man/extract_model.Rd
+++ b/man/extract_model.Rd
@@ -16,7 +16,7 @@ A fitted model.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#soft-deprecated}{\figure{lifecycle-soft-deprecated.svg}{options: alt='[Soft-deprecated]'}}}{\strong{[Soft-deprecated]}}
 }
 \details{
-Use \code{\link[=extract_fit_engine]{extract_fit_engine()}} instead of \code{extract_model()}.
+Use \code{\link[=extract_fit_engine.tune_results]{extract_fit_engine()}} instead of \code{extract_model()}.
 
 When extracting the fitted results, the workflow is easily accessible. If
 there is only interest in the model, this functions can be used


### PR DESCRIPTION
Taken together with #555, closes #407. :)