### PR TITLE
namespacing ggplot2::CoordFixed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.0.1.9002
+Version: 1.0.1.9003
 Authors@R: c(
     person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/coord_obs_pred.R
+++ b/R/coord_obs_pred.R
@@ -13,7 +13,7 @@ CoordObsPred <-
       )
       self$limits$y <- rngs
       self$limits$x <- rngs
-      ggplot2::ggproto_parent(CoordFixed, self)$setup_panel_params(scale_x, scale_y, params)
+      ggplot2::ggproto_parent(ggplot2::CoordFixed, self)$setup_panel_params(scale_x, scale_y, params)
     },
     aspect = function(self, ranges) {
       1 / self$ratio


### PR DESCRIPTION
Fixes a bug that occurs when the function is imported from another package. 