### PR TITLE
move forward with `parameters()` method deprecation

### DIFF
--- a/R/param_set.workflows.R
+++ b/R/param_set.workflows.R
@@ -5,46 +5,14 @@
 #'
 #' These methods have been deprecated in favor of [extract_parameter_set_dials()].
 #'
-#' These methods extend the generic [dials::parameters()] to work with more
-#' complex objects, such as recipes, model specifications, and workflows.
 #' @param x An object
 #' @param ... Not currently used.
 #' @return A parameter set object
-#' @examplesIf tune:::should_run_examples(suggests = c("xgboost", "C5.0"))
-#' library(tibble)
-#' library(recipes)
-#'
-#' recipe(mpg ~ ., data = mtcars) %>%
-#'   step_impute_knn(all_predictors(), neighbors = tune()) %>%
-#'   step_pca(all_predictors(), num_comp = tune()) %>%
-#'   dials::parameters()
-#'
-#' # A peak under the hood
-#' tibble::as_tibble(.Last.value)
-#'
-#' recipe(mpg ~ ., data = mtcars) %>%
-#'   step_ns(disp, deg_free = tune("disp df")) %>%
-#'   step_ns(wt, deg_free = tune("wt df")) %>%
-#'   dials::parameters()
-#'
-#' recipe(mpg ~ ., data = mtcars) %>%
-#'   step_normalize(all_predictors()) %>%
-#'   dials::parameters()
-#'
-#' library(parsnip)
-#'
-#' boost_tree(trees = tune(), min_n = tune()) %>%
-#'   set_engine("xgboost") %>%
-#'   dials::parameters()
-#'
-#' boost_tree(trees = tune(), min_n = tune()) %>%
-#'   set_engine("C5.0", rules = TRUE) %>%
-#'   dials::parameters()
 #'
 #' @keywords internal
 #' @export
 parameters.workflow <- function(x, ...) {
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     "0.1.6.9003",
     "parameters.workflow()",
     "hardhat::extract_parameter_set_dials()"
@@ -55,7 +23,7 @@ parameters.workflow <- function(x, ...) {
 #' @export
 #' @rdname parameters.workflow
 parameters.model_spec <- function(x, ...) {
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     "0.1.6.9003",
     "parameters.model_spec()",
     "hardhat::extract_parameter_set_dials()"
@@ -66,7 +34,7 @@ parameters.model_spec <- function(x, ...) {
 #' @export
 #' @rdname parameters.workflow
 parameters.recipe <- function(x, ...) {
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     "0.1.6.9003",
     "parameters.workflow()",
     "hardhat::extract_parameter_set_dials()"

--- a/R/pull.R
+++ b/R/pull.R
@@ -226,7 +226,7 @@ extract_metrics_config <- function(param_names, metrics) {
 #' @return A fitted model.
 #' @export
 extract_model <- function(x) {
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     "0.1.6",
     "extract_model()",
     "extract_fit_engine()"

--- a/man/parameters.workflow.Rd
+++ b/man/parameters.workflow.Rd
@@ -24,41 +24,5 @@ A parameter set object
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
 These methods have been deprecated in favor of \code{\link[=extract_parameter_set_dials]{extract_parameter_set_dials()}}.
-
-These methods extend the generic \code{\link[dials:parameters]{dials::parameters()}} to work with more
-complex objects, such as recipes, model specifications, and workflows.
-}
-\examples{
-\dontshow{if (tune:::should_run_examples(suggests = c("xgboost", "C5.0"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-library(tibble)
-library(recipes)
-
-recipe(mpg ~ ., data = mtcars) \%>\%
-  step_impute_knn(all_predictors(), neighbors = tune()) \%>\%
-  step_pca(all_predictors(), num_comp = tune()) \%>\%
-  dials::parameters()
-
-# A peak under the hood
-tibble::as_tibble(.Last.value)
-
-recipe(mpg ~ ., data = mtcars) \%>\%
-  step_ns(disp, deg_free = tune("disp df")) \%>\%
-  step_ns(wt, deg_free = tune("wt df")) \%>\%
-  dials::parameters()
-
-recipe(mpg ~ ., data = mtcars) \%>\%
-  step_normalize(all_predictors()) \%>\%
-  dials::parameters()
-
-library(parsnip)
-
-boost_tree(trees = tune(), min_n = tune()) \%>\%
-  set_engine("xgboost") \%>\%
-  dials::parameters()
-
-boost_tree(trees = tune(), min_n = tune()) \%>\%
-  set_engine("C5.0", rules = TRUE) \%>\%
-  dials::parameters()
-\dontshow{\}) # examplesIf}
 }
 \keyword{internal}


### PR DESCRIPTION
Closes #647.🦜