### PR TITLE
clarify duplicated error messages in `select_by_*`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Fixed bug in `select_by_pct_loss()` where the model with the greatest loss within the limit was returned rather than the most simple model whose loss was within the limit. (#543)
 * Extended `show_best()`, `select_best()`, `select_by_one_std_error()`, `select_by_pct_loss()` to accommodate metrics with a target value of zero (notably, `yardstick::mpe()` and `yardstick::msd()`). (#243)
+* Clarified error messages in `select_by_*` functions. Error messages now only note entries in `...` that are likely candidates for failure to `arrange()`, and those error messages are no longer duplicated for each entry in `...`.
 
 * Improves condition handling for errors that occur during extraction from workflows. While messages and warnings were appropriately handled, errors occurring due to mis-specified `extract()` functions being supplied to `control_*()` functions were silently caught. As with warnings, errors are now surfaced both during execution and at `print()` (#575).
 

--- a/R/select_best.R
+++ b/R/select_best.R
@@ -210,8 +210,8 @@ select_by_pct_loss.tune_results <- function(x, ..., metric = NULL, limit = 2) {
   if (inherits(res, "try-error")) {
     var_nm <- rlang::eval_tidy(dots)
     var_nm <- purrr::map_chr(var_nm, ~ as.character(rlang::quo_get_expr(.x)))
-    msg <- paste0("Could not sort results by '", var_nm, "'.")
-    rlang::abort(msg)
+    var_nm <- var_nm[!var_nm %in% colnames(collect_metrics(x))]
+    cli::cli_abort("Could not sort results by {.var {var_nm}}.")
   }
 
   # discard models more complex than the best and
@@ -301,8 +301,8 @@ select_by_one_std_err.tune_results <- function(x, ..., metric = NULL) {
   if (inherits(res, "try-error")) {
     var_nm <- rlang::eval_tidy(dots)
     var_nm <- purrr::map_chr(var_nm, ~ as.character(rlang::quo_get_expr(.x)))
-    msg <- paste0("Could not sort results by '", var_nm, "'.")
-    rlang::abort(msg)
+    var_nm <- var_nm[!var_nm %in% colnames(collect_metrics(x))]
+    cli::cli_abort("Could not sort results by {.var {var_nm}}.")
   }
   res %>% dplyr::slice(1)
 }

--- a/R/select_best.R
+++ b/R/select_best.R
@@ -209,7 +209,7 @@ select_by_pct_loss.tune_results <- function(x, ..., metric = NULL, limit = 2) {
   res <- try(dplyr::arrange(res, !!!dots), silent = TRUE)
   if (inherits(res, "try-error")) {
     var_nm <- rlang::eval_tidy(dots)
-    var_nm <- purrr::map_chr(var_nm, ~ as.character(rlang::quo_get_expr(.x)))
+    var_nm <- purrr::map_chr(var_nm, ~ rlang::quo_name(.x))
     var_nm <- var_nm[!var_nm %in% colnames(collect_metrics(x))]
     cli::cli_abort("Could not sort results by {.var {var_nm}}.")
   }
@@ -300,7 +300,7 @@ select_by_one_std_err.tune_results <- function(x, ..., metric = NULL) {
   res <- try(dplyr::arrange(res, !!!dots), silent = TRUE)
   if (inherits(res, "try-error")) {
     var_nm <- rlang::eval_tidy(dots)
-    var_nm <- purrr::map_chr(var_nm, ~ as.character(rlang::quo_get_expr(.x)))
+    var_nm <- purrr::map_chr(var_nm, ~ rlang::quo_name(.x))
     var_nm <- var_nm[!var_nm %in% colnames(collect_metrics(x))]
     cli::cli_abort("Could not sort results by {.var {var_nm}}.")
   }

--- a/tests/testthat/_snaps/select_best.md
+++ b/tests/testthat/_snaps/select_best.md
@@ -142,6 +142,14 @@
       Error in `select_by_one_std_err()`:
       ! Could not sort results by `weight_funk` and `Kay`.
 
+---
+
+    Code
+      select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk, desc(K))
+    Condition
+      Error in `select_by_one_std_err()`:
+      ! Could not sort results by `weight_funk` and `desc(K)`.
+
 # percent loss
 
     Code
@@ -220,4 +228,12 @@
     Condition
       Error in `select_by_pct_loss()`:
       ! Could not sort results by `weight_funk` and `Kay`.
+
+---
+
+    Code
+      select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk, desc(K))
+    Condition
+      Error in `select_by_pct_loss()`:
+      ! Could not sort results by `weight_funk` and `desc(K)`.
 

--- a/tests/testthat/_snaps/select_best.md
+++ b/tests/testthat/_snaps/select_best.md
@@ -118,6 +118,30 @@
       Error in `select_by_one_std_err()`:
       ! No `select_by_one_std_err()` exists for this type of object.
 
+---
+
+    Code
+      select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk)
+    Condition
+      Error in `select_by_one_std_err()`:
+      ! Could not sort results by `weight_funk`.
+
+---
+
+    Code
+      select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk, K)
+    Condition
+      Error in `select_by_one_std_err()`:
+      ! Could not sort results by `weight_funk`.
+
+---
+
+    Code
+      select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk, Kay)
+    Condition
+      Error in `select_by_one_std_err()`:
+      ! Could not sort results by `weight_funk` and `Kay`.
+
 # percent loss
 
     Code
@@ -172,4 +196,28 @@
     Condition
       Error in `select_by_pct_loss()`:
       ! No `select_by_pct_loss()` exists for this type of object.
+
+---
+
+    Code
+      select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk)
+    Condition
+      Error in `select_by_pct_loss()`:
+      ! Could not sort results by `weight_funk`.
+
+---
+
+    Code
+      select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk, K)
+    Condition
+      Error in `select_by_pct_loss()`:
+      ! Could not sort results by `weight_funk`.
+
+---
+
+    Code
+      select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk, Kay)
+    Condition
+      Error in `select_by_pct_loss()`:
+      ! Could not sort results by `weight_funk` and `Kay`.
 

