### PR TITLE
remove `tidyr_new_interface()` check

### DIFF
--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -50,10 +50,6 @@ utils::globalVariables(
 
 # ------------------------------------------------------------------------------
 
-tidyr_new_interface <- function() {
-  utils::packageVersion("tidyr") > "0.8.99"
-}
-
 release_bullets <- function() {
   c(
     "Update dependencies with `devtools::install_dev_deps()` and update the test objects via `R CMD BATCH --vanilla inst/test_objects.R`.",

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -304,11 +304,7 @@ tune_grid_loop_iter <- function(split,
   # Nest grid_info:
   # - Preprocessor info in the outer level
   # - Model info in the inner level
-  if (tidyr_new_interface()) {
-    grid_info <- tidyr::nest(grid_info, data = !!cols)
-  } else {
-    grid_info <- tidyr::nest(grid_info, !!cols)
-  }
+  grid_info <- tidyr::nest(grid_info, data = !!cols)
 
   training <- rsample::analysis(split)
 

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -396,11 +396,7 @@ compute_grid_info_model_and_preprocessor <- function(workflow,
   parameter_names_model <- parameters_model[["id"]]
 
   # Nest model parameters, keep preprocessor parameters outside
-  if (tidyr_new_interface()) {
-    out <- tidyr::nest(grid, data = dplyr::all_of(parameter_names_model))
-  } else {
-    out <- tidyr::nest(grid, dplyr::all_of(parameter_names_model))
-  }
+  out <- tidyr::nest(grid, data = dplyr::all_of(parameter_names_model))
 
   n_preprocessors <- nrow(out)
   seq_preprocessors <- seq_len(n_preprocessors)

--- a/R/pull.R
+++ b/R/pull.R
@@ -33,12 +33,8 @@ pulley <- function(resamples, res, col) {
     return(res)
   }
 
-  if (tidyr_new_interface()) {
-    pulled_vals <- tidyr::nest(pulled_vals, data = -starts_with("id"))
-    names(pulled_vals)[ncol(pulled_vals)] <- col
-  } else {
-    pulled_vals <- tidyr::nest(pulled_vals, -starts_with("id"), .key = !!col)
-  }
+  pulled_vals <- tidyr::nest(pulled_vals, data = -starts_with("id"))
+  names(pulled_vals)[ncol(pulled_vals)] <- col
 
   res <- new_bare_tibble(resamples)
   res <- full_join(res, pulled_vals, by = id_cols)


### PR DESCRIPTION
Cutting out complexity is nice! But also, turns out `packageVersion()` is a slow-poke.🦥

With main dev:

``` r
library(tidymodels)

bench::mark(
  fit = fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars))
)
#> # A tibble: 1 × 6
#>   expression        min    median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm>  <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit             1.11s     1.11s     0.907    30.5MB     7.25
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit           1.03s    1.03s     0.936    29.4MB     8.42
```

<sup>Created on 2023-03-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

The minimum version for tidyr in DESCRIPTION has been bumped since these changes were added anyway, so this helper would always return `TRUE`:

https://github.com/tidymodels/tune/blob/e61a83bf4180d38cd85234e5ab188a4579ca2fbd/DESCRIPTION#L36
