### PR TITLE
speed up `predict_model()`

### DIFF
--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -40,11 +40,9 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
 
   for (type_iter in types) {
     # Regular predictions
-    tmp_res <-
-      predict(model, x_vals, type = type_iter) %>%
-      mutate(.row = orig_rows) %>%
-      cbind(grid, row.names = NULL) %>%
-      tibble::as_tibble()
+    tmp_res <- predict(model, x_vals, type = type_iter)
+    tmp_res$.row <- orig_rows
+    tmp_res <- vctrs::vec_cbind(tmp_res, grid)
 
     if (!is.null(submodels)) {
       submod_length <- lengths(submodels)
@@ -61,16 +59,20 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
             type = type_iter,
             !!!make_submod_arg(grid, model, submodels)
           )
-        tmp_res <-
-          eval_tidy(mp_call) %>%
-          mutate(.row = orig_rows) %>%
-          unnest(cols = dplyr::starts_with(".pred")) %>%
-          cbind(dplyr::select(grid, -dplyr::all_of(submod_param)), row.names = NULL) %>%
-          tibble::as_tibble() %>%
-          # go back to user-defined name
-          dplyr::rename(!!!make_rename_arg(grid, model, submodels)) %>%
-          dplyr::select(dplyr::all_of(names(tmp_res))) %>%
-          dplyr::bind_rows(tmp_res)
+
+        tmp_sub <- eval_tidy(mp_call)
+        tmp_sub$.row <- orig_rows
+        tmp_sub <- unnest(tmp_sub, cols = dplyr::starts_with(".pred"))
+
+        grid_bind <- grid
+        grid_bind[, submod_param] <- NULL
+
+        tmp_sub <- vctrs::vec_cbind(tmp_sub, grid_bind)
+        rownames(tmp_sub) <- NULL
+        tmp_sub <- dplyr::rename(tmp_sub, !!!make_rename_arg(grid, model, submodels))
+        tmp_sub <- tmp_sub[, names(tmp_res)]
+
+        tmp_res <- vec_rbind(tmp_sub, tmp_res)
       }
     }
 
@@ -84,7 +86,7 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
   } # end type loop
 
   # Add outcome data
-  y_vals <- dplyr::mutate(y_vals, .row = orig_rows)
+  y_vals$.row <- orig_rows
   res <- dplyr::full_join(res, y_vals, by = ".row")
 
   # Add case weights (if needed)
@@ -99,7 +101,11 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
     }
   }
 
-  tibble::as_tibble(res)
+  if (!tibble::is_tibble(res)) {
+    res <- tibble::as_tibble(res)
+  }
+
+  res
 }
 
 #' @export


### PR DESCRIPTION
Rewrites dplyr in `predict_model()` to use vctrs and tibble. :) With `main` dev tune:

``` r
library(tidymodels)

bench::mark(
  fit =  fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars)),
  tune = tune_grid(boost_tree(mode = "regression", trees = tune()), mpg ~ ., bootstraps(mtcars)),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit           1.11s    1.11s     0.903      27MB     8.13
#> 2 tune          5.28s    5.28s     0.189     394MB     6.25
```

With this PR:

``` r
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit           1.05s    1.05s     0.948    26.9MB     8.53
#> 2 tune          5.17s    5.17s     0.193     403MB     5.61
```

<sup>Created on 2023-03-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>