### PR TITLE
pre-compute `metrics_info(metrics)`

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -264,7 +264,7 @@ tune_grid_loop_iter <- function(split,
                                 metrics,
                                 control,
                                 seed,
-                                metrics_info = metrics_info(metrics)),
+                                metrics_info = metrics_info(metrics),
                                 params) {
   load_pkgs(workflow)
   .load_namespace(control$pkgs)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -136,6 +136,7 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
   splits <- resamples$splits
   packages <- c(control$pkgs, required_pkgs(workflow))
   grid_info <- compute_grid_info(workflow, grid)
+  metrics_info <- metrics_info(metrics)
 
   if (!catalog_is_active()) {
     initialize_catalog(control = control)
@@ -172,7 +173,8 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
           workflow = workflow,
           metrics = metrics,
           control = control,
-          seed = seed
+          seed = seed,
+          metrics_info = metrics_info
         )
       }
     )
@@ -210,7 +212,8 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
             workflow = workflow,
             metrics = metrics,
             control = control,
-            seed = seed
+            seed = seed,
+            metrics_info = metrics_info
           )
         }
     )
@@ -257,7 +260,8 @@ tune_grid_loop_iter <- function(split,
                                 workflow,
                                 metrics,
                                 control,
-                                seed) {
+                                seed,
+                                metrics_info = metrics_info(metrics)) {
   load_pkgs(workflow)
   .load_namespace(control$pkgs)
 
@@ -405,7 +409,8 @@ tune_grid_loop_iter <- function(split,
       iter_msg_predictions <- paste(iter_msg_model, "(predictions)")
 
       iter_predictions <- .catch_and_log(
-        predict_model(split, workflow, iter_grid, metrics, iter_submodels),
+        predict_model(split, workflow, iter_grid, metrics,
+                      iter_submodels, metrics_info = metrics_info),
         control,
         split,
         iter_msg_predictions,
@@ -426,7 +431,8 @@ tune_grid_loop_iter <- function(split,
         outcome_name = outcome_names,
         event_level = event_level,
         split = split,
-        .config = iter_config
+        .config = iter_config,
+        metrics_info = metrics_info
       )
 
       iter_config_metrics <- extract_metrics_config(param_names, out_metrics)
@@ -458,7 +464,8 @@ tune_grid_loop_iter_safely <- function(fn_tune_grid_loop_iter,
                                        workflow,
                                        metrics,
                                        control,
-                                       seed) {
+                                       seed,
+                                       metrics_info) {
   fn_tune_grid_loop_iter_wrapper <- super_safely(fn_tune_grid_loop_iter)
 
   # Likely want to debug with `debugonce(tune_grid_loop_iter)`
@@ -468,7 +475,8 @@ tune_grid_loop_iter_safely <- function(fn_tune_grid_loop_iter,
     workflow,
     metrics,
     control,
-    seed
+    seed,
+    metrics_info = metrics_info
   )
 
   error <- result$error

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -1,4 +1,4 @@
-predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
+predict_model <- function(split, workflow, grid, metrics, submodels = NULL, metrics_info) {
   model <- extract_fit_parsnip(workflow)
 
   new_data <- rsample::assessment(split)
@@ -32,8 +32,7 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL) {
   }
 
   # Determine the type of prediction that is required
-  type_info <- metrics_info(metrics)
-  types <- unique(type_info$type)
+  types <- unique(metrics_info$type)
 
   res <- NULL
   merge_vars <- c(".row", names(grid))

--- a/R/grid_performance.R
+++ b/R/grid_performance.R
@@ -46,11 +46,13 @@ metrics_info <- function(x) {
 #' @param workflow A workflow.
 #' @param grid_preprocessor A tibble with parameter information.
 #' @param new_data A data frame or matrix of predictors to process.
+#' @param metrics_info The output of `tune:::metrics_info(metrics)`---only
+#' included as an argument to allow for pre-computing.
 #' @keywords internal
 #' @name tune-internal-functions
 #' @export
 .estimate_metrics <- function(dat, metric, param_names, outcome_name, event_level,
-                              metrics_info) {
+                              metrics_info = metrics_info(metrics)) {
   if (inherits(dat, "try-error")) {
     return(NULL)
   }

--- a/R/grid_performance.R
+++ b/R/grid_performance.R
@@ -49,14 +49,14 @@ metrics_info <- function(x) {
 #' @keywords internal
 #' @name tune-internal-functions
 #' @export
-.estimate_metrics <- function(dat, metric, param_names, outcome_name, event_level) {
+.estimate_metrics <- function(dat, metric, param_names, outcome_name, event_level,
+                              metrics_info) {
   if (inherits(dat, "try-error")) {
     return(NULL)
   }
 
   # Determine the type of prediction that is required
-  type_info <- metrics_info(metric)
-  types <- unique(type_info$type)
+  types <- unique(metrics_info$type)
 
   if (length(outcome_name) > 1L) {
     rlang::abort(paste0(

--- a/R/pull.R
+++ b/R/pull.R
@@ -140,7 +140,8 @@ append_metrics <- function(collection,
                            outcome_name,
                            event_level,
                            split,
-                           .config = NULL) {
+                           .config = NULL,
+                           metrics_info) {
   if (inherits(predictions, "try-error")) {
     return(collection)
   }
@@ -150,7 +151,8 @@ append_metrics <- function(collection,
     metric = metrics,
     param_names = param_names,
     outcome_name = outcome_name,
-    event_level = event_level
+    event_level = event_level,
+    metrics_info = metrics_info
   )
 
   tmp_est <- cbind(tmp_est, labels(split))

--- a/man/tune-internal-functions.Rd
+++ b/man/tune-internal-functions.Rd
@@ -16,7 +16,14 @@ forge_from_workflow(new_data, workflow)
 
 finalize_workflow_preprocessor(workflow, grid_preprocessor)
 
-.estimate_metrics(dat, metric, param_names, outcome_name, event_level)
+.estimate_metrics(
+  dat,
+  metric,
+  param_names,
+  outcome_name,
+  event_level,
+  metrics_info = metrics_info(metrics)
+)
 
 .load_namespace(x)
 
@@ -43,6 +50,9 @@ initialize_catalog(control, env = rlang::caller_env())
 outcome.}
 
 \item{event_level}{A logical passed from the control function.}
+
+\item{metrics_info}{The output of \code{tune:::metrics_info(metrics)}---only
+included as an argument to allow for pre-computing.}
 
 \item{x}{A character vector of package names.}
 


### PR DESCRIPTION
The `metrics_info` helper is a small helper to reformat `as_tibble.metric_set` for easier filtering/selecting. It's reasonably fast, but was called in a couple places inside the `tune_grid_loop_iter` _interior_ loops, so ends up being called thousands of times even for small grid searches. We can thus pre-compute that output and pass it as an argument to `tune_grid_loop_iter`. Note that this introduces merge conflicts with #641—glad to take care of that once we get there.

With `main` dev:

``` r
library(tidymodels)

set.seed(1)

bench::mark(
  total = fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars, 100)),
  iterations = 5
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total         2.71s    2.73s     0.363    46.3MB     6.96
```

...with a 4% decrease in evaluation time with this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total          2.6s    2.62s     0.377    45.3MB     7.23
```

That effect is more substantial when tuning hyperparameters. :)

<sup>Created on 2023-03-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
