### PR TITLE
audit usages of `\donttest`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,12 +40,15 @@ Imports:
     workflows (>= 1.0.0),
     yardstick (>= 1.0.0)
 Suggests: 
+    C50,
     covr,
     kernlab,
+    kknn,
     knitr,
     modeldata,
     spelling,
     testthat (>= 3.0.0),
+    xgboost,
     xml2
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate

--- a/R/collect.R
+++ b/R/collect.R
@@ -46,8 +46,7 @@
 #' [collect_notes()] returns a tibble with columns for the resampling
 #' indicators, the location (preprocessor, model, etc.), type (error or warning),
 #' and the notes.
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples(suggests = "kknn"))
 #' data("example_ames_knn")
 #' # The parameters for the model:
 #' extract_parameter_set_dials(ames_wflow)
@@ -85,7 +84,6 @@
 #' collect_predictions(resampled) %>% arrange(.row)
 #' collect_predictions(resampled, summarize = TRUE) %>% arrange(.row)
 #' collect_predictions(resampled, summarize = TRUE, grid[1, ]) %>% arrange(.row)
-#' }
 #' @export
 collect_predictions <- function(x, ...) {
   UseMethod("collect_predictions")

--- a/R/collect.R
+++ b/R/collect.R
@@ -46,7 +46,7 @@
 #' [collect_notes()] returns a tibble with columns for the resampling
 #' indicators, the location (preprocessor, model, etc.), type (error or warning),
 #' and the notes.
-#' @examplesIf (tune:::should_run_examples(suggests = "kknn"))
+#' @examplesIf tune:::should_run_examples(suggests = "kknn")
 #' data("example_ames_knn")
 #' # The parameters for the model:
 #' extract_parameter_set_dials(ames_wflow)

--- a/R/expo_decay.R
+++ b/R/expo_decay.R
@@ -14,7 +14,7 @@
 #' @param slope A coefficient for the exponent to control the rate of decay. The
 #'  sign of the slope controls the direction of decay.
 #' @return A single numeric value.
-#' @examplesIf (tune:::should_run_examples())
+#' @examplesIf tune:::should_run_examples()
 #' library(tibble)
 #' library(purrr)
 #' library(ggplot2)

--- a/R/expo_decay.R
+++ b/R/expo_decay.R
@@ -14,8 +14,7 @@
 #' @param slope A coefficient for the exponent to control the rate of decay. The
 #'  sign of the slope controls the direction of decay.
 #' @return A single numeric value.
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples())
 #' library(tibble)
 #' library(purrr)
 #' library(ggplot2)
@@ -32,7 +31,6 @@
 #' ) %>%
 #'   ggplot(aes(x = iter, y = value)) +
 #'   geom_path()
-#' }
 #' @export
 expo_decay <- function(iter, start_val, limit_val, slope = 1 / 5) {
   # between 0:1

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -10,8 +10,7 @@
 #'  this case, the parameter tibble should be "K" and not "neighbors".
 #' @return An updated version of `x`.
 #' @export
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples(suggests = "kknn"))
 #' data("example_ames_knn")
 #'
 #' library(parsnip)
@@ -29,7 +28,6 @@
 #'
 #' knn_model
 #' finalize_model(knn_model, lowest_rmse)
-#' }
 finalize_model <- function(x, parameters) {
   if (!inherits(x, "model_spec")) {
     rlang::abort("`x` should be a parsnip model specification.")

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -10,7 +10,7 @@
 #'  this case, the parameter tibble should be "K" and not "neighbors".
 #' @return An updated version of `x`.
 #' @export
-#' @examplesIf (tune:::should_run_examples(suggests = "kknn"))
+#' @examplesIf tune:::should_run_examples(suggests = "kknn")
 #' data("example_ames_knn")
 #'
 #' library(parsnip)

--- a/R/last_fit.R
+++ b/R/last_fit.R
@@ -28,8 +28,7 @@
 #' @return A single row tibble that emulates the structure of `fit_resamples()`.
 #' However, a list column called `.workflow` is also attached with the fitted
 #' model (and recipe, if any) that used the training set.
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples())
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)
@@ -58,7 +57,6 @@
 #'   add_model(lin_mod)
 #'
 #' last_fit(spline_wfl, split = tr_te_split)
