### PR TITLE
catch and log `extract` issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed bug in `select_by_pct_loss()` where the model with the greatest loss within the limit was returned rather than the most simple model whose loss was within the limit. (#543)
 
+* Improves condition handling for errors that occur during extraction from workflows. While messages and warnings were appropriately handled, errors occurring due to mis-specified `extract()` functions being supplied to `control_*()` functions were silently caught. As with warnings, errors are now surfaced both during execution and at `print()`.
+
 # tune 1.0.1
 
 * `last_fit()`, `fit_resamples()`, `tune_grid()`, and `tune_bayes()` do not automatically error if  the wrong type of `control` object is passed. If the passed control object is not a superset of the one that is needed, the function will still error. As an example, passing `control_grid()` to `tune_bayes()` will fail but passing `control_bayes()` to `tune_grid()` will not. ([#449](https://github.com/tidymodels/tune/issues/449))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Fixed bug in `select_by_pct_loss()` where the model with the greatest loss within the limit was returned rather than the most simple model whose loss was within the limit. (#543)
 
-* Improves condition handling for errors that occur during extraction from workflows. While messages and warnings were appropriately handled, errors occurring due to mis-specified `extract()` functions being supplied to `control_*()` functions were silently caught. As with warnings, errors are now surfaced both during execution and at `print()`.
+* Improves condition handling for errors that occur during extraction from workflows. While messages and warnings were appropriately handled, errors occurring due to mis-specified `extract()` functions being supplied to `control_*()` functions were silently caught. As with warnings, errors are now surfaced both during execution and at `print()` (#575).
 
 # tune 1.0.1
 

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -412,13 +412,20 @@ tune_grid_loop_iter <- function(split,
         iter_grid <- tibble::new_tibble(x = list(), nrow = nrow)
       }
 
-      out_extracts <- append_extracts(
-        collection = out_extracts,
-        workflow = workflow,
-        grid = iter_grid,
-        split = split,
-        ctrl = control,
-        .config = iter_config
+      out_extracts <- .catch_and_log(
+        append_extracts(
+          collection = out_extracts,
+          workflow = workflow,
+          grid = iter_grid,
+          split = split,
+          ctrl = control,
+          .config = iter_config
+        ),
+        control,
+        split,
+        paste(iter_msg_model, "(extracts)"),
+        bad_only = TRUE,
+        notes = out_notes
       )
 
       iter_msg_predictions <- paste(iter_msg_model, "(predictions)")

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -413,14 +413,14 @@ tune_grid_loop_iter <- function(split,
       }
 
       elt_extract <- .catch_and_log(
-        extract_details(workflow, ctrl$extract),
+        extract_details(workflow, control$extract),
         control,
         split,
         paste(iter_msg_model, "(extracts)"),
         bad_only = TRUE,
         notes = out_notes
       )
-      elt_extract <- make_extracts(elt_extract, workflow, iter_grid, split, .config = iter_config)
+      elt_extract <- make_extracts(elt_extract, iter_grid, split, .config = iter_config)
       out_extracts <- append_extracts(out_extracts, elt_extract)
 
       iter_msg_predictions <- paste(iter_msg_model, "(predictions)")

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -412,21 +412,16 @@ tune_grid_loop_iter <- function(split,
         iter_grid <- tibble::new_tibble(x = list(), nrow = nrow)
       }
 
-      out_extracts <- .catch_and_log(
-        append_extracts(
-          collection = out_extracts,
-          workflow = workflow,
-          grid = iter_grid,
-          split = split,
-          ctrl = control,
-          .config = iter_config
-        ),
+      elt_extract <- .catch_and_log(
+        extract_details(workflow, ctrl$extract),
         control,
         split,
         paste(iter_msg_model, "(extracts)"),
         bad_only = TRUE,
         notes = out_notes
       )
+      elt_extract <- make_extracts(elt_extract, workflow, iter_grid, split, .config = iter_config)
+      out_extracts <- append_extracts(out_extracts, elt_extract)
 
       iter_msg_predictions <- paste(iter_msg_model, "(predictions)")
 

--- a/R/pull.R
+++ b/R/pull.R
@@ -23,9 +23,9 @@ pulley <- function(resamples, res, col) {
 
   id_cols <- grep("^id", names(resamples), value = TRUE)
   resamples <- dplyr::arrange(resamples, !!!syms(id_cols))
-  pulled_vals <- try(purrr::map_dfr(res, ~ .x[[col]]), silent = TRUE)
+  pulled_vals <- purrr::map_dfr(res, ~ .x[[col]])
 
-  if (inherits(pulled_vals, "try-error") || nrow(pulled_vals) == 0) {
+  if (nrow(pulled_vals) == 0) {
     res <-
       resamples %>%
       mutate(col = purrr::map(splits, ~NULL)) %>%
@@ -194,7 +194,7 @@ append_extracts <- function(collection, extracts) {
   dplyr::bind_rows(collection, extracts)
 }
 
-make_extracts <- function(extract, workflow, grid, split, .config = NULL) {
+make_extracts <- function(extract, grid, split, .config = NULL) {
   extracts <- dplyr::bind_cols(grid, labels(split))
   extracts$.extracts <- list(extract)
 

--- a/R/pull.R
+++ b/R/pull.R
@@ -190,15 +190,19 @@ append_predictions <- function(collection, predictions, split, control, .config 
   dplyr::bind_rows(collection, predictions)
 }
 
-append_extracts <- function(collection, workflow, grid, split, ctrl, .config = NULL) {
+append_extracts <- function(collection, extracts) {
+  dplyr::bind_rows(collection, extracts)
+}
+
+make_extracts <- function(extract, workflow, grid, split, .config = NULL) {
   extracts <- dplyr::bind_cols(grid, labels(split))
-  extracts$.extracts <- list(extract_details(workflow, ctrl$extract))
+  extracts$.extracts <- list(extract)
 
   if (!rlang::is_null(.config)) {
     extracts <- cbind(extracts, .config)
   }
 
-  dplyr::bind_rows(collection, extracts)
+  extracts
 }
 
 append_outcome_names <- function(all_outcome_names, outcome_names) {

--- a/R/tune_results.R
+++ b/R/tune_results.R
@@ -66,6 +66,7 @@ summarize_notes <- function(x) {
     dplyr::group_nest(type) %>%
     dplyr::mutate(data = purrr::map(data, ~ dplyr::count(.x, note))) %>%
     tidyr::unnest(data) %>%
+    dplyr::rowwise() %>%
     dplyr::mutate(
       note = gsub("(Error:)", "", note),
       note = glue::glue_collapse(note, width = 0.85 * getOption("width")),
@@ -74,8 +75,8 @@ summarize_notes <- function(x) {
       note = paste0(pre, n, ": ", note)
     )
   cat("\nThere were issues with some computations:\n\n")
-  cat(by_type$note)
-  cat("\n\nRun `show_notes(.Last.tune.result)` for more information.\n")
+  cat(by_type$note, sep = "\n")
+  cat("\nRun `show_notes(.Last.tune.result)` for more information.\n")
   invisible(NULL)
 }
 

--- a/tests/testthat/_snaps/bayes.md
+++ b/tests/testthat/_snaps/bayes.md
@@ -25,51 +25,61 @@
       v Fold01: preprocessor 1/1
       i Fold01: preprocessor 1/1, model 1/1
       v Fold01: preprocessor 1/1, model 1/1
+      i Fold01: preprocessor 1/1, model 1/1 (extracts)
       i Fold01: preprocessor 1/1, model 1/1 (predictions)
       i Fold02: preprocessor 1/1
       v Fold02: preprocessor 1/1
       i Fold02: preprocessor 1/1, model 1/1
       v Fold02: preprocessor 1/1, model 1/1
+      i Fold02: preprocessor 1/1, model 1/1 (extracts)
       i Fold02: preprocessor 1/1, model 1/1 (predictions)
       i Fold03: preprocessor 1/1
       v Fold03: preprocessor 1/1
       i Fold03: preprocessor 1/1, model 1/1
       v Fold03: preprocessor 1/1, model 1/1
+      i Fold03: preprocessor 1/1, model 1/1 (extracts)
       i Fold03: preprocessor 1/1, model 1/1 (predictions)
       i Fold04: preprocessor 1/1
       v Fold04: preprocessor 1/1
       i Fold04: preprocessor 1/1, model 1/1
       v Fold04: preprocessor 1/1, model 1/1
+      i Fold04: preprocessor 1/1, model 1/1 (extracts)
       i Fold04: preprocessor 1/1, model 1/1 (predictions)
       i Fold05: preprocessor 1/1
       v Fold05: preprocessor 1/1
       i Fold05: preprocessor 1/1, model 1/1
       v Fold05: preprocessor 1/1, model 1/1
+      i Fold05: preprocessor 1/1, model 1/1 (extracts)
       i Fold05: preprocessor 1/1, model 1/1 (predictions)
       i Fold06: preprocessor 1/1
       v Fold06: preprocessor 1/1
       i Fold06: preprocessor 1/1, model 1/1
       v Fold06: preprocessor 1/1, model 1/1
+      i Fold06: preprocessor 1/1, model 1/1 (extracts)
       i Fold06: preprocessor 1/1, model 1/1 (predictions)
       i Fold07: preprocessor 1/1
       v Fold07: preprocessor 1/1
       i Fold07: preprocessor 1/1, model 1/1
       v Fold07: preprocessor 1/1, model 1/1
+      i Fold07: preprocessor 1/1, model 1/1 (extracts)
       i Fold07: preprocessor 1/1, model 1/1 (predictions)
       i Fold08: preprocessor 1/1
       v Fold08: preprocessor 1/1
       i Fold08: preprocessor 1/1, model 1/1
       v Fold08: preprocessor 1/1, model 1/1
+      i Fold08: preprocessor 1/1, model 1/1 (extracts)
       i Fold08: preprocessor 1/1, model 1/1 (predictions)
       i Fold09: preprocessor 1/1
       v Fold09: preprocessor 1/1
       i Fold09: preprocessor 1/1, model 1/1
       v Fold09: preprocessor 1/1, model 1/1
+      i Fold09: preprocessor 1/1, model 1/1 (extracts)
       i Fold09: preprocessor 1/1, model 1/1 (predictions)
       i Fold10: preprocessor 1/1
       v Fold10: preprocessor 1/1
       i Fold10: preprocessor 1/1, model 1/1
       v Fold10: preprocessor 1/1, model 1/1
+      i Fold10: preprocessor 1/1, model 1/1 (extracts)
       i Fold10: preprocessor 1/1, model 1/1 (predictions)
       v Estimating performance
       (x) Newest results:	rmse=2.666 (+/-0.281)
@@ -88,51 +98,61 @@
       v Fold01: preprocessor 1/1
       i Fold01: preprocessor 1/1, model 1/1
       v Fold01: preprocessor 1/1, model 1/1
+      i Fold01: preprocessor 1/1, model 1/1 (extracts)
       i Fold01: preprocessor 1/1, model 1/1 (predictions)
       i Fold02: preprocessor 1/1
       v Fold02: preprocessor 1/1
       i Fold02: preprocessor 1/1, model 1/1
       v Fold02: preprocessor 1/1, model 1/1
+      i Fold02: preprocessor 1/1, model 1/1 (extracts)
       i Fold02: preprocessor 1/1, model 1/1 (predictions)
       i Fold03: preprocessor 1/1
       v Fold03: preprocessor 1/1
       i Fold03: preprocessor 1/1, model 1/1
       v Fold03: preprocessor 1/1, model 1/1
+      i Fold03: preprocessor 1/1, model 1/1 (extracts)
       i Fold03: preprocessor 1/1, model 1/1 (predictions)
       i Fold04: preprocessor 1/1
       v Fold04: preprocessor 1/1
       i Fold04: preprocessor 1/1, model 1/1
       v Fold04: preprocessor 1/1, model 1/1
+      i Fold04: preprocessor 1/1, model 1/1 (extracts)
       i Fold04: preprocessor 1/1, model 1/1 (predictions)
       i Fold05: preprocessor 1/1
       v Fold05: preprocessor 1/1
       i Fold05: preprocessor 1/1, model 1/1
       v Fold05: preprocessor 1/1, model 1/1
+      i Fold05: preprocessor 1/1, model 1/1 (extracts)
       i Fold05: preprocessor 1/1, model 1/1 (predictions)
       i Fold06: preprocessor 1/1
       v Fold06: preprocessor 1/1
       i Fold06: preprocessor 1/1, model 1/1
       v Fold06: preprocessor 1/1, model 1/1
+      i Fold06: preprocessor 1/1, model 1/1 (extracts)
       i Fold06: preprocessor 1/1, model 1/1 (predictions)
       i Fold07: preprocessor 1/1
       v Fold07: preprocessor 1/1
       i Fold07: preprocessor 1/1, model 1/1
       v Fold07: preprocessor 1/1, model 1/1
+      i Fold07: preprocessor 1/1, model 1/1 (extracts)
       i Fold07: preprocessor 1/1, model 1/1 (predictions)
       i Fold08: preprocessor 1/1
       v Fold08: preprocessor 1/1
       i Fold08: preprocessor 1/1, model 1/1
       v Fold08: preprocessor 1/1, model 1/1
+      i Fold08: preprocessor 1/1, model 1/1 (extracts)
       i Fold08: preprocessor 1/1, model 1/1 (predictions)
       i Fold09: preprocessor 1/1
       v Fold09: preprocessor 1/1
       i Fold09: preprocessor 1/1, model 1/1
       v Fold09: preprocessor 1/1, model 1/1
+      i Fold09: preprocessor 1/1, model 1/1 (extracts)
       i Fold09: preprocessor 1/1, model 1/1 (predictions)
       i Fold10: preprocessor 1/1
       v Fold10: preprocessor 1/1
       i Fold10: preprocessor 1/1, model 1/1
       v Fold10: preprocessor 1/1, model 1/1
+      i Fold10: preprocessor 1/1, model 1/1 (extracts)
       i Fold10: preprocessor 1/1, model 1/1 (predictions)
       v Estimating performance
       (x) Newest results:	rmse=2.453 (+/-0.381)
@@ -211,51 +231,61 @@
       v Fold01: preprocessor 1/1
       i Fold01: preprocessor 1/1, model 1/1
       v Fold01: preprocessor 1/1, model 1/1
+      i Fold01: preprocessor 1/1, model 1/1 (extracts)
       i Fold01: preprocessor 1/1, model 1/1 (predictions)
       i Fold02: preprocessor 1/1
       v Fold02: preprocessor 1/1
       i Fold02: preprocessor 1/1, model 1/1
       v Fold02: preprocessor 1/1, model 1/1
+      i Fold02: preprocessor 1/1, model 1/1 (extracts)
       i Fold02: preprocessor 1/1, model 1/1 (predictions)
       i Fold03: preprocessor 1/1
       v Fold03: preprocessor 1/1
       i Fold03: preprocessor 1/1, model 1/1
       v Fold03: preprocessor 1/1, model 1/1
+      i Fold03: preprocessor 1/1, model 1/1 (extracts)
       i Fold03: preprocessor 1/1, model 1/1 (predictions)
       i Fold04: preprocessor 1/1
       v Fold04: preprocessor 1/1
       i Fold04: preprocessor 1/1, model 1/1
       v Fold04: preprocessor 1/1, model 1/1
+      i Fold04: preprocessor 1/1, model 1/1 (extracts)
       i Fold04: preprocessor 1/1, model 1/1 (predictions)
       i Fold05: preprocessor 1/1
       v Fold05: preprocessor 1/1
       i Fold05: preprocessor 1/1, model 1/1
       v Fold05: preprocessor 1/1, model 1/1
+      i Fold05: preprocessor 1/1, model 1/1 (extracts)
       i Fold05: preprocessor 1/1, model 1/1 (predictions)
       i Fold06: preprocessor 1/1
       v Fold06: preprocessor 1/1
       i Fold06: preprocessor 1/1, model 1/1
       v Fold06: preprocessor 1/1, model 1/1
+      i Fold06: preprocessor 1/1, model 1/1 (extracts)
       i Fold06: preprocessor 1/1, model 1/1 (predictions)
       i Fold07: preprocessor 1/1
       v Fold07: preprocessor 1/1
       i Fold07: preprocessor 1/1, model 1/1
       v Fold07: preprocessor 1/1, model 1/1
+      i Fold07: preprocessor 1/1, model 1/1 (extracts)
       i Fold07: preprocessor 1/1, model 1/1 (predictions)
       i Fold08: preprocessor 1/1
       v Fold08: preprocessor 1/1
       i Fold08: preprocessor 1/1, model 1/1
       v Fold08: preprocessor 1/1, model 1/1
+      i Fold08: preprocessor 1/1, model 1/1 (extracts)
       i Fold08: preprocessor 1/1, model 1/1 (predictions)
       i Fold09: preprocessor 1/1
       v Fold09: preprocessor 1/1
       i Fold09: preprocessor 1/1, model 1/1
       v Fold09: preprocessor 1/1, model 1/1
+      i Fold09: preprocessor 1/1, model 1/1 (extracts)
       i Fold09: preprocessor 1/1, model 1/1 (predictions)
       i Fold10: preprocessor 1/1
       v Fold10: preprocessor 1/1
       i Fold10: preprocessor 1/1, model 1/1
       v Fold10: preprocessor 1/1, model 1/1
+      i Fold10: preprocessor 1/1, model 1/1 (extracts)
       i Fold10: preprocessor 1/1, model 1/1 (predictions)
       v Estimating performance
       (x) Newest results:	rmse=2.666 (+/-0.281)
@@ -274,51 +304,61 @@
       v Fold01: preprocessor 1/1
       i Fold01: preprocessor 1/1, model 1/1
       v Fold01: preprocessor 1/1, model 1/1
+      i Fold01: preprocessor 1/1, model 1/1 (extracts)
       i Fold01: preprocessor 1/1, model 1/1 (predictions)
       i Fold02: preprocessor 1/1
       v Fold02: preprocessor 1/1
       i Fold02: preprocessor 1/1, model 1/1
       v Fold02: preprocessor 1/1, model 1/1
+      i Fold02: preprocessor 1/1, model 1/1 (extracts)
       i Fold02: preprocessor 1/1, model 1/1 (predictions)
       i Fold03: preprocessor 1/1
       v Fold03: preprocessor 1/1
       i Fold03: preprocessor 1/1, model 1/1
       v Fold03: preprocessor 1/1, model 1/1
+      i Fold03: preprocessor 1/1, model 1/1 (extracts)
       i Fold03: preprocessor 1/1, model 1/1 (predictions)
       i Fold04: preprocessor 1/1
       v Fold04: preprocessor 1/1
       i Fold04: preprocessor 1/1, model 1/1
       v Fold04: preprocessor 1/1, model 1/1
+      i Fold04: preprocessor 1/1, model 1/1 (extracts)
       i Fold04: preprocessor 1/1, model 1/1 (predictions)
       i Fold05: preprocessor 1/1
       v Fold05: preprocessor 1/1
       i Fold05: preprocessor 1/1, model 1/1
       v Fold05: preprocessor 1/1, model 1/1
+      i Fold05: preprocessor 1/1, model 1/1 (extracts)
       i Fold05: preprocessor 1/1, model 1/1 (predictions)
       i Fold06: preprocessor 1/1
       v Fold06: preprocessor 1/1
       i Fold06: preprocessor 1/1, model 1/1
       v Fold06: preprocessor 1/1, model 1/1
+      i Fold06: preprocessor 1/1, model 1/1 (extracts)
       i Fold06: preprocessor 1/1, model 1/1 (predictions)
       i Fold07: preprocessor 1/1
       v Fold07: preprocessor 1/1
       i Fold07: preprocessor 1/1, model 1/1
       v Fold07: preprocessor 1/1, model 1/1
+      i Fold07: preprocessor 1/1, model 1/1 (extracts)
       i Fold07: preprocessor 1/1, model 1/1 (predictions)
       i Fold08: preprocessor 1/1
       v Fold08: preprocessor 1/1
       i Fold08: preprocessor 1/1, model 1/1
       v Fold08: preprocessor 1/1, model 1/1
+      i Fold08: preprocessor 1/1, model 1/1 (extracts)
       i Fold08: preprocessor 1/1, model 1/1 (predictions)
       i Fold09: preprocessor 1/1
       v Fold09: preprocessor 1/1
       i Fold09: preprocessor 1/1, model 1/1
       v Fold09: preprocessor 1/1, model 1/1
+      i Fold09: preprocessor 1/1, model 1/1 (extracts)
       i Fold09: preprocessor 1/1, model 1/1 (predictions)
       i Fold10: preprocessor 1/1
       v Fold10: preprocessor 1/1
       i Fold10: preprocessor 1/1, model 1/1
       v Fold10: preprocessor 1/1, model 1/1
+      i Fold10: preprocessor 1/1, model 1/1 (extracts)
       i Fold10: preprocessor 1/1, model 1/1 (predictions)
       v Estimating performance
       (x) Newest results:	rmse=2.453 (+/-0.381)

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -87,7 +87,8 @@
       
       There were issues with some computations:
       
-        - Error(s) x3: Error in extractor(object): AHHHAH   - Warning(s) x3: Error in extractor(object): AHHHAH
+        - Error(s) x3: Error in extractor(object): AHHH
+        - Warning(s) x3: AH
       
       Run `show_notes(.Last.tune.result)` for more information.
 

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -1,0 +1,93 @@
+# mis-specified extract function
+
+    Code
+      res_extract_warning <- fit_resamples(wf, boots, control = control_resamples(
+        extract = raise_warning))
+    Message
+      ! Bootstrap1: preprocessor 1/1, model 1/1 (extracts): AHHH
+      ! Bootstrap2: preprocessor 1/1, model 1/1 (extracts): AHHH
+      ! Bootstrap3: preprocessor 1/1, model 1/1 (extracts): AHHH
+
+---
+
+    Code
+      res_extract_error <- fit_resamples(wf, boots, control = control_resamples(
+        extract = raise_error))
+    Message
+      x Bootstrap1: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
+      x Bootstrap2: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
+      x Bootstrap3: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
+
+---
+
+    Code
+      res_extract_both <- fit_resamples(wf, boots, control = control_resamples(
+        extract = raise_both))
+    Message
+      ! Bootstrap1: preprocessor 1/1, model 1/1 (extracts): AH
+      x Bootstrap1: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
+      ! Bootstrap2: preprocessor 1/1, model 1/1 (extracts): AH
+      x Bootstrap2: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
+      ! Bootstrap3: preprocessor 1/1, model 1/1 (extracts): AH
+      x Bootstrap3: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
+
+---
+
+    Code
+      res_extract_warning
+    Output
+      # Resampling results
+      # Bootstrap sampling 
+      # A tibble: 3 x 5
+        splits          id         .metrics         .notes           .extracts       
+        <list>          <chr>      <list>           <list>           <list>          
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
+      
+      There were issues with some computations:
+      
+        - Warning(s) x3: AHHH
+      
+      Run `show_notes(.Last.tune.result)` for more information.
+
+---
+
+    Code
+      res_extract_error
+    Output
+      # Resampling results
+      # Bootstrap sampling 
+      # A tibble: 3 x 5
+        splits          id         .metrics         .notes           .extracts
+        <list>          <chr>      <list>           <list>           <list>   
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]> <NULL>   
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 3]> <NULL>   
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [1 x 3]> <NULL>   
+      
+      There were issues with some computations:
+      
+        - Error(s) x3: Error in extractor(object): AHHH
+      
+      Run `show_notes(.Last.tune.result)` for more information.
+
+---
+
+    Code
+      res_extract_both
+    Output
+      # Resampling results
+      # Bootstrap sampling 
+      # A tibble: 3 x 5
+        splits          id         .metrics         .notes           .extracts
+        <list>          <chr>      <list>           <list>           <list>   
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [2 x 3]> <NULL>   
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [2 x 3]> <NULL>   
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [2 x 3]> <NULL>   
+      
+      There were issues with some computations:
+      
+        - Error(s) x3: Error in extractor(object): AHHHAH   - Warning(s) x3: Error in extractor(object): AHHHAH
+      
+      Run `show_notes(.Last.tune.result)` for more information.
+

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -34,6 +34,14 @@
 ---
 
     Code
+      res_extract_error_once <- fit_resamples(wf, boots, control = control_resamples(
+        extract = raise_error_once))
+    Message
+      x Bootstrap1: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): oh no
+
+---
+
+    Code
       res_extract_warning
     Output
       # Resampling results
@@ -59,11 +67,11 @@
       # Resampling results
       # Bootstrap sampling 
       # A tibble: 3 x 5
-        splits          id         .metrics         .notes           .extracts
-        <list>          <chr>      <list>           <list>           <list>   
-      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]> <NULL>   
-      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 3]> <NULL>   
-      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [1 x 3]> <NULL>   
+        splits          id         .metrics         .notes           .extracts       
+        <list>          <chr>      <list>           <list>           <list>          
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
       
       There were issues with some computations:
       
@@ -79,11 +87,11 @@
       # Resampling results
       # Bootstrap sampling 
       # A tibble: 3 x 5
-        splits          id         .metrics         .notes           .extracts
-        <list>          <chr>      <list>           <list>           <list>   
-      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [2 x 3]> <NULL>   
-      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [2 x 3]> <NULL>   
-      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [2 x 3]> <NULL>   
+        splits          id         .metrics         .notes           .extracts       
+        <list>          <chr>      <list>           <list>           <list>          
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [2 x 3]> <tibble [1 x 2]>
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [2 x 3]> <tibble [1 x 2]>
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [2 x 3]> <tibble [1 x 2]>
       
       There were issues with some computations:
       
@@ -91,4 +99,77 @@
         - Warning(s) x3: AH
       
       Run `show_notes(.Last.tune.result)` for more information.
+
+---
+
+    Code
+      res_extract_error_once
+    Output
+      # Resampling results
+      # Bootstrap sampling 
+      # A tibble: 3 x 5
+        splits          id         .metrics         .notes           .extracts       
+        <list>          <chr>      <list>           <list>           <list>          
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [0 x 3]> <tibble [1 x 2]>
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [0 x 3]> <tibble [1 x 2]>
+      
+      There were issues with some computations:
+      
+        - Error(s) x1: Error in extractor(object): oh no
+      
+      Run `show_notes(.Last.tune.result)` for more information.
+
+---
+
+    Code
+      res_extract_warning$.notes[[1]]
+    Output
+      # A tibble: 1 x 3
+        location                               type    note 
+        <chr>                                  <chr>   <chr>
+      1 preprocessor 1/1, model 1/1 (extracts) warning AHHH 
+
+---
+
+    Code
+      res_extract_error$.extracts[[1]]$.extracts[[1]]
+    Output
+      [1] "Error in extractor(object) : AHHH\n"
+      attr(,"class")
+      [1] "try-error"
+      attr(,"condition")
+      <simpleError in extractor(object): AHHH>
+
+---
+
+    Code
+      res_extract_error$.notes[[1]]
+    Output
+      # A tibble: 1 x 3
+        location                               type  note                            
+        <chr>                                  <chr> <chr>                           
+      1 preprocessor 1/1, model 1/1 (extracts) error Error in extractor(object): AHHH
+
+---
+
+    Code
+      res_extract_both$.extracts[[1]]$.extracts[[1]]
+    Output
+      [1] "Error in extractor(object) : AHHH\n"
+      attr(,"class")
+      [1] "try-error"
+      attr(,"condition")
+      <simpleError in extractor(object): AHHH>
+
+---
+
+    Code
+      res_extract_error_once$.extracts[[1]]$.extracts[[1]]
+    Output
+      [1] "Error in extractor(object) : oh no\n"
+      attr(,"class")
+      [1] "try-error"
+      attr(,"condition")
+      <simpleError in extractor(object): oh no>
 

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -95,7 +95,7 @@ test_that("mis-specified extract function", {
     )
 
   set.seed(1)
-  boots <- bootstraps(mtcars, 3)
+  boots <- rsample::bootstraps(mtcars, 3)
 
   raise_warning <- function(x) {warning("AHHH"); TRUE}
   raise_error <- function(x) {stop("AHHH"); TRUE}

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -100,6 +100,18 @@ test_that("mis-specified extract function", {
   raise_warning <- function(x) {warning("AHHH"); TRUE}
   raise_error <- function(x) {stop("AHHH"); TRUE}
   raise_both <- function(x) {warning("AH"); stop("AHHH"); TRUE}
+  raise_error_once <- local({
+    first <- TRUE
+
+    function(x) {
+      if (first) {
+        first <<- FALSE
+        stop("oh no")
+      }
+
+      "hi"
+    }
+  })
 
   expect_snapshot(
     res_extract_warning <-
@@ -116,9 +128,27 @@ test_that("mis-specified extract function", {
       fit_resamples(wf, boots, control = control_resamples(extract = raise_both))
   )
 
+  expect_snapshot(
+    res_extract_error_once <-
+      fit_resamples(wf, boots, control = control_resamples(extract = raise_error_once))
+  )
+
   expect_snapshot(res_extract_warning)
   expect_snapshot(res_extract_error)
   expect_snapshot(res_extract_both)
+  expect_snapshot(res_extract_error_once)
+
+  expect_true(res_extract_warning$.extracts[[1]]$.extracts[[1]])
+  expect_snapshot(res_extract_warning$.notes[[1]])
+
+  expect_snapshot(res_extract_error$.extracts[[1]]$.extracts[[1]])
+  expect_snapshot(res_extract_error$.notes[[1]])
+
+  expect_snapshot(res_extract_both$.extracts[[1]]$.extracts[[1]])
+
+  expect_snapshot(res_extract_error_once$.extracts[[1]]$.extracts[[1]])
+  expect_equal(res_extract_error_once$.extracts[[2]]$.extracts[[1]], "hi")
+  expect_equal(res_extract_error_once$.extracts[[3]]$.extracts[[1]], "hi")
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -87,6 +87,40 @@ test_that("tune model only", {
   expect_true(all(!extract_2_2$is_null_rec))
 })
 
+test_that("mis-specified extract function", {
+  wf <-
+    workflows::workflow(
+      preprocessor = mpg ~ .,
+      spec = parsnip::linear_reg()
+    )
+
+  set.seed(1)
+  boots <- bootstraps(mtcars, 3)
+
+  raise_warning <- function(x) {warning("AHHH"); TRUE}
+  raise_error <- function(x) {stop("AHHH"); TRUE}
+  raise_both <- function(x) {warning("AH"); stop("AHHH"); TRUE}
+
+  expect_snapshot(
+    res_extract_warning <-
+      fit_resamples(wf, boots, control = control_resamples(extract = raise_warning))
+  )
+
+  expect_snapshot(
+    res_extract_error <-
+      fit_resamples(wf, boots, control = control_resamples(extract = raise_error))
+  )
+
+  expect_snapshot(
+    res_extract_both <-
+      fit_resamples(wf, boots, control = control_resamples(extract = raise_both))
+  )
+
+  expect_snapshot(res_extract_warning)
+  expect_snapshot(res_extract_error)
+  expect_snapshot(res_extract_both)
+})
+
 # ------------------------------------------------------------------------------
 
 test_that("tune model and recipe", {


### PR DESCRIPTION
With CRAN tune, the package hides errors that occur with mis-specified `extract` functions:

``` r
library(tidymodels)

wf <- workflow(mpg ~ ., linear_reg())
set.seed(1)
boots <- bootstraps(mtcars, 3)

# warn at extract --------------------------------------------------------------
raise_warning <- function(x) {warning("AHHH"); TRUE}

res_extract_warn <-
  fit_resamples(
    wf, boots, control = control_resamples(extract = raise_warning)
  )
#> ! Bootstrap1: internal: AHHH
#> ! Bootstrap2: internal: AHHH
#> ! Bootstrap3: internal: AHHH

res_extract_warn
#> # Resampling results
#> # Bootstrap sampling 
#> # A tibble: 3 × 5
#>   splits          id         .metrics         .notes           .extracts       
#>   <list>          <chr>      <list>           <list>           <list>          
#> 1 <split [32/13]> Bootstrap1 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>
#> 2 <split [32/17]> Bootstrap2 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>
#> 3 <split [32/11]> Bootstrap3 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>
#> 
#> There were issues with some computations:
#> 
#>   - Warning(s) x3: AHHH
#> 
#> Run `show_notes(.Last.tune.result)` for more information.

# error at extract -------------------------------------------------------------
raise_error <- function(x) {stop("AHHH"); TRUE}

res_extract_error <-
  fit_resamples(
    wf, boots, control = control_resamples(extract = raise_error)
  )

res_extract_error
#> # Resampling results
#> # Bootstrap sampling 
#> # A tibble: 3 × 5
#>   splits          id         .metrics         .notes           .extracts       
#>   <list>          <chr>      <list>           <list>           <list>          
#> 1 <split [32/13]> Bootstrap1 <tibble [2 × 4]> <tibble [0 × 3]> <tibble [1 × 2]>
#> 2 <split [32/17]> Bootstrap2 <tibble [2 × 4]> <tibble [0 × 3]> <tibble [1 × 2]>
#> 3 <split [32/11]> Bootstrap3 <tibble [2 × 4]> <tibble [0 × 3]> <tibble [1 × 2]>

res_extract_error$.extracts[[1]]$.extracts
#> [[1]]
#> [1] "Error in extractor(object) : AHHH\n"
#> attr(,"class")
#> [1] "try-error"
#> attr(,"condition")
#> <simpleError in extractor(object): AHHH>
```

<sup>Created on 2022-11-04 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

With this PR, the package surfaces `extract`ion errors in the same way that it does errors that occur elsewhere:

``` r
library(tidymodels)

wf <- workflow(mpg ~ ., linear_reg())
set.seed(1)
boots <- bootstraps(mtcars, 3)

# warn at extract --------------------------------------------------------------
raise_warning <- function(x) {warning("AHHH"); TRUE}

res_extract_warn <-
  fit_resamples(
    wf, boots, control = control_resamples(extract = raise_warning)
  )
#> ! Bootstrap1: preprocessor 1/1, model 1/1 (extracts): AHHH
#> ! Bootstrap2: preprocessor 1/1, model 1/1 (extracts): AHHH
#> ! Bootstrap3: preprocessor 1/1, model 1/1 (extracts): AHHH

res_extract_warn
#> # Resampling results
#> # Bootstrap sampling 
#> # A tibble: 3 × 5
#>   splits          id         .metrics         .notes           .extracts       
#>   <list>          <chr>      <list>           <list>           <list>          
#> 1 <split [32/13]> Bootstrap1 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>
#> 2 <split [32/17]> Bootstrap2 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>
#> 3 <split [32/11]> Bootstrap3 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>
#> 
#> There were issues with some computations:
#> 
#>   - Warning(s) x3: AHHH
#> 
#> Run `show_notes(.Last.tune.result)` for more information.

# error at extract -------------------------------------------------------------
raise_error <- function(x) {stop("AHHH"); TRUE}

res_extract_error <-
  fit_resamples(
    wf, boots, control = control_resamples(extract = raise_error)
  )
#> x Bootstrap1: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
#> x Bootstrap2: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
#> x Bootstrap3: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH

res_extract_error
#> # Resampling results
#> # Bootstrap sampling 
#> # A tibble: 3 × 5
#>   splits          id         .metrics         .notes           .extracts
#>   <list>          <chr>      <list>           <list>           <list>   
#> 1 <split [32/13]> Bootstrap1 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>
#> 2 <split [32/17]> Bootstrap2 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>   
#> 3 <split [32/11]> Bootstrap3 <tibble [2 × 4]> <tibble [1 × 3]> <tibble [1 × 2]>   
#> 
#> There were issues with some computations:
#> 
#>   - Error(s) x3: Error in extractor(object): AHHH
#> 
#> Run `show_notes(.Last.tune.result)` for more information.

# both warn and error at extract
raise_both <- function(x) {warning("AH"); stop("AHHH"); TRUE}

res_extract_both <-
  fit_resamples(
    wf, boots, control = control_resamples(extract = raise_both)
  )
#> ! Bootstrap1: preprocessor 1/1, model 1/1 (extracts): AH
#> x Bootstrap1: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
#> ! Bootstrap2: preprocessor 1/1, model 1/1 (extracts): AH
#> x Bootstrap2: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH
#> ! Bootstrap3: preprocessor 1/1, model 1/1 (extracts): AH
#> x Bootstrap3: preprocessor 1/1, model 1/1 (extracts): Error in extractor(object): AHHH

res_extract_both
#> # Resampling results
#> # Bootstrap sampling 
#> # A tibble: 3 × 5
#>   splits          id         .metrics         .notes           .extracts
#>   <list>          <chr>      <list>           <list>           <list>   
#> 1 <split [32/13]> Bootstrap1 <tibble [2 × 4]> <tibble [2 × 3]> <tibble [1 × 2]>   
#> 2 <split [32/17]> Bootstrap2 <tibble [2 × 4]> <tibble [2 × 3]> <tibble [1 × 2]>   
#> 3 <split [32/11]> Bootstrap3 <tibble [2 × 4]> <tibble [2 × 3]> <tibble [1 × 2]>   
#> 
#> There were issues with some computations:
#> 
#>   - Error(s) x3: Error in extractor(object): AHHH
#>   - Warning(s) x3: AH
#> 
#> Run `show_notes(.Last.tune.result)` for more information.
```

<sup>Created on 2022-11-04 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Fixes #565, to the extent that we will. :)