### PR TITLE
address join warnings in dplyr compatibility tests

### DIFF
--- a/tests/testthat/test-compat-dplyr.R
+++ b/tests/testthat/test-compat-dplyr.R
@@ -168,7 +168,7 @@ test_that("left_join() can keep tune_results class if tune_results structure is 
 test_that("left_join() can lose tune_results class if rows are added", {
   for (x in helper_tune_results) {
     y <- tibble(id = x$id[[1]], x = 1:2)
-    expect_s3_class_bare_tibble(left_join(x, y, by = "id"))
+    expect_s3_class_bare_tibble(left_join(x, y, by = "id", multiple = "all"))
   }
 })
 
@@ -195,7 +195,7 @@ test_that("right_join() can keep tune_results class if tune_results structure is
 test_that("right_join() can lose tune_results class if rows are added", {
   for (x in helper_tune_results) {
     y <- tibble(id = x$id[[1]], x = 1:2)
-    expect_s3_class_bare_tibble(right_join(x, y, by = "id"))
+    expect_s3_class_bare_tibble(right_join(x, y, by = "id", multiple = "all"))
   }
 })
 
@@ -203,7 +203,7 @@ test_that("right_join() restores to the type of first input", {
   for (x in helper_tune_results) {
     y <- tibble(id = x$id[[1]], x = 1)
     # technically tune_results structure is intact, but `y` is a bare tibble!
-    expect_s3_class_bare_tibble(right_join(y, x, by = "id"))
+    expect_s3_class_bare_tibble(right_join(y, x, by = "id", multiple = "all"))
   }
 })
 


### PR DESCRIPTION
Closes #601. Turns out these were coming from the tests themselves rather than the functionality they were testing, so these were a quick fix. :)