### PR TITLE
add a line ending to printed notes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * The `control_last_fit()` function gained an argument `allow_par` that defaults to `FALSE`. This change addresses failures after `last_fit()` using modeling engines that require native serialization, and we anticipate little to no increase in time-to-fit resulting from this change. (#539, tidymodels/bonsai#52)
 
+* `show_notes()` does a better jobs of... showing notes. 
+
 # tune 1.0.0
 
 * `show_notes()` is a new function that can better help understand warnings and errors. 

--- a/R/tune_results.R
+++ b/R/tune_results.R
@@ -156,9 +156,9 @@ show_notes <- function(x, n = 10) {
   max_width <- min(max_width, cli::console_width())
 
   notes <-  paste(cli::rule(width = max_width), notes, sep = "\n")
-  notes <-  paste(notes, "\n")
+  notes <-  paste0(notes, "\n")
   cat(msg)
-  cat(notes)
+  cat(notes, sep = "")
   invisible(x)
 }
 

--- a/R/tune_results.R
+++ b/R/tune_results.R
@@ -156,6 +156,7 @@ show_notes <- function(x, n = 10) {
   max_width <- min(max_width, cli::console_width())
 
   notes <-  paste(cli::rule(width = max_width), notes, sep = "\n")
+  notes <-  paste(notes, "\n")
   cat(msg)
   cat(notes)
   invisible(x)

--- a/tests/testthat/_snaps/notes.md
+++ b/tests/testthat/_snaps/notes.md
@@ -45,7 +45,7 @@
       unique notes:
       --------------------------------------------------------------------------------
       Error in `step_date()`:
-      ! The following required column is missing from `new_data` in step 'step_date': date. 
+      ! The following required column is missing from `new_data` in step 'step_date': date.
 
 ---
 
@@ -70,7 +70,7 @@
     Output
       unique notes:
       ------------------------------------------------------
-      prediction from a rank-deficient fit may be misleading 
+      prediction from a rank-deficient fit may be misleading
 
 ---
 
@@ -82,11 +82,38 @@
 ---
 
     Code
+      fit_lr <- parsnip::logistic_reg() %>% fit_resamples(class ~ ., rs)
+    Message
+      ! Fold01: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge
+      ! Fold02: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold02: internal: No control observations were detected in `truth` with control level 'cla...
+      ! Fold03: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold03: internal: No control observations were detected in `truth` with control level 'cla...
+      ! Fold04: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold04: internal: No control observations were detected in `truth` with control level 'cla...
+      ! Fold05: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold05: internal: No control observations were detected in `truth` with control level 'cla...
+      ! Fold06: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold06: internal: No control observations were detected in `truth` with control level 'cla...
+      ! Fold07: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold07: internal: No control observations were detected in `truth` with control level 'cla...
+      ! Fold08: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold08: internal: No control observations were detected in `truth` with control level 'cla...
+      ! Fold09: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold09: internal: No control observations were detected in `truth` with control level 'cla...
+      ! Fold10: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
+      ! Fold10: internal: No control observations were detected in `truth` with control level 'cla...
+
+---
+
+    Code
       show_notes(fit_lr)
     Output
       unique notes:
       -----------------------------------
-      glm.fit: algorithm did not converge 
-       -----------------------------------
-      glm.fit: algorithm did not converge, glm.fit: fitted probabilities numerically 0 or 1 occurred 
+      glm.fit: algorithm did not converge
+      -----------------------------------
+      glm.fit: algorithm did not converge, glm.fit: fitted probabilities numerically 0 or 1 occurred
+      -----------------------------------
+      No control observations were detected in `truth` with control level 'class_2'.
 

--- a/tests/testthat/_snaps/notes.md
+++ b/tests/testthat/_snaps/notes.md
@@ -45,7 +45,7 @@
       unique notes:
       --------------------------------------------------------------------------------
       Error in `step_date()`:
-      ! The following required column is missing from `new_data` in step 'step_date': date.
+      ! The following required column is missing from `new_data` in step 'step_date': date. 
 
 ---
 
@@ -70,7 +70,7 @@
     Output
       unique notes:
       ------------------------------------------------------
-      prediction from a rank-deficient fit may be misleading
+      prediction from a rank-deficient fit may be misleading 
 
 ---
 
@@ -78,4 +78,15 @@
       show_notes(.Last.tune.result)
     Output
       Great job! No notes to show.
+
+---
+
+    Code
+      show_notes(fit_lr)
+    Output
+      unique notes:
+      -----------------------------------
+      glm.fit: algorithm did not converge 
+       -----------------------------------
+      glm.fit: algorithm did not converge, glm.fit: fitted probabilities numerically 0 or 1 occurred 
 

--- a/tests/testthat/test-notes.R
+++ b/tests/testthat/test-notes.R
@@ -59,13 +59,11 @@ test_that("showing notes", {
   set.seed(1)
   dat <- modeldata::sim_classification(150, intercept = 15)
   rs <- rsample::vfold_cv(dat)
-  fit_lr <-
-    parsnip::logistic_reg() %>%
-    fit_resamples(
-      class ~ .,
-      rs,
-      metrics = yardstick::metric_set(accuracy, kap, recall, precision)
-    )
+  expect_snapshot(
+    fit_lr <-
+      parsnip::logistic_reg() %>%
+      fit_resamples(class ~ ., rs)
+  )
   expect_snapshot(show_notes(fit_lr))
 
 })

--- a/tests/testthat/test-notes.R
+++ b/tests/testthat/test-notes.R
@@ -3,6 +3,7 @@ library(dplyr)
 library(recipes)
 library(parsnip)
 library(rsample)
+library(yardstick)
 
 test_that("showing notes", {
   skip_if_not_installed("modeldata")
@@ -52,6 +53,19 @@ test_that("showing notes", {
     add_recipe(clean_rec)
 
   res_clean <- clean_wflow %>% fit_resamples(rs)
-  expect_snapshot(show_notes(.Last.tune.result
-                             ))
+  expect_snapshot(show_notes(.Last.tune.result))
+
+  # Get cli lines right
+  set.seed(1)
+  dat <- modeldata::sim_classification(150, intercept = 15)
+  rs <- rsample::vfold_cv(dat)
+  fit_lr <-
+    parsnip::logistic_reg() %>%
+    fit_resamples(
+      class ~ .,
+      rs,
+      metrics = yardstick::metric_set(accuracy, kap, recall, precision)
+    )
+  expect_snapshot(show_notes(fit_lr))
+
 })


### PR DESCRIPTION
For some notes, `show_notes()` would not properly break the lines: 

``` r
library(tidymodels)
set.seed(1)
dat <- sim_classification(150, intercept = 15)
rs <- vfold_cv(dat)
fit_lr <- 
  logistic_reg() %>% 
  fit_resamples(
  class ~ .,
  rs,
  metrics = metric_set(accuracy, kap, recall, precision)
)
#> ! Fold01: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge
#> ! Fold02: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold03: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold04: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold05: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold06: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold07: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold08: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold09: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold10: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
show_notes(fit_lr)
#> unique notes:
#> ───────────────────────────────────
#> glm.fit: algorithm did not converge ───────────────────────────────────
#> glm.fit: algorithm did not converge, glm.fit: fitted probabilities numerically 0 or 1 occurred
```

<sup>Created on 2022-09-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

For this new version:

``` r
library(tidymodels)
set.seed(1)
dat <- sim_classification(150, intercept = 15)
rs <- vfold_cv(dat)
fit_lr <- 
  logistic_reg() %>% 
  fit_resamples(
  class ~ .,
  rs,
  metrics = metric_set(accuracy, kap, recall, precision)
)
#> ! Fold01: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge
#> ! Fold02: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold03: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold04: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold05: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold06: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold07: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold08: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold09: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
#> ! Fold10: preprocessor 1/1, model 1/1: glm.fit: algorithm did not converge, glm.fit: fitted probabilities numer...
show_notes(fit_lr)
#> unique notes:
#> ───────────────────────────────────
#> glm.fit: algorithm did not converge 
#>  ───────────────────────────────────
#> glm.fit: algorithm did not converge, glm.fit: fitted probabilities numerically 0 or 1 occurred
```

<sup>Created on 2022-09-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>