### PR TITLE
speed up grid code paths

### DIFF
--- a/tests/testthat/_snaps/resample.md
+++ b/tests/testthat/_snaps/resample.md
@@ -22,11 +22,11 @@
     Message
       x Fold1: preprocessor 1/1:
         Error in `fit()`:
-        ! Can't subset columns that don't exist.
+        ! Can't select columns that don't exist.
         x Column `foobar` doesn't exist.
       x Fold2: preprocessor 1/1:
         Error in `fit()`:
-        ! Can't subset columns that don't exist.
+        ! Can't select columns that don't exist.
         x Column `foobar` doesn't exist.
     Condition
       Warning:

--- a/tests/testthat/_snaps/resample.md
+++ b/tests/testthat/_snaps/resample.md
@@ -22,11 +22,11 @@
     Message
       x Fold1: preprocessor 1/1:
         Error in `fit()`:
-        ! Can't select columns that don't exist.
+        ! Can't subset columns that don't exist.
         x Column `foobar` doesn't exist.
       x Fold2: preprocessor 1/1:
         Error in `fit()`:
-        ! Can't select columns that don't exist.
+        ! Can't subset columns that don't exist.
         x Column `foobar` doesn't exist.
     Condition
       Warning:


### PR DESCRIPTION
Rewrites dplyr in main grid code path to use vctrs and tibble. :)

``` r
library(tidymodels)

bench::mark(
  fit =  fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars, 100)),
  check = FALSE
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit           4.51s    4.51s    0.222       51MB     4.44
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit           3.96s    3.96s    0.252     47.7MB     4.29
```

<sup>Created on 2023-03-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>