### PR TITLE
return complete results in `.Last.tune.result`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* Fixed bug in `tune_bayes()` where `.Last.tune.result` would return intermediate tuning results. (#613)
+
 * Refined machinery for logging issues during tuning. Rather than printing out warnings and errors as they appear, the package will now only print unique tuning issues, and iteratively update a progress bar to maintain counts of each unique issue. This feature is only enabled for tuning sequentially. (#588)
 
 * Introduced a new function `fit_best()` that provides a shorthand interface to fit a final model after parameter tuning. (#586)

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -290,6 +290,8 @@ tune_bayes_workflow <-
         workflow = NULL
       )
 
+      .stash_last_result(out)
+
       return(out)
     })
 
@@ -433,14 +435,18 @@ tune_bayes_workflow <-
     # Reset `on.exit()` hook
     on.exit()
 
-    new_iteration_results(
-      x = unsummarized,
-      parameters = param_info,
-      metrics = metrics,
-      outcomes = outcomes,
-      rset_info = rset_info,
-      workflow = workflow_output
-    )
+    res <-
+      new_iteration_results(
+        x = unsummarized,
+        parameters = param_info,
+        metrics = metrics,
+        outcomes = outcomes,
+        rset_info = rset_info,
+        workflow = workflow_output
+      )
+
+    .stash_last_result(res)
+    res
     }) # end of evalq() call
   }
 

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -125,6 +125,7 @@ test_that("tune model only (with recipe)", {
     )
   })
 
+  expect_equal(res, .Last.tune.result)
   expect_equal(unique(res$id), folds$id)
   res_est <- collect_metrics(res)
   expect_equal(nrow(res_est), iterT * 2)


### PR DESCRIPTION
Closes #613. :)

This also works for interrupted tuning:

https://user-images.githubusercontent.com/35748691/221272759-2ef95ab8-cb4c-41cd-b3d3-310cd4ed7ebe.mov

