### PR TITLE
consolidate "All models failed" messages

### DIFF
--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -293,6 +293,12 @@ tune_bayes_workflow <-
       return(out)
     })
 
+    # Preempt `estimate_tune_results()` error and rely
+    # on `on.exit()` condition to return preliminary results
+    if (is_cataclysmic(unsummarized)) {
+      return()
+    }
+
     # Get the averaged resampling stats before stripping attributes
     mean_stats <- estimate_tune_results(unsummarized)
 

--- a/tests/testthat/_snaps/bayes.md
+++ b/tests/testthat/_snaps/bayes.md
@@ -396,8 +396,6 @@
     Condition
       Warning:
       All models failed. Run `show_notes(.Last.tune.result)` for more information.
-      Error in `estimate_tune_results()`:
-      ! All models failed. Run `show_notes(.Last.tune.result)` for more information.
     Message
       x Optimization stopped prematurely; returning current results.
 
@@ -418,8 +416,6 @@
     Condition
       Warning:
       All models failed. Run `show_notes(.Last.tune.result)` for more information.
-      Error in `estimate_tune_results()`:
-      ! All models failed. Run `show_notes(.Last.tune.result)` for more information.
     Message
       x Optimization stopped prematurely; returning current results.
 

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -325,7 +325,7 @@ test_that("tune model only - failure in recipe is caught elegantly", {
   rec <- recipes::recipe(mpg ~ ., data = mtcars) %>%
     recipes::step_bs(disp, deg_free = NA_real_)
 
-  expect_snapshot(error = TRUE, {
+  expect_snapshot({
     cars_res <- tune_bayes(
       svm_mod,
       preprocessor = rec,
@@ -345,7 +345,7 @@ test_that("tune model only - failure in formula is caught elegantly", {
     add_formula(y ~ z) %>%
     add_model(svm_mod)
 
-  expect_snapshot(error = TRUE, {
+  expect_snapshot({
     cars_res <- tune_bayes(
       wflow,
       resamples = data_folds,


### PR DESCRIPTION
Closes #472. With this PR, the reprex in the original now gives the output:

``` r
library(tidymodels)

svm_mod <- svm_rbf(mode = "regression", cost = tune()) %>%
  set_engine("kernlab")

set.seed(7898)
data_folds <- vfold_cv(mtcars, v = 2)

# NA values not allowed in recipe
rec <- recipe(mpg ~ ., data = mtcars) %>%
  step_bs(disp, deg_free = NA_real_)

cars_res <- tune_bayes(svm_mod, preprocessor = rec, resamples = data_folds)
#> → 1 | error: Error in `step_bs()`:
#> Caused by error in `if (...) NULL`:
#> ! missing value where TRUE/FALSE needed
#> Warning: All models failed. Run `show_notes(.Last.tune.result)` for more information.
#> ✖ Optimization stopped prematurely; returning current results.
#> There were issues with some computations   1: x2
```

<sup>Created on 2023-02-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Instead of supplying both a warning and an error with the same message, "cataclysmic" initial grid results now just result in a warning and early return.