### PR TITLE
retain `.iter` in `collector()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tune (development version)
 
+* Fixed a bug introduced in tune 1.1.0 in `collect_()` functions where the 
+  `.iter` column was dropped.
+
 # tune 1.1.0
 
 tune 1.1.0 introduces a number of new features and bug fixes, accompanied by various optimizations that substantially decrease the total evaluation time to tune hyperparameters in the tidymodels.

--- a/tests/testthat/test-collect.R
+++ b/tests/testthat/test-collect.R
@@ -112,6 +112,11 @@ test_that("classification class predictions, averaged", {
   res <- collect_predictions(svm_tune_class, summarize = TRUE)
   expect_equal(nrow(res), nrow(two_class_dat) * nrow(svm_grd))
   expect_false(dplyr::is_grouped_df(res))
+  expect_named(
+    collect_predictions(svm_tune, summarize = TRUE),
+    c(".row", "cost value", "Class", ".config", ".iter", ".pred_Class1",
+      ".pred_Class2", ".pred_class")
+  )
 
   # pull out an example to test
   all_res_subset <-


### PR DESCRIPTION
Fixes #665! With this PR:

``` r
library(tidymodels)

res <- 
  tune_bayes(
    nearest_neighbor("regression", neighbors = tune()), 
    mpg ~ ., 
    vfold_cv(mtcars, v = 3), 
    control = tune::control_bayes(save_pred = TRUE),
    iter = 2, initial = 3
  )

collect_predictions(res)
#> # A tibble: 160 × 7
#>    id    .pred  .row neighbors   mpg .config              .iter
#>    <chr> <dbl> <int>     <int> <dbl> <chr>                <int>
#>  1 Fold1  28.2     3         2  22.8 Preprocessor1_Model1     0
#>  2 Fold1  18.5     5         2  18.7 Preprocessor1_Model1     0
#>  3 Fold1  23.9     9         2  22.8 Preprocessor1_Model1     0
#>  4 Fold1  20.1    11         2  17.8 Preprocessor1_Model1     0
#>  5 Fold1  16.2    13         2  17.3 Preprocessor1_Model1     0
#>  6 Fold1  16.2    14         2  15.2 Preprocessor1_Model1     0
#>  7 Fold1  11.5    15         2  10.4 Preprocessor1_Model1     0
#>  8 Fold1  11.5    17         2  14.7 Preprocessor1_Model1     0
#>  9 Fold1  32.7    19         2  30.4 Preprocessor1_Model1     0
#> 10 Fold1  21      30         2  19.7 Preprocessor1_Model1     0
#> # ℹ 150 more rows
```

<sup>Created on 2023-04-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


