### PR TITLE
pre-extract workflow parameter set

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -261,7 +261,7 @@ tune_grid_loop_iter <- function(split,
                                 metrics,
                                 control,
                                 seed,
-                                params = hardhat::extract_parameter_set_dials(workflow)) {
+                                params) {
   load_pkgs(workflow)
   .load_namespace(control$pkgs)
 


### PR DESCRIPTION
The extraction of parameter sets from workflows is now much quicker, though it still happens for every resample. In the boilerplate mtcars bootstrap fit, it accounts for ~13% of total evaluation time with `main` dev. Since the workflow is not an index of the loop over `tune_grid_loop_iter`, we can pre-compute the parameter set and pass it as an argument. 

With `main` dev:

``` r
library(tidymodels)

set.seed(1)

bench::mark(
  total = fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars, 100)),
  iterations = 5
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total         2.71s    2.73s     0.363    46.3MB     6.96
```

<sup>Created on 2023-03-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total         2.35s    2.39s     0.415    43.5MB     7.40
```

<sup>Created on 2023-03-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>