### PR TITLE
separate `get_operator()` into two functions

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -2,23 +2,31 @@
 # Helpers for parallel processing
 
 # object should be a workflow
-get_operator <- function(allow = TRUE, object) {
+allow_parallelism <- function(allow = TRUE, object = NULL) {
   is_par <- foreach::getDoParWorkers() > 1
-  pkgs <- required_pkgs(object)
-  blacklist <- c("keras", "rJava")
-  if (is_par & allow && any(pkgs %in% blacklist)) {
-    pkgs <- pkgs[pkgs %in% blacklist]
-    msg <- paste0("'", pkgs, "'", collapse = ", ")
-    msg <- paste("Some required packages prohibit parallel processing: ", msg)
-    cli::cli_alert_warning(msg)
-    allow <- FALSE
+  if (!is.null(object)) {
+    pkgs <- required_pkgs(object)
+    blacklist <- c("keras", "rJava")
+    if (is_par & allow && any(pkgs %in% blacklist)) {
+      pkgs <- pkgs[pkgs %in% blacklist]
+      msg <- paste0("'", pkgs, "'", collapse = ", ")
+      msg <- paste("Some required packages prohibit parallel processing: ", msg)
+      cli::cli_alert_warning(msg)
+      allow <- FALSE
+    }
   }
 
-  cond <- allow && is_par
+  allow && is_par
+}
+
+get_operator <- function(allow = TRUE, object) {
+  cond <- allow_parallelism(allow, object)
+
   if (cond) {
     res <- foreach::`%dopar%`
   } else {
     res <- foreach::`%do%`
   }
+
   res
 }

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -20,9 +20,7 @@ allow_parallelism <- function(allow = TRUE, object = NULL) {
 }
 
 get_operator <- function(allow = TRUE, object) {
-  cond <- allow_parallelism(allow, object)
-
-  if (cond) {
+  if (allow_parallelism(allow, object)) {
     res <- foreach::`%dopar%`
   } else {
     res <- foreach::`%do%`


### PR DESCRIPTION
The issue cataloger (#588) only kicks in when parallelism will not be used (i.e. when `tune:::get_operator()` returns `foreach::%do%` rather than `foreach::%dopar%`). This PR makes no functional changes to `get_operator()`, but splits the logic that generates the logical value that `get_operator()` will use to conditionally pick the `do` operator into a helper called `allow_parallelism()`. We can then use the conditions generated by `allow_parallelism()` to decide whether to raise prompts as usual or use the issue cataloger.