### PR TITLE
fix argument name in `vfold_cv()`

### DIFF
--- a/tests/testthat/test-extract-helpers.R
+++ b/tests/testthat/test-extract-helpers.R
@@ -24,7 +24,7 @@ test_that("extract methods for resample_results objects", {
       recipes::step_normalize(recipes::all_numeric_predictors()))
   lm_rec_res <- fit_resamples(
     lm_rec_wflow,
-    resamples = rsample::vfold_cv(mtcars, V = 2),
+    resamples = rsample::vfold_cv(mtcars, v = 2),
     control = control_resamples(save_workflow = TRUE)
   )
 


### PR DESCRIPTION
to avoid errors with the stricter dev version of rsample