### PR TITLE
Fix passing of `eval_time` from `last_fit_workflow()` to `last_fit.workflow()` 

### DIFF
--- a/R/last_fit.R
+++ b/R/last_fit.R
@@ -149,7 +149,14 @@ last_fit.workflow <- function(object, split, ..., metrics = NULL,
 }
 
 
-last_fit_workflow <- function(object, split, metrics, control, call = rlang::caller_env(), eval_time = NULL) {
+last_fit_workflow <- function(object,
+                              split,
+                              metrics,
+                              control,
+                              eval_time = NULL,
+                              ...,
+                              call = rlang::caller_env()) {
+  rlang::check_dots_empty()
   check_no_tuning(object)
 
   if (workflows::is_trained_workflow(object)) {

--- a/tests/testthat/_snaps/last-fit.md
+++ b/tests/testthat/_snaps/last-fit.md
@@ -12,7 +12,7 @@
     Code
       last_fit(lm_fit)
     Condition
-      Error:
+      Error in `last_fit()`:
       ! `last_fit()` is not well-defined for a fitted workflow.
 
 # ellipses with last_fit


### PR DESCRIPTION
Closes #691 

This changes signature of `last_fit_workflow()` in two ways
- moving `eval_time` up for how `last_fit_workflow()` gets called inside of `last_fit.workflow()` and `last_fit.model_spec()`
- add dots and `check_dots_empty()` to force usage of `call` as a named argument

``` r
library(tidymodels)
library(censored)
#> Loading required package: survival

lung <- lung %>% 
  mutate(event_time = Surv(time, status), .keep = "unused")

set.seed(1)
lung_split <- initial_split(lung)

lasso_spec <- proportional_hazards(penalty = 0.1, mixture = 0) %>%
  set_engine("glmnet") %>%
  set_mode("censored regression")

lasso_wflow <- workflow() %>% 
  add_model(lasso_spec) %>% 
  add_formula(event_time ~ .)

last_fit(lasso_wflow, lung_split, eval_time = c(100, 200))
#> # Resampling results
#> # Manual resampling 
#> # A tibble: 1 × 6
#>   splits           id               .metrics .notes   .predictions .workflow 
#>   <list>           <chr>            <list>   <list>   <list>       <list>    
#> 1 <split [171/57]> train/test split <tibble> <tibble> <tibble>     <workflow>
```

<sup>Created on 2023-06-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>