### PR TITLE
use `verbose` option to toggle cataloger

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -99,7 +99,9 @@ initialize_catalog <- function(control, env = rlang::caller_env()) {
       id = numeric(0)
     ), nrow = 0)
 
-  if (!(allow_parallelism(control$allow_par) || is_testing())) {
+  if (!(allow_parallelism(control$allow_par) ||
+        is_testing()) &&
+      !control$verbose) {
     progress_active <- TRUE
   } else {
     progress_active <- FALSE
@@ -290,7 +292,7 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
   control2 <- control
   control2$verbose <- TRUE
 
-  should_catalog <- !(allow_parallelism(control$allow_par) || is_testing())
+  should_catalog <- uses_catalog()
 
   wrn <- res$signals
   if (length(wrn) > 0) {


### PR DESCRIPTION
Closes #643!🍄

This PR makes some small changes that reconcile the `verbose` control option with the issue cataloger. Note that this PR doesn't change the `verbose` argument description:

https://github.com/tidymodels/tune/blob/009b43317bcb8b163b4eb9a6da31ac83cfd184d4/R/control.R#L119-L124

This behavior feels more consistent with the currently documented description. 

* When `verbose` is `TRUE`, we log all results incl warnings and errors as they appear. Output with the cataloger is awkward in that case:

```
✓ Bootstrap1: preprocessor 1/1
→ A | warning: non-list contrasts argument ignored
✓ Bootstrap1: preprocessor 1/1, model 1/1        
✓ Bootstrap2: preprocessor 1/1                   
✓ Bootstrap2: preprocessor 1/1, model 1/1        
✓ Bootstrap3: preprocessor 1/1                   
✓ Bootstrap3: preprocessor 1/1, model 1/1        
✓ Bootstrap4: preprocessor 1/1                   
✓ Bootstrap4: preprocessor 1/1, model 1/1        
✓ Bootstrap5: preprocessor 1/1                   
✓ Bootstrap5: preprocessor 1/1, model 1/1        
There were issues with some computations   A: x5
```

so we instead defer to the previous machinery to log warnings and errors then.

* When `verbose` is `FALSE`, we only log warnings and errors. The cataloger is a less overwhelming UI in that case, so it kicks in then.

The other untouched but relevant bit of code here is:

https://github.com/tidymodels/tune/blob/009b43317bcb8b163b4eb9a6da31ac83cfd184d4/R/logging.R#L262-L265

...which addresses the linked issue. We missed that in tests because we disable the cataloger in tests for reproducibility. 