### PR TITLE
left-justify condition messages

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -187,8 +187,12 @@ tune_catalog <- function(issues) {
 
       # construct issue summary
       color <- if (current$type == "warning") {cli::col_yellow} else {cli::col_red}
+      pad <- nchar(pull(res[issue, "id"])) + 14L
+      justify <- paste0("\n", paste0(rep("\u00a0", pad), collapse = ""))
+      note <- gsub("\n", justify, current$note)
+      if (current$type == "error") {note <- paste0("\u00a0\u00a0", note)}
       msg <- glue::glue(
-        "{color(cli::style_bold(lbls[pull(res[issue, 'id'])]))} | {color(current$type)}: {current$note}"
+        "{color(cli::style_bold(lbls[pull(res[issue, 'id'])]))} | {color(current$type)}: {note}"
       )
       cli::cli_alert(msg)
     }

--- a/R/logging.R
+++ b/R/logging.R
@@ -186,13 +186,18 @@ tune_catalog <- function(issues) {
       }
 
       # construct issue summary
-      color <- if (current$type == "warning") {cli::col_yellow} else {cli::col_red}
+      color <- if (current$type == "warning") cli::col_yellow else cli::col_red
+      # pad by nchar(label) + nchar("warning") + additional spaces and symbols
       pad <- nchar(pull(res[issue, "id"])) + 14L
-      justify <- paste0("\n", paste0(rep("\u00a0", pad), collapse = ""))
+      justify <- paste0("\n", strrep("\u00a0", pad))
       note <- gsub("\n", justify, current$note)
-      if (current$type == "error") {note <- paste0("\u00a0\u00a0", note)}
+      # pad `nchar("warning") - nchar("error")` spaces to the right of the `:`
+      if (current$type == "error") {
+        note <- paste0("\u00a0\u00a0", note)
+      }
       msg <- glue::glue(
-        "{color(cli::style_bold(lbls[pull(res[issue, 'id'])]))} | {color(current$type)}: {note}"
+        "{color(cli::style_bold(lbls[pull(res[issue, 'id'])]))} | \\
+         {color(current$type)}: {note}"
       )
       cli::cli_alert(msg)
     }

--- a/inst/test_catalog.R
+++ b/inst/test_catalog.R
@@ -53,6 +53,12 @@ raise_error_numbered <- function() {local({
   }
 })}
 
+raise_multiline_conditions <- function(x) {
+  cli::cli_warn(c("hmmm what's happening", "uuuhhHhH"))
+  cli::cli_abort(c("aHHHksdjvndiuf", "!" = "),:"))
+  x
+}
+
 # run tuning processes with known errors ---------------------------------------
 # for each test case, ensure that each issue is allotted a unique and minimal
 # number that's counted correctly in the final summary. the expected
@@ -73,6 +79,16 @@ res_fit <-
   )
 #> → A | warning: ope! yikes. (but rlang)
 #> → B | error: AHHhH (but rlang)
+#> There were issues with some computations   A: x10   B: x10
+
+res_fit <-
+  fit_resamples(spec_dt, form, folds,
+                control = control_resamples(extract = raise_multiline_conditions)
+  )
+#> → A | warning: hmmm what's happening
+#>                uuuhhHhH
+#> → B | error:   aHHHksdjvndiuf
+#>                ! ),:
 #> There were issues with some computations   A: x10   B: x10
 
 res_fit <-


### PR DESCRIPTION
Closes #617.

The previous catalog output:

``` r
library(tidymodels)

become_flustered <- function(x) {
  cli::cli_warn(c("hmmm what's happening", "uuuhhHhH"))
  cli::cli_abort(c("aHHHksdjvndiuf", "!" = "),:"))
  x
}

res <- 
  fit_resamples(
    linear_reg(),
    mpg ~ .,
    bootstraps(mtcars, 10),
    control = control_resamples(extract = become_flustered)
  )
#> → A | warning: hmmm what's happening
#> uuuhhHhH
#> → B | error: aHHHksdjvndiuf
#> ! ),:
#> There were issues with some computations   A: x10   B: x10
```

Would now look like:

``` r
res <- 
  fit_resamples(
    linear_reg(),
    mpg ~ .,
    bootstraps(mtcars, 10),
    control = control_resamples(extract = become_flustered)
  )
#> → A | warning: hmmm what's happening
#>                uuuhhHhH
#> → B | error:   aHHHksdjvndiuf
#>                ! ),:
#> There were issues with some computations   A: x10   B: x10
```

Example with a more likely failure, from a recipe:

``` r
library(tidymodels)

res <- 
  fit_resamples(
    linear_reg(),
    recipe(mpg ~ ., data = mtcars) %>% step_mutate(vs = gfdhdfds + 4),
    vfold_cv(mtcars, v = 2)
  )
#> → A | error:   Error in `step_mutate()`:
#>                Caused by error in `dplyr::mutate()`:
#>                ℹ In argument: `vs = gfdhdfds + 4`.
#>                Caused by error:
#>                ! object 'gfdhdfds' not found
#> There were issues with some computations   A: x2
#> 
#> Warning: All models failed. Run `show_notes(.Last.tune.result)` for more
#> information.
```

This opts to allot 7 characters to "error" or "warning" regardless of which will be printed so that the condition messages are always left-justified even if some are errors and others are warnings.

The justification code here is pretty scrappy, pending `r-lib/cli#229`.