--- a/tests/testthat/test-select_best.R
+++ b/tests/testthat/test-select_best.R
@@ -168,6 +168,15 @@ test_that("one-std error rule", {
   expect_snapshot(error = TRUE, {
     select_by_one_std_err(mtcars, metric = "disp")
   })
+  expect_snapshot(error = TRUE, {
+    select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk)
+  })
+  expect_snapshot(error = TRUE, {
+    select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk, K)
+  })
+  expect_snapshot(error = TRUE, {
+    select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk, Kay)
+  })
 })
 
 
@@ -211,6 +220,15 @@ test_that("percent loss", {
 
   expect_snapshot(error = TRUE, {
     select_by_pct_loss(mtcars, metric = "disp")
+  })
+  expect_snapshot(error = TRUE, {
+    select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk)
+  })
+  expect_snapshot(error = TRUE, {
+    select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk, K)
+  })
+  expect_snapshot(error = TRUE, {
+    select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk, Kay)
   })
 
   data("example_ames_knn")

--- a/tests/testthat/test-select_best.R
+++ b/tests/testthat/test-select_best.R
@@ -177,6 +177,9 @@ test_that("one-std error rule", {
   expect_snapshot(error = TRUE, {
     select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk, Kay)
   })
+  expect_snapshot(error = TRUE, {
+    select_by_one_std_err(knn_results, metric = "roc_auc", weight_funk, desc(K))
+  })
 })
 
 
@@ -229,6 +232,9 @@ test_that("percent loss", {
   })
   expect_snapshot(error = TRUE, {
     select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk, Kay)
+  })
+  expect_snapshot(error = TRUE, {
+    select_by_pct_loss(knn_results, metric = "roc_auc", weight_funk, desc(K))
   })
 
   data("example_ames_knn")


### PR DESCRIPTION
Closes #570. Addresses duplicated error messages with misspecified `...` in `select_by_*` functions, and subsets out entries in `...` that are in `collect_metrics` output (and thus ought to be `arrange`able).🙂

``` r
library(tune)

data("example_ames_knn")

# well-specified:
select_by_pct_loss(ames_grid_search, metric = "rmse", weight_func)
#> # A tibble: 1 × 13
#>       K weigh…¹ dist_…²   lon   lat .metric .esti…³   mean     n std_err .config
#>   <int> <chr>     <dbl> <int> <int> <chr>   <chr>    <dbl> <int>   <dbl> <chr>  
#> 1     5 rank      0.411     2     7 rmse    standa… 0.0740    10 0.00328 Prepro…
#> # … with 2 more variables: .best <dbl>, .loss <dbl>, and abbreviated variable
#> #   names ¹​weight_func, ²​dist_power, ³​.estimator

# with a second, well-specified parameter:
select_by_pct_loss(ames_grid_search, metric = "rmse", weight_func, K)
#> # A tibble: 1 × 13
#>       K weigh…¹ dist_…²   lon   lat .metric .esti…³   mean     n std_err .config
#>   <int> <chr>     <dbl> <int> <int> <chr>   <chr>    <dbl> <int>   <dbl> <chr>  
#> 1     5 rank      0.411     2     7 rmse    standa… 0.0740    10 0.00328 Prepro…
#> # … with 2 more variables: .best <dbl>, .loss <dbl>, and abbreviated variable
#> #   names ¹​weight_func, ²​dist_power, ³​.estimator

# misspell the first one:
select_by_pct_loss(ames_grid_search, metric = "rmse", weight_funk, K)
#> Error in `select_by_pct_loss()`:
#> ! Could not sort results by `weight_funk`.

# misspell both:
select_by_pct_loss(ames_grid_search, metric = "rmse", weight_funk, Kay)
#> Error in `select_by_pct_loss()`:
#> ! Could not sort results by `weight_funk` and `Kay`.
```

<sup>Created on 2022-11-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>