### PR TITLE
drop grid attributes in `check_grid()`

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -61,7 +61,10 @@ check_grid <- function(grid, workflow, pset = NULL) {
     }
 
     grid_distinct <- distinct(grid)
+
+    # remove attributes, particularly those tacked on by `expand.grid()`
     grid_distinct <- vctrs::new_data_frame(grid_distinct, n = nrow(grid_distinct))
+
     if (!identical(nrow(grid_distinct), nrow(grid))) {
       rlang::warn(
         "Duplicate rows in grid of tuning combinations found and removed."

--- a/R/checks.R
+++ b/R/checks.R
@@ -61,7 +61,7 @@ check_grid <- function(grid, workflow, pset = NULL) {
     }
 
     grid_distinct <- distinct(grid)
-    grid_distinct <- vctrs::vec_restore(grid_distinct, tibble::tibble())
+    grid_distinct <- vctrs::new_data_frame(grid_distinct, n = nrow(grid_distinct))
     if (!identical(nrow(grid_distinct), nrow(grid))) {
       rlang::warn(
         "Duplicate rows in grid of tuning combinations found and removed."

--- a/R/checks.R
+++ b/R/checks.R
@@ -61,6 +61,7 @@ check_grid <- function(grid, workflow, pset = NULL) {
     }
 
     grid_distinct <- distinct(grid)
+    grid_distinct <- vctrs::vec_restore(grid_distinct, tibble::tibble())
     if (!identical(nrow(grid_distinct), nrow(grid))) {
       rlang::warn(
         "Duplicate rows in grid of tuning combinations found and removed."


### PR DESCRIPTION
Closes #603!

Per dplyr 1.1.0 NEWS:

> `distinct()` now retains attributes of bare data frames (#6318).