### PR TITLE
use getter to extract condition message

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -538,7 +538,7 @@ super_safely <- function(fn) {
 
   # Construct a try()-error to be compatible with `log_problems()`
   handle_error <- function(e) {
-    e <- structure(e$message, class = "try-error", condition = e)
+    e <- structure(conditionMessage(e), class = "try-error", condition = e)
     list(result = NULL, error = e, warnings = warnings)
   }
 

--- a/R/logging.R
+++ b/R/logging.R
@@ -120,7 +120,7 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
 
   wrn <- res$signals
   if (length(wrn) > 0) {
-    wrn_msg <- purrr::map_chr(wrn, ~ .x$message)
+    wrn_msg <- purrr::map_chr(wrn, ~conditionMessage(.x))
     wrn_msg <- unique(wrn_msg)
     wrn_msg <- paste(wrn_msg, collapse = ", ")
 


### PR DESCRIPTION
Instead of subsetting conditions with `$`, this PR proposes using `conditionMessage` to retrieve the message from errors/warnings. The `$message` slot can be a vector of arbitrary length, while `conditionMessage` will collapse messages to length 1. 

[EDIT: no new issues in finetune as a result of this PR.]