### PR TITLE
accommodate list-columns in `grid`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* Allowed users to supply list-columns in `grid` arguments. (#625)
+
 * Fixed bug in `tune_bayes()` where `.Last.tune.result` would return intermediate tuning results. (#613)
 
 * Refined machinery for logging issues during tuning. Rather than printing out warnings and errors as they appear, the package will now only print unique tuning issues, and iteratively update a progress bar to maintain counts of each unique issue. This feature is only enabled for tuning sequentially. (#588)

--- a/R/merge.R
+++ b/R/merge.R
@@ -85,10 +85,10 @@ update_model <- function(grid, object, pset, step_id, nms, ...) {
     if (nrow(param_info) == 1) {
       if (param_info$component_id == "main") {
         object$args[[param_info$name]] <-
-          rlang::as_quosure(grid[[i]], env = rlang::empty_env())
+          rlang::as_quosure(grid[[i]][[1]], env = rlang::empty_env())
       } else {
         object$eng_args[[param_info$name]] <-
-          rlang::as_quosure(grid[[i]], env = rlang::empty_env())
+          rlang::as_quosure(grid[[i]][[1]], env = rlang::empty_env())
       }
     }
   }

--- a/tests/testthat/test-merge.R
+++ b/tests/testthat/test-merge.R
@@ -154,6 +154,24 @@ test_that("model spec merges", {
       rlang::as_quosure(bst_grid$rules[[i]], empty_env())
     )
   }
+
+  # ensure that `grid` can handle list-columns
+  bst_model_obj <-
+    boost_tree(mode = "classification") %>%
+    set_args(objective = tune())
+
+  bst_grid_obj <- tibble::tibble(objective = list("hey", "there"))
+
+  bst_updated_obj <- merge(bst_model_obj, bst_grid_obj)
+
+  expect_equal(
+    rlang::quo_get_expr(bst_updated_obj$x[[1]]$eng_args$objective),
+    "hey"
+  )
+  expect_equal(
+    rlang::quo_get_expr(bst_updated_obj$x[[2]]$eng_args$objective),
+    "there"
+  )
 })
 
 test_that("partially model spec merge", {


### PR DESCRIPTION
Closes #625—more discussion there.

Here's the reprex from that issue, with this PR:

``` r
library(tidymodels)

# focal_loss --------------------------------------------------------------
focal_loss <- function(preds, dtrain, alpha = 0.5,focal_gamma = 0) {
  labels <- getinfo(dtrain, "label")
  preds <- 1 / (1 + exp(-preds))
  
  p<- preds
  y <- labels
  
  grad <- (y*alpha*(1-p)^focal_gamma*(focal_gamma*log(p)*p-(1-p))-
             (1-y)*(1-alpha)*p^(focal_gamma)*(focal_gamma*log(1-p)*(1-p)-p))
  
  
  
  du <- y*alpha*(1-p)^(focal_gamma-1)*(log(p)*(-focal_gamma^2 *p + (1-p)*focal_gamma)+ 2*focal_gamma*(1-p)+(1-p))
  dv <- -(1-y)*(1-alpha)*p^(focal_gamma-1)*(log(1-p)*(focal_gamma^2*(1-p)-p*focal_gamma)-2*focal_gamma*p-p)
  
  hess <- (du+dv)*p*(1-p)
  
  return(list(grad = grad, hess = hess))
}

# data setup ----------------------------------------------------------------
data <- two_class_dat %>% 
  rename(y = Class)

set.seed(100)

splits <- initial_split(data,prop = 0.8, strata = y)
train_data <- training(splits)
test_data <- testing(splits)
resamples <- vfold_cv(data = train_data,v = 5,strata = y)

# specifications ----------------------------------------------------
xgb_spec <- 
  boost_tree(mode = "classification", tree_depth = tune(), trees = tune()) %>% 
  # note that i just set `objective = tune()` here
  set_engine(object = ., engine = "xgboost", objective = tune())

xgb_recipe <- train_data %>% 
  recipe(y ~ .) |> 
  #step_mutate_at(all_numeric_predictors(), fn = list(orig = ~.)) %>%
  step_normalize(all_predictors(), -all_outcomes()) 

xgb_workflow <- 
  workflow() %>% 
  add_recipe(xgb_recipe) %>% 
  add_model(xgb_spec)

# grid setup ------------------------------------------------------------------
partial_grid <-
  expand_grid(
    alpha = seq(0, 1, length.out = 3),
    focal_gamma = seq(0, 5, length.out = 3)
  )

partial_grid$partials <-
  map2(
    partial_grid$alpha,
    partial_grid$focal_gamma,
    ~partial(focal_loss, alpha = !!.x, focal_gamma = !!.y)
  )
    
xgb_grid <-
  extract_parameter_set_dials(xgb_spec) %>%
  filter(id != "objective") %>%
  grid_latin_hypercube(size = 9) %>%
  bind_cols(partial_grid %>% select(objective = partials))

# tune! -----------------------------------------------------------------------
res <- tune_grid(xgb_workflow, resamples = resamples, grid = xgb_grid)

res
#> # Tuning results
#> # 5-fold cross-validation using stratification 
#> # A tibble: 5 × 4
#>   splits            id    .metrics          .notes          
#>   <list>            <chr> <list>            <list>          
#> 1 <split [505/127]> Fold1 <tibble [18 × 7]> <tibble [0 × 3]>
#> 2 <split [505/127]> Fold2 <tibble [18 × 7]> <tibble [0 × 3]>
#> 3 <split [505/127]> Fold3 <tibble [18 × 7]> <tibble [0 × 3]>
#> 4 <split [506/126]> Fold4 <tibble [18 × 7]> <tibble [0 × 3]>
#> 5 <split [507/125]> Fold5 <tibble [18 × 7]> <tibble [0 × 3]>
```

<sup>Created on 2023-03-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>