-#' }
 #' @export
 last_fit <- function(object, ...) {
   UseMethod("last_fit")

--- a/R/last_fit.R
+++ b/R/last_fit.R
@@ -28,7 +28,7 @@
 #' @return A single row tibble that emulates the structure of `fit_resamples()`.
 #' However, a list column called `.workflow` is also attached with the fitted
 #' model (and recipe, if any) that used the training set.
-#' @examplesIf (tune:::should_run_examples())
+#' @examplesIf tune:::should_run_examples()
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)

--- a/R/merge.R
+++ b/R/merge.R
@@ -13,7 +13,7 @@
 #'
 #' @return A tibble with a column `x` that has as many rows as were in `y`.
 #' @keywords internal
-#' @examplesIf (tune:::should_run_examples(suggests = c("xgboost", "modeldata")))
+#' @examplesIf tune:::should_run_examples(suggests = c("xgboost", "modeldata"))
 #' library(tibble)
 #' library(recipes)
 #' library(parsnip)

--- a/R/merge.R
+++ b/R/merge.R
@@ -13,10 +13,11 @@
 #'
 #' @return A tibble with a column `x` that has as many rows as were in `y`.
 #' @keywords internal
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples(suggests = c("xgboost", "modeldata")))
 #' library(tibble)
 #' library(recipes)
+#' library(parsnip)
+#' library(dials)
 #'
 #' pca_rec <-
 #'   recipe(mpg ~ ., data = mtcars) %>%
@@ -50,24 +51,19 @@
 #'
 #' merge(pca_rec, pca_grid)
 #'
-#' if (rlang::is_installed("modeldata")) {
-#'   library(parsnip)
-#'   library(dials)
-#'   data(hpc_data, package = "modeldata")
+#' data(hpc_data, package = "modeldata")
 #'
-#'   xgb_mod <-
-#'     boost_tree(trees = tune(), min_n = tune()) %>%
-#'     set_engine("xgboost")
+#' xgb_mod <-
+#'   boost_tree(trees = tune(), min_n = tune()) %>%
+#'   set_engine("xgboost")
 #'
-#'   set.seed(254)
-#'   xgb_grid <-
-#'     extract_parameter_set_dials(xgb_mod) %>%
-#'     finalize(hpc_data) %>%
-#'     grid_max_entropy(size = 3)
+#' set.seed(254)
+#' xgb_grid <-
+#'   extract_parameter_set_dials(xgb_mod) %>%
+#'   finalize(hpc_data) %>%
+#'   grid_max_entropy(size = 3)
 #'
-#'   merge(xgb_mod, xgb_grid)
-#' }
-#' }
+#' merge(xgb_mod, xgb_grid)
 #' @export
 merge.recipe <- function(x, y, ...) {
   merger(x, y, ...)

--- a/R/param_set.workflows.R
+++ b/R/param_set.workflows.R
@@ -10,7 +10,7 @@
 #' @param x An object
 #' @param ... Not currently used.
 #' @return A parameter set object
-#' @examplesIf (tune:::should_run_examples(suggests = c("xgboost", "C5.0")))
+#' @examplesIf tune:::should_run_examples(suggests = c("xgboost", "C5.0"))
 #' library(tibble)
 #' library(recipes)
 #'

--- a/R/param_set.workflows.R
+++ b/R/param_set.workflows.R
@@ -10,8 +10,7 @@
 #' @param x An object
 #' @param ... Not currently used.
 #' @return A parameter set object
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples(suggests = c("xgboost", "C5.0")))
 #' library(tibble)
 #' library(recipes)
 #'
@@ -41,7 +40,6 @@
 #' boost_tree(trees = tune(), min_n = tune()) %>%
 #'   set_engine("C5.0", rules = TRUE) %>%
 #'   dials::parameters()
-#' }
 #'
 #' @keywords internal
 #' @export

--- a/R/plots.R
+++ b/R/plots.R
@@ -51,7 +51,7 @@
 #' _except_ when an identifier was used (e.g. `neighbors = tune("K")`).
 #'
 #' @seealso [tune_grid()], [tune_bayes()]
-#' @examplesIf (tune:::should_run_examples())
+#' @examplesIf tune:::should_run_examples()
 #' # For grid search:
 #' data("example_ames_knn")
 #'

--- a/R/plots.R
+++ b/R/plots.R
@@ -51,8 +51,7 @@
 #' _except_ when an identifier was used (e.g. `neighbors = tune("K")`).
 #'
 #' @seealso [tune_grid()], [tune_bayes()]
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples())
 #' # For grid search:
 #' data("example_ames_knn")
 #'
@@ -69,7 +68,6 @@
 #'
 #' # Plot performance over iterations
 #' autoplot(ames_iter_search, metric = "rmse", type = "performance")
-#' }
 #' @export
 autoplot.tune_results <-
   function(object,

--- a/R/resample.R
+++ b/R/resample.R
@@ -17,7 +17,7 @@
 #' @inheritSection tune_grid Obtaining Predictions
 #' @inheritSection tune_grid Extracting Information
 #' @seealso [control_resamples()], [collect_predictions()], [collect_metrics()]
-#' @examplesIf (tune:::should_run_examples())
+#' @examplesIf tune:::should_run_examples()
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)

--- a/R/resample.R
+++ b/R/resample.R
@@ -17,8 +17,7 @@
 #' @inheritSection tune_grid Obtaining Predictions
 #' @inheritSection tune_grid Extracting Information
 #' @seealso [control_resamples()], [collect_predictions()], [collect_metrics()]
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples())
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)
@@ -51,7 +50,6 @@
 #'   add_model(lin_mod)
 #'
 #' wf_res <- fit_resamples(wf, folds)
-#' }
 #' @export
 fit_resamples <- function(object, ...) {
   UseMethod("fit_resamples")

--- a/R/select_best.R
+++ b/R/select_best.R
@@ -37,8 +37,7 @@
 #' @references
 #' Breiman, Leo; Friedman, J. H.; Olshen, R. A.; Stone, C. J. (1984).
 #' _Classification and Regression Trees._ Monterey, CA: Wadsworth.
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples())
 #' data("example_ames_knn")
 #'
 #' show_best(ames_iter_search, metric = "rmse")
@@ -58,7 +57,6 @@
 #'   metric = "rmse",
 #'   limit = 5, desc(K)
 #' )
-#' }
 #' @export
 show_best <- function(x, ...) {
   UseMethod("show_best")

--- a/R/select_best.R
+++ b/R/select_best.R
@@ -37,7 +37,7 @@
 #' @references
 #' Breiman, Leo; Friedman, J. H.; Olshen, R. A.; Stone, C. J. (1984).
 #' _Classification and Regression Trees._ Monterey, CA: Wadsworth.
-#' @examplesIf (tune:::should_run_examples())
+#' @examplesIf tune:::should_run_examples()
 #' data("example_ames_knn")
 #'
 #' show_best(ames_iter_search, metric = "rmse")

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -127,7 +127,7 @@
 #'
 #' @inheritSection tune_grid Extracting Information
 #'
-#' @examplesIf (tune:::should_run_examples(suggests = "kernlab"))
+#' @examplesIf tune:::should_run_examples(suggests = "kernlab")
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -158,7 +158,7 @@
 #' As noted above, in some cases, model predictions can be derived for
 #'  sub-models so that, in these cases, not every row in the tuning parameter
 #'  grid has a separate R object associated with it.
-#' @examplesIf (tune:::should_run_examples(suggests = "kernlab"))
+#' @examplesIf tune:::should_run_examples(suggests = "kernlab")
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -158,8 +158,7 @@
 #' As noted above, in some cases, model predictions can be derived for
 #'  sub-models so that, in these cases, not every row in the tuning parameter
 #'  grid has a separate R object associated with it.
-#' @examples
-#' \donttest{
+#' @examplesIf (tune:::should_run_examples(suggests = "kernlab"))
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)
@@ -233,7 +232,6 @@
 #'
 #' set.seed(3254)
 #' svm_res_wf <- tune_grid(wf, resamples = folds, grid = 7)
-#' }
 #' @export
 tune_grid <- function(object, ...) {
   UseMethod("tune_grid")

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,7 +49,7 @@ is_cran_check <- function() {
 
 # suggests: a character vector of package names, giving packages
 #           listed in Suggests that are needed for the example.
-# for use a la `@examplesIf (tune:::should_run_examples())`
+# for use a la `@examplesIf tune:::should_run_examples()`
 should_run_examples <- function(suggests = NULL) {
   has_needed_installs <- TRUE
 

--- a/man/autoplot.tune_results.Rd
+++ b/man/autoplot.tune_results.Rd
@@ -74,7 +74,7 @@ Parameters are labeled using the labels found in the parameter object
 }
 }
 \examples{
-\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # For grid search:
 data("example_ames_knn")
 

--- a/man/autoplot.tune_results.Rd
+++ b/man/autoplot.tune_results.Rd
@@ -74,7 +74,7 @@ Parameters are labeled using the labels found in the parameter object
 }
 }
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # For grid search:
 data("example_ames_knn")
 
@@ -91,7 +91,7 @@ autoplot(ames_iter_search, metric = "rmse", type = "parameters")
 
 # Plot performance over iterations
 autoplot(ames_iter_search, metric = "rmse", type = "performance")
-}
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=tune_grid]{tune_grid()}}, \code{\link[=tune_bayes]{tune_bayes()}}

--- a/man/collect_predictions.Rd
+++ b/man/collect_predictions.Rd
@@ -80,7 +80,7 @@ and the notes.
 Obtain and format results produced by tuning functions
 }
 \examples{
-\dontshow{if ((tune:::should_run_examples(suggests = "kknn"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples(suggests = "kknn")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data("example_ames_knn")
 # The parameters for the model:
 extract_parameter_set_dials(ames_wflow)

--- a/man/collect_predictions.Rd
+++ b/man/collect_predictions.Rd
@@ -80,7 +80,7 @@ and the notes.
 Obtain and format results produced by tuning functions
 }
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples(suggests = "kknn"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data("example_ames_knn")
 # The parameters for the model:
 extract_parameter_set_dials(ames_wflow)
@@ -118,5 +118,5 @@ resampled <-
 collect_predictions(resampled) \%>\% arrange(.row)
 collect_predictions(resampled, summarize = TRUE) \%>\% arrange(.row)
 collect_predictions(resampled, summarize = TRUE, grid[1, ]) \%>\% arrange(.row)
-}
+\dontshow{\}) # examplesIf}
 }

--- a/man/expo_decay.Rd
+++ b/man/expo_decay.Rd
@@ -30,7 +30,7 @@ would be required since only the first argument would be evaluated during
 tuning.
 }
 \examples{
-\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(tibble)
 library(purrr)
 library(ggplot2)

--- a/man/expo_decay.Rd
+++ b/man/expo_decay.Rd
@@ -30,7 +30,7 @@ would be required since only the first argument would be evaluated during
 tuning.
 }
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(tibble)
 library(purrr)
 library(ggplot2)
@@ -47,5 +47,5 @@ tibble(
 ) \%>\%
   ggplot(aes(x = iter, y = value)) +
   geom_path()
-}
+\dontshow{\}) # examplesIf}
 }

--- a/man/finalize_model.Rd
+++ b/man/finalize_model.Rd
@@ -28,7 +28,7 @@ The \verb{finalize_*} functions take a list or tibble of tuning parameter values
 update objects with those values.
 }
 \examples{
-\dontshow{if ((tune:::should_run_examples(suggests = "kknn"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples(suggests = "kknn")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data("example_ames_knn")
 
 library(parsnip)

--- a/man/finalize_model.Rd
+++ b/man/finalize_model.Rd
@@ -28,7 +28,7 @@ The \verb{finalize_*} functions take a list or tibble of tuning parameter values
 update objects with those values.
 }
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples(suggests = "kknn"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data("example_ames_knn")
 
 library(parsnip)
@@ -46,5 +46,5 @@ lowest_rmse
 
 knn_model
 finalize_model(knn_model, lowest_rmse)
-}
+\dontshow{\}) # examplesIf}
 }

--- a/man/fit_resamples.Rd
+++ b/man/fit_resamples.Rd
@@ -139,7 +139,7 @@ grid has a separate R object associated with it.
 }
 
 \examples{
-\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)

--- a/man/fit_resamples.Rd
+++ b/man/fit_resamples.Rd
@@ -139,7 +139,7 @@ grid has a separate R object associated with it.
 }
 
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)
@@ -172,7 +172,7 @@ wf <- workflow() \%>\%
   add_model(lin_mod)
 
 wf_res <- fit_resamples(wf, folds)
-}
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=control_resamples]{control_resamples()}}, \code{\link[=collect_predictions]{collect_predictions()}}, \code{\link[=collect_metrics]{collect_metrics()}}

--- a/man/last_fit.Rd
+++ b/man/last_fit.Rd
@@ -53,7 +53,7 @@ would be to fit using the entire training set and verify performance using
 the test data.
 }
 \examples{
-\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)

--- a/man/last_fit.Rd
+++ b/man/last_fit.Rd
@@ -53,7 +53,7 @@ would be to fit using the entire training set and verify performance using
 the test data.
 }
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)
@@ -82,5 +82,5 @@ spline_wfl <-
   add_model(lin_mod)
 
 last_fit(spline_wfl, split = tr_te_split)
-}
+\dontshow{\}) # examplesIf}
 }

--- a/man/merge.recipe.Rd
+++ b/man/merge.recipe.Rd
@@ -26,7 +26,7 @@ A tibble with a column \code{x} that has as many rows as were in \code{y}.
 \pkg{parsnip} model or recipe.
 }
 \examples{
-\dontshow{if ((tune:::should_run_examples(suggests = c("xgboost", "modeldata")))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples(suggests = c("xgboost", "modeldata"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(tibble)
 library(recipes)
 library(parsnip)

--- a/man/merge.recipe.Rd
+++ b/man/merge.recipe.Rd
@@ -26,9 +26,11 @@ A tibble with a column \code{x} that has as many rows as were in \code{y}.
 \pkg{parsnip} model or recipe.
 }
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples(suggests = c("xgboost", "modeldata")))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(tibble)
 library(recipes)
+library(parsnip)
+library(dials)
 
 pca_rec <-
   recipe(mpg ~ ., data = mtcars) \%>\%
@@ -62,23 +64,19 @@ spline_grid <-
 
 merge(pca_rec, pca_grid)
 
-if (rlang::is_installed("modeldata")) {
-  library(parsnip)
-  library(dials)
-  data(hpc_data, package = "modeldata")
+data(hpc_data, package = "modeldata")
 
-  xgb_mod <-
-    boost_tree(trees = tune(), min_n = tune()) \%>\%
-    set_engine("xgboost")
+xgb_mod <-
+  boost_tree(trees = tune(), min_n = tune()) \%>\%
+  set_engine("xgboost")
 
-  set.seed(254)
-  xgb_grid <-
-    extract_parameter_set_dials(xgb_mod) \%>\%
-    finalize(hpc_data) \%>\%
-    grid_max_entropy(size = 3)
+set.seed(254)
+xgb_grid <-
+  extract_parameter_set_dials(xgb_mod) \%>\%
+  finalize(hpc_data) \%>\%
+  grid_max_entropy(size = 3)
 
-  merge(xgb_mod, xgb_grid)
-}
-}
+merge(xgb_mod, xgb_grid)
+\dontshow{\}) # examplesIf}
 }
 \keyword{internal}

--- a/man/parameters.workflow.Rd
+++ b/man/parameters.workflow.Rd
@@ -29,7 +29,7 @@ These methods extend the generic \code{\link[dials:parameters]{dials::parameters
 complex objects, such as recipes, model specifications, and workflows.
 }
 \examples{
-\dontshow{if ((tune:::should_run_examples(suggests = c("xgboost", "C5.0")))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples(suggests = c("xgboost", "C5.0"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(tibble)
 library(recipes)
 

--- a/man/parameters.workflow.Rd
+++ b/man/parameters.workflow.Rd
@@ -29,7 +29,7 @@ These methods extend the generic \code{\link[dials:parameters]{dials::parameters
 complex objects, such as recipes, model specifications, and workflows.
 }
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples(suggests = c("xgboost", "C5.0")))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(tibble)
 library(recipes)
 
@@ -59,7 +59,6 @@ boost_tree(trees = tune(), min_n = tune()) \%>\%
 boost_tree(trees = tune(), min_n = tune()) \%>\%
   set_engine("C5.0", rules = TRUE) \%>\%
   dials::parameters()
-}
-
+\dontshow{\}) # examplesIf}
 }
 \keyword{internal}

--- a/man/show_best.Rd
+++ b/man/show_best.Rd
@@ -84,7 +84,7 @@ model has an RMSE of 1. The percent loss would be \code{(1.00 - 0.75)/1.00 * 100
 or 25 percent. Note that loss will always be non-negative.
 }
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data("example_ames_knn")
 
 show_best(ames_iter_search, metric = "rmse")
@@ -104,7 +104,7 @@ select_by_pct_loss(
   metric = "rmse",
   limit = 5, desc(K)
 )
-}
+\dontshow{\}) # examplesIf}
 }
 \references{
 Breiman, Leo; Friedman, J. H.; Olshen, R. A.; Stone, C. J. (1984).

--- a/man/show_best.Rd
+++ b/man/show_best.Rd
@@ -84,7 +84,7 @@ model has an RMSE of 1. The percent loss would be \code{(1.00 - 0.75)/1.00 * 100
 or 25 percent. Note that loss will always be non-negative.
 }
 \examples{
-\dontshow{if ((tune:::should_run_examples())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data("example_ames_knn")
 
 show_best(ames_iter_search, metric = "rmse")

--- a/man/tune_bayes.Rd
+++ b/man/tune_bayes.Rd
@@ -217,7 +217,7 @@ grid has a separate R object associated with it.
 }
 
 \examples{
-\dontshow{if ((tune:::should_run_examples(suggests = "kernlab"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples(suggests = "kernlab")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -205,7 +205,7 @@ grid has a separate R object associated with it.
 }
 
 \examples{
-\dontshow{if ((tune:::should_run_examples(suggests = "kernlab"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples(suggests = "kernlab")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -205,7 +205,7 @@ grid has a separate R object associated with it.
 }
 
 \examples{
-\donttest{
+\dontshow{if ((tune:::should_run_examples(suggests = "kernlab"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)
@@ -279,7 +279,7 @@ wf <- workflow() \%>\%
 
 set.seed(3254)
 svm_res_wf <- tune_grid(wf, resamples = folds, grid = 7)
-}
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=control_grid]{control_grid()}}, \code{\link[=tune]{tune()}}, \code{\link[=fit_resamples]{fit_resamples()}},


### PR DESCRIPTION
This PR follows up on #554 and implements the helper introduced there. `should_run_examples` will allow us to check examples outside of CRAN and build examples to include in the pkgdown site. These examples will continue to not be run in CRAN checks. :)

Also formally introduces some suggested packages that we use in examples and tests as Suggests. Otherwise, it's a bit difficult to spot dependencies from the example code, so I'd appreciate another set of eyes there!