### PR TITLE
speed up `collector()` helper

### DIFF
--- a/R/collect.R
+++ b/R/collect.R
@@ -361,7 +361,7 @@ collector <- function(x, coll_col = ".predictions") {
 
   id_cols <- colnames(x)[grepl("id", colnames(x))]
   keep_cols <- c(coll_col, id_cols)
-  x <- x[, keep_cols]
+  x <- x[keep_cols]
   coll_col <- x[[coll_col]]
 
   res <-
@@ -373,11 +373,7 @@ collector <- function(x, coll_col = ".predictions") {
   arrange_cols <- c(".iter", ".config")
   arrange_cols <- arrange_cols[rlang::has_name(res, arrange_cols)]
 
-  if (length(arrange_cols) == 1) {
-    return(res[vctrs::vec_order(res[[arrange_cols]]), ])
-  }
-
-  arrange(res, !!!rlang::syms(arrange_cols))
+  res <- vctrs::vec_slice(res, vctrs::vec_order(res[arrange_cols]))
 }
 
 #' @export

--- a/R/collect.R
+++ b/R/collect.R
@@ -362,15 +362,16 @@ collector <- function(x, coll_col = ".predictions") {
   id_cols <- colnames(x)[grepl("id", colnames(x))]
   keep_cols <- c(coll_col, id_cols)
   x <- x[, keep_cols]
+  coll_col <- x[[coll_col]]
 
   res <-
     vctrs::vec_cbind(
-      vctrs::list_unchop(x[[coll_col]]),
-      vctrs::vec_rep_each(x[, id_cols], times = vctrs::list_sizes(x[[coll_col]]))
+      vctrs::list_unchop(coll_col),
+      vctrs::vec_rep_each(x[, id_cols], times = vctrs::list_sizes(coll_col))
     )
 
   arrange_cols <- c(".iter", ".config")
-  arrange_cols <- arrange_cols[(arrange_cols %in% names(res))]
+  arrange_cols <- arrange_cols[rlang::has_name(res, arrange_cols)]
 
   if (length(arrange_cols) == 1) {
     return(res[vctrs::vec_order(res[[arrange_cols]]), ])


### PR DESCRIPTION
This helper takes up most all of the time in `collect_predictions()`. tune will see some speedup here, but `stacks::add_candidates()` especially benefits.

With `main` dev:

``` r
library(tidymodels)

res <- 
  fit_resamples(
    linear_reg(), 
    mpg ~ ., 
    bootstraps(mtcars),
    control = control_grid(save_pred = TRUE)
  )

bench::mark(
  predictions = tune:::collector(res, ".predictions"),
  metrics = tune:::collector(res, ".metrics"),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 predictions   3.12ms    3.4ms      283.   621.4KB     6.24
#> 2 metrics       3.02ms   3.35ms      298.    36.5KB     6.22
```

With this PR:

``` r
#> # A tibble: 2 × 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 predictions    433µs    445µs     2236.    75.7KB     6.18
#> 2 metrics        328µs    337µs     2960.    12.8KB     8.26
```