### PR TITLE
transition messaging functions

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -234,7 +234,7 @@ check_bayes_initial_size <- function(num_param, num_grid, race = FALSE) {
 
   if (num_grid < num_param + 1) {
     diff <- num_param - num_grid + 1
-    rlang::inform(
+    cli::cli_bullets(
       c(
         `!` = msg,
         `*` = cli::pluralize(

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -407,7 +407,7 @@ set_workflow <- function(workflow, control) {
         cols <- get_tune_colors()
         msg <- strwrap(msg, prefix = paste0(cols$symbol$info(cli::symbol$info), " "))
         msg <- cols$message$info(paste0(msg, collapse = "\n"))
-        rlang::inform(msg)
+        cli::cli_bullets(msg)
       }
     }
     workflow

--- a/tests/testthat/_snaps/bayes.md
+++ b/tests/testthat/_snaps/bayes.md
@@ -451,7 +451,8 @@
       tune:::check_bayes_initial_size(5, 3, FALSE)
     Message
       ! There are 5 tuning parameters and 3 grid points were requested.
-      * There are more tuning parameters than there are initial points. This is likely to cause numerical issues in the first few search iterations.
+      * There are more tuning parameters than there are initial points. This is
+        likely to cause numerical issues in the first few search iterations.
 
 ---
 
@@ -459,7 +460,8 @@
       tune:::check_bayes_initial_size(5, 3, TRUE)
     Message
       ! There are 5 tuning parameters and 3 grid points were requested.
-      * There are more tuning parameters than there are initial points. This is likely to cause numerical issues in the first few search iterations.
+      * There are more tuning parameters than there are initial points. This is
+        likely to cause numerical issues in the first few search iterations.
       * With racing, only completely resampled parameters are used.
 
 ---
@@ -468,7 +470,8 @@
       tune:::check_bayes_initial_size(2, 2, FALSE)
     Message
       ! There are 2 tuning parameters and 2 grid points were requested.
-      * There are as many tuning parameters as there are initial points. This is likely to cause numerical issues in the first few search iterations.
+      * There are as many tuning parameters as there are initial points. This is
+        likely to cause numerical issues in the first few search iterations.
 
 ---
 

--- a/tests/testthat/_snaps/resample.md
+++ b/tests/testthat/_snaps/resample.md
@@ -111,9 +111,9 @@
       fit_resamples(lin_mod, recipes::recipe(mpg ~ ., mtcars[rep(1:32, 3000), ]),
       folds, control = control_resamples(save_workflow = TRUE))
     Message
-      i The workflow being saved contains a recipe, which is 8.07 Mb in
-      i memory. If this was not intentional, please set the control setting
-      i `save_workflow = FALSE`.
+      i The workflow being saved contains a recipe, which is 8.07 Mb in i memory. If
+      this was not intentional, please set the control setting i `save_workflow =
+      FALSE`.
     Output
       # Resampling results
       # 2-fold cross-validation 


### PR DESCRIPTION
Related to #588. `cli::cli_bullets()` is aware of the progress bar and will clear it before printing, while `rlang::inform()` will print on top of it and leave remaining characters visible:


https://user-images.githubusercontent.com/35748691/208186327-0fe06dd5-d2d1-4dec-91b5-190d8648f20e.mov

