### PR TITLE
error in `last_fit()` when supplied a fitted workflow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Added a new function, `compute_metrics()`, that allows for computing new metrics after evaluating against resamples. The arguments and output formats are closely related to those from `collect_metrics()`, but this function requires that the input be generated with the control option `save_pred = TRUE` and additionally takes a `metrics` argument with a metric set for new metrics to compute. This allows for computing new performance metrics without requiring users to re-fit and re-predict from each model. (#663)
 
+* `last_fit()` will now error when supplied a fitted workflow. (#678)
+
 # tune 1.1.1
 
 * Fixed a bug introduced in tune 1.1.0 in `collect_()` functions where the 

--- a/R/last_fit.R
+++ b/R/last_fit.R
@@ -141,8 +141,16 @@ last_fit.workflow <- function(object, split, ..., metrics = NULL, control = cont
   last_fit_workflow(object, split, metrics, control)
 }
 
-last_fit_workflow <- function(object, split, metrics, control) {
+last_fit_workflow <- function(object, split, metrics, control, call = rlang::caller_env()) {
   check_no_tuning(object)
+
+  if (workflows::is_trained_workflow(object)) {
+    cli::cli_abort(
+      "`last_fit()` is not well-defined for a fitted workflow.",
+      call = call
+    )
+  }
+
   splits <- list(split)
   resamples <- rsample::manual_rset(splits, ids = "train/test split")
 

--- a/tests/testthat/_snaps/last-fit.md
+++ b/tests/testthat/_snaps/last-fit.md
@@ -7,6 +7,14 @@
       ! `last_fit()` (`?tune::last_fit()`) is not well-defined for fitted model objects.
       i `last_fit()` (`?tune::last_fit()`) takes a model specification (`?parsnip::model_spec()`) or unfitted workflow (`?workflows::workflow()`) as its first argument.
 
+# workflow method
+
+    Code
+      last_fit(lm_fit)
+    Condition
+      Error in `last_fit()`:
+      ! `last_fit()` is not well-defined for a fitted workflow.
+
 # ellipses with last_fit
 
     Code

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -66,6 +66,15 @@ test_that("model_fit method", {
   expect_snapshot(last_fit(lm_fit), error = TRUE)
 })
 
+test_that("workflow method", {
+  library(parsnip)
+  library(workflows)
+
+  lm_fit <- workflow(mpg ~ ., linear_reg()) %>% fit(data = mtcars)
+
+  expect_snapshot(last_fit(lm_fit), error = TRUE)
+})
+
 test_that("collect metrics of last fit", {
   set.seed(23598723)
   split <- rsample::initial_split(mtcars)


### PR DESCRIPTION
Closes #678!

Will drop revdepchecks here in a bit. Job name: `42082da7-21b9-405c-ac4a-920d97511110`.