### PR TITLE
restore column ordering in `collector()`

### DIFF
--- a/R/collect.R
+++ b/R/collect.R
@@ -374,8 +374,8 @@ collector <- function(x, coll_col = ".predictions") {
 
   res <-
     vctrs::vec_cbind(
-      vctrs::list_unchop(coll_col),
-      vctrs::vec_rep_each(x[, id_cols], times = vctrs::list_sizes(coll_col))
+      vctrs::vec_rep_each(x[, id_cols], times = vctrs::list_sizes(coll_col)),
+      vctrs::list_unchop(coll_col)
     )
 
   arrange_cols <- c(".iter", ".config")


### PR DESCRIPTION
#657 resulted in `id` columns landing in a different position than they previously were, resulting in [finetune failures](https://github.com/tidymodels/extratests/actions/runs/4581493656/jobs/8091062789#step:8:533) on extratests. This PR restores the column ordering from the old helper.