### PR TITLE
correct sorting in `select_by_pct_loss()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* Fixed bug in `select_by_pct_loss()` where the model with the greatest loss within the limit was returned rather than the most simple model whose loss was within the limit. (#543)
+
 # tune 1.0.1
 
 * `last_fit()`, `fit_resamples()`, `tune_grid()`, and `tune_bayes()` do not automatically error if  the wrong type of `control` object is passed. If the passed control object is not a superset of the one that is needed, the function will still error. As an example, passing `control_grid()` to `tune_bayes()` will fail but passing `control_bayes()` to `tune_grid()` will not. ([#449](https://github.com/tidymodels/tune/issues/449))

--- a/R/select_best.R
+++ b/R/select_best.R
@@ -210,12 +210,12 @@ select_by_pct_loss.tune_results <- function(x, ..., metric = NULL, limit = 2) {
     rlang::abort(msg)
   }
 
-  # discard models more complex than the best then rank by loss
+  # discard models more complex than the best and
+  # remove models with greater increase in loss than the limit
   best_index <- which(res$.loss == 0)
   res %>%
     dplyr::slice(1:best_index) %>%
     dplyr::filter(.loss < limit) %>%
-    dplyr::arrange(desc(.loss)) %>%
     dplyr::slice(1)
 }
 

--- a/tests/testthat/test-select_best.R
+++ b/tests/testthat/test-select_best.R
@@ -212,4 +212,10 @@ test_that("percent loss", {
   expect_snapshot(error = TRUE, {
     select_by_pct_loss(mtcars, metric = "disp")
   })
+
+  data("example_ames_knn")
+  expect_equal(
+    select_by_pct_loss(ames_grid_search, metric = "rmse", limit = 10, desc(K))$K,
+    40
+  )
 })


### PR DESCRIPTION
This PR fixes a bug in `select_by_pct_loss()` where the model with the greatest loss within the limit was returned rather than the most simple model whose loss was within the limit. Closes #543!

Maybe unsurprisingly, in all of the existing tests, the most simple model within the loss limit also happened to have the greatest loss, so this change introduced no new test failures. I thus added a test a la the reprex in the original issue to make sure we check this case. :)