### PR TITLE
remove dplyr compatibility test for 0-row `slice()`

### DIFF
--- a/tests/testthat/test-compat-dplyr-old.R
+++ b/tests/testthat/test-compat-dplyr-old.R
@@ -128,7 +128,6 @@ test_that("slice() drops tune_results class when rows are modified", {
 
 test_that("slice() keeps tune_results class when rows are untouched", {
   for (x in helper_tune_results) {
-    expect_s3_class_tune_results(slice(x))
     expect_s3_class_tune_results(slice(x, seq_len(nrow(x))))
   }
 })


### PR DESCRIPTION
From the dplyr 1.1.0 release notes:

> slice() with no inputs now returns 0 rows. This is mostly for theoretical consistency (https://github.com/tidyverse/dplyr/pull/6573).

On the relevant PR, Davis points out the same failure occurring with rsample in revdeps, with the same changes made to those tests [here](https://github.com/tidymodels/rsample/pull/380).

Note that we continue to test "`slice()` keep[ing] tune_results class when rows are untouched" in the line following the removed line.

Edit: closes #602. :)