### PR TITLE
speed up `.config_key_from_metrics()` helper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     tibble (>= 3.1.0),
     tidyr (>= 1.2.0),
     tidyselect (>= 1.1.2),
-    vctrs (>= 0.4.1),
+    vctrs (>= 0.6.1),
     withr,
     workflows (>= 1.0.0),
     yardstick (>= 1.0.0)


### PR DESCRIPTION
This helper gets a lot of traffic inside of `collect_metrics()`, and thus `estimate_tune_results()`. tune will see some speedup here, but `stacks::add_candidates()` especially benefits.

With `main` dev:

``` r
library(tidymodels)

set.seed(1)

car_rec <-
  recipe(mpg ~ ., data = mtcars) %>%
  step_normalize(all_predictors())

svm_mod <-
  svm_rbf("regression", cost = tune(), rbf_sigma = tune()) %>%
  set_engine("kernlab")

svm_bayes <- tune_bayes(svm_mod, car_rec, vfold_cv(mtcars, v = 5))

bench::mark(
  old = .config_key_from_metrics(svm_bayes)
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old          3.71ms   3.79ms      261.    96.1KB     10.7
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new           938µs    966µs     1026.    64.8KB     10.5
```
