### PR TITLE
audit uses of `tibble()` and `as_tibble()`

### DIFF
--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -253,14 +253,14 @@ new_grid_info_resamples <- function() {
 
   iter_config <- list("Preprocessor1_Model1")
 
-  out <- tibble::tibble(
+  out <- tibble::new_tibble(list(
     .iter_preprocessor = 1L,
     .msg_preprocessor = msgs_preprocessor,
     .iter_model = 1L,
     .iter_config = iter_config,
     .msg_model = msgs_model,
     .submodels = list(list())
-  )
+  ), nrow = length(msgs_model))
 
   out
 }

--- a/R/grid_performance.R
+++ b/R/grid_performance.R
@@ -18,10 +18,13 @@ pred_type <- function(x) {
 metrics_info <- function(x) {
   metric_list <- rlang::env_get(environment(x), "fns")
   metric_dir <- purrr::map_chr(metric_list, attr, "direction")
-  res <- tibble::tibble(
-    .metric = names(metric_dir),
-    direction = unname(metric_dir),
-    type = unname(purrr::map_chr(metric_list, pred_type))
+  res <- tibble::new_tibble(
+    list(
+      .metric = names(metric_dir),
+      direction = unname(metric_dir),
+      type = unname(purrr::map_chr(metric_list, pred_type))
+    ),
+    nrow = length(metric_dir)
   )
   res
 }

--- a/R/logging.R
+++ b/R/logging.R
@@ -92,12 +92,12 @@ catalog_is_active <- function() {
 #' @export
 initialize_catalog <- function(control, env = rlang::caller_env()) {
   catalog <-
-    tibble::tibble(
+    tibble::new_tibble(list(
       type = character(0),
       note = character(0),
       n = numeric(0),
       id = numeric(0)
-    )
+    ), nrow = 0)
 
   if (!(allow_parallelism(control$allow_par) || is_testing())) {
     progress_active <- TRUE
@@ -152,9 +152,9 @@ log_catalog <- function(msg, type) {
     )
 
   issues <-
-    tibble::tibble(
-      type = type,
-      note = msg
+    tibble::new_tibble(
+      list(type = type, note = msg),
+      nrow = length(msg)
     )
 
   tune_catalog(issues)
@@ -298,7 +298,10 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
     wrn_msg <- unique(wrn_msg)
     wrn_msg <- paste(wrn_msg, collapse = ", ")
 
-    wrn_msg <- tibble::tibble(location = loc, type = "warning", note = wrn_msg)
+    wrn_msg <- tibble::new_tibble(
+      list(location = loc, type = "warning", note = wrn_msg),
+      nrow = 1
+    )
 
     notes <- dplyr::bind_rows(notes, wrn_msg)
 
@@ -317,7 +320,10 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
       err_msg <- gsub("\n$", "", err_msg)
     }
 
-    err_msg <- tibble::tibble(location = loc, type = "error", note = err_msg)
+    err_msg <- tibble::new_tibble(
+      list(location = loc, type = "error", note = err_msg),
+      nrow = 1
+    )
 
     notes <- dplyr::bind_rows(notes, err_msg)
 

--- a/R/merge.R
+++ b/R/merge.R
@@ -116,7 +116,8 @@ merger <- function(x, y, ...) {
   pset <- hardhat::extract_parameter_set_dials(x)
 
   if (nrow(pset) == 0) {
-    res <- tibble::tibble(x = purrr::map(1:nrow(y), ~x))
+    res <- purrr::map(1:nrow(y), ~x)
+    res <- tibble::new_tibble(list(x = res), nrow = length(res))
     return(res)
   }
   grid_name <- colnames(y)
@@ -132,7 +133,8 @@ merger <- function(x, y, ...) {
   }
 
   if (!any(grid_name %in% pset$id)) {
-    res <- tibble::tibble(x = purrr::map(1:nrow(y), ~ x))
+    res <- purrr::map(1:nrow(y), ~ x)
+    res <- tibble::new_tibble(list(x = res), nrow = length(res))
     return(res)
   }
 

--- a/R/merge.R
+++ b/R/merge.R
@@ -116,7 +116,7 @@ merger <- function(x, y, ...) {
   pset <- hardhat::extract_parameter_set_dials(x)
 
   if (nrow(pset) == 0) {
-    res <- purrr::map(1:nrow(y), ~x)
+    res <- purrr::map(seq_len(nrow(y)), ~x)
     res <- tibble::new_tibble(list(x = res), nrow = length(res))
     return(res)
   }
@@ -133,7 +133,7 @@ merger <- function(x, y, ...) {
   }
 
   if (!any(grid_name %in% pset$id)) {
-    res <- purrr::map(1:nrow(y), ~ x)
+    res <- purrr::map(seq_len(nrow(y)), ~ x)
     res <- tibble::new_tibble(list(x = res), nrow = length(res))
     return(res)
   }

--- a/R/min_grid.R
+++ b/R/min_grid.R
@@ -109,7 +109,7 @@ get_submodel_info <- function(spec) {
     dplyr::filter(engine == spec$engine) %>%
     dplyr::select(name = parsnip, has_submodel) %>%
     dplyr::full_join(
-      hardhat::extract_parameter_set_dials(spec) %>% tibble::as_tibble() %>% dplyr::select(name, id),
+      hardhat::extract_parameter_set_dials(spec) %>% dplyr::select(name, id),
       by = "name"
     ) %>%
     dplyr::mutate(id = ifelse(is.na(id), name, id)) %>%
@@ -127,7 +127,7 @@ submod_only <- function(grid) {
     return(grid)
   }
   nm <- colnames(grid)[1]
-  fit_only <- tibble::tibble(nm = max(grid[[nm]], na.rm = TRUE))
+  fit_only <- tibble::new_tibble(list(nm = max(grid[[nm]], na.rm = TRUE)), nrow = 1)
   names(fit_only) <- nm
   sub_mods <- list(grid[[nm]][-which.max(grid[[nm]])])
   names(sub_mods) <- nm

--- a/R/pull.R
+++ b/R/pull.R
@@ -123,9 +123,9 @@ reduce_all_outcome_names <- function(resamples) {
 
 ensure_tibble <- function(x) {
   if (is.null(x)) {
-    res <- tibble::tibble(.notes = character(0))
+    res <- tibble::new_tibble(list(.notes = character(0)), nrow = 0)
   } else {
-    res <- tibble::tibble(.notes = x)
+    res <- tibble::new_tibble(list(.notes = x), nrow = length(x))
   }
   res
 }

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -320,7 +320,10 @@ tune_bayes_workflow <-
 
     for (i in (1:iter) + score_card$overall_iter) {
       .notes <-
-        tibble::tibble(location = character(0), type = character(0), note = character(0))
+        tibble::new_tibble(
+          list(location = character(0), type = character(0), note = character(0)),
+          nrow = 0
+        )
 
       log_best(control, i, score_card)
 

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -379,7 +379,7 @@ pull_rset_attributes <- function(x) {
   att <- attributes(x)
   att_nms <- names(att)
   att_nms <- setdiff(att_nms, excl_att)
-  att$class <- setdiff(class(x), class(tibble::tibble()))
+  att$class <- setdiff(class(x), class(tibble::new_tibble(list())))
   att$class <- att$class[att$class != "rset"]
 
   lab <- try(pretty(x), silent = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,7 +92,7 @@ new_bare_tibble <- function(x, ..., class = character()) {
   if (any(names(x) == "parameters")) {
     res <- x$parameters
   } else {
-    res <- tibble::tibble()
+    res <- tibble::new_tibble(list())
   }
   res
 }


### PR DESCRIPTION
Makes sure we only use `tibble::tibble()` and `tibble::as_tibble()` when we need to, as:

``` r
library(tibble)
  
tbl <- tibble()

bench::mark(
  tibble = tibble(),
  as_tibble = as_tibble(tbl),
  new_tibble_tbl = new_tibble(tbl),
  new_tibble_list = new_tibble(list()),
  iterations = 10
)
#> # A tibble: 4 × 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tibble            43.3µs  45.22µs    18938.      280B        0
#> 2 as_tibble        36.24µs   37.7µs    24980.     101KB        0
#> 3 new_tibble_tbl    4.88µs   5.37µs   174965.        0B        0
#> 4 new_tibble_list   4.76µs   5.43µs   184495.        0B        0
```

<sup>Created on 2023-03-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

With `main` dev tune:

``` r
library(tidymodels)

bench::mark(
  fit =  fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars)),
  iterations = 5
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit           1.08s    1.09s     0.923      27MB     7.38
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit           1.04s    1.05s     0.943      27MB     7.54
```

<sup>Created on 2023-03-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>