### PR TITLE
pass patched submodel argument to prediction machinery

### DIFF
--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -62,7 +62,7 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL,
         submod_param <- names(submodels)
         subgrid <- make_submod_arg(grid, model, submodels)
 
-        tmp_sub <- predict_wrapper(model, x_vals, type_iter, eval_time, submodels)
+        tmp_sub <- predict_wrapper(model, x_vals, type_iter, eval_time, subgrid)
         tmp_sub$.row <- orig_rows
         tmp_sub <- unnest(tmp_sub, cols = dplyr::starts_with(".pred"))
 

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -113,6 +113,21 @@ test_that("tune model only (with recipe, multi-predict)", {
   expect_equal(res_est$n, rep(10, nrow(grid) * 2))
 })
 
+test_that("tune model only (without recipe, multi-predict. #695)", {
+  skip_on_cran()
+  skip_if_not_installed("kknn")
+
+  knn_res <-
+    tune_grid(
+      parsnip::nearest_neighbor(mode = "regression", neighbors = tune("k")),
+      mpg ~ .,
+      resamples = rsample::bootstraps(mtcars, 5),
+      grid = 4
+    )
+
+  expect_equal(nrow(knn_res$.notes[[1]]), 0)
+})
+
 # ------------------------------------------------------------------------------
 
 test_that("tune model only (fairness - include `by` variable as predictor)", {


### PR DESCRIPTION
Closes #695. :)

``` r
library(tidymodels)

set.seed(2020)
knn_res <- 
  tune_grid(
    nearest_neighbor(mode = "regression", neighbors = tune("k")),
    mpg ~ .,
    resamples = bootstraps(mtcars, 5),
    grid = 4
  )

knn_res
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 4
#>   splits          id         .metrics         .notes          
#>   <list>          <chr>      <list>           <list>          
#> 1 <split [32/13]> Bootstrap1 <tibble [8 × 5]> <tibble [0 × 3]>
#> 2 <split [32/12]> Bootstrap2 <tibble [8 × 5]> <tibble [0 × 3]>
#> 3 <split [32/10]> Bootstrap3 <tibble [8 × 5]> <tibble [0 × 3]>
#> 4 <split [32/12]> Bootstrap4 <tibble [8 × 5]> <tibble [0 × 3]>
#> 5 <split [32/14]> Bootstrap5 <tibble [8 × 5]> <tibble [0 × 3]>
```

<sup>Created on 2023-06-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>