### PR TITLE
transition from deprecated `rlang::flatten()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     hardhat (>= 1.2.0),
     lifecycle (>= 1.0.0),
     parsnip (>= 1.0.2),
-    purrr (>= 0.3.2),
+    purrr (>= 1.0.0),
     recipes (>= 1.0.4),
     rlang (>= 1.0.2),
     rsample (>= 1.0.0),

--- a/R/pull.R
+++ b/R/pull.R
@@ -98,7 +98,7 @@ pull_all_outcome_names <- function(resamples, res) {
 
 reduce_all_outcome_names <- function(resamples) {
   all_outcome_names <- resamples$.all_outcome_names
-  all_outcome_names <- rlang::flatten(all_outcome_names)
+  all_outcome_names <- purrr::list_flatten(all_outcome_names)
   all_outcome_names <- vctrs::vec_unique(all_outcome_names)
 
   n_unique <- length(all_outcome_names)

--- a/tests/testthat/_snaps/case-weights.md
+++ b/tests/testthat/_snaps/case-weights.md
@@ -16,7 +16,7 @@
       Error in `extract_case_weights()`:
       ! `col` must exist and be a quosure at this point.
       i This is an internal error that was detected in the tune package.
-        Please report it at <https://github.com/tidymodels/tune/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+        Please report it at <https://github.com/tidymodels/tune/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 # `extract_case_weights()` errors if case weights column isn't the right class
 

--- a/tests/testthat/test-case-weights.R
+++ b/tests/testthat/test-case-weights.R
@@ -21,6 +21,7 @@ test_that("gives informative default error", {
 # extract_case_weights()
 
 test_that("`extract_case_weights()` errors if `col` doesn't exist", {
+  skip_if(packageVersion("rlang") < "1.0.6.9000")
   wf <- workflows::workflow()
 
   expect_snapshot(error = TRUE, {


### PR DESCRIPTION
Related to #619. `rlang::flatten()` is being deprecated in favor of `purrr::list_flatten()` in its upcoming release, resulting in a few snapshot changes and new warnings. This PR separates the needed changes from #619 so we can continue to work on `main` once that rlang release comes without needing to merge 619! Note that these changes don't require that new rlang release.