### PR TITLE
align machinery for `".by"` and `".eval_time"` grouping

### DIFF
--- a/R/collect.R
+++ b/R/collect.R
@@ -528,13 +528,10 @@ estimate_tune_results <- function(x, col_name = ".metrics", ...) {
     x <- dplyr::distinct(x)
   }
 
-  group_cols <- c(".metric", ".estimator")
-  if (".by" %in% names(x)) {
-    group_cols <- c(group_cols, ".by")
-  }
   x <- x %>%
     tibble::as_tibble() %>%
-    dplyr::group_by(!!!rlang::syms(param_names), !!!rlang::syms(group_cols)) %>%
+    dplyr::group_by(!!!rlang::syms(param_names), .metric, .estimator,
+                    !!!rlang::syms(group_cols)) %>%
     dplyr::summarize(
       mean = mean(.estimate, na.rm = TRUE),
       n = sum(!is.na(.estimate)),

--- a/R/utils.R
+++ b/R/utils.R
@@ -131,6 +131,9 @@ new_bare_tibble <- function(x, ..., class = character()) {
   if (any(names(mtrcs) == ".eval_time")) {
     res <- c(res, ".eval_time")
   }
+  if (any(names(mtrcs) == ".by")) {
+    res <- c(res, ".by")
+  }
   res
 }
 


### PR DESCRIPTION
Closes #699. The diff of #684 looks quite clean but it actually obscures a bad merge upstream with #619. In the first few lines of `estimate_tune_results()`, #619 initialized a `group_cols` object, and #684 later overwrote it. This PR moves the logic for additionally summarizing by `".by"` into the helper used for `".eval_time"` and then uses the pattern from #619 otherwise.

Note that this changes the column ordering for `.eval_time` relative to `.metric` and `.estimator` in `collect_metrics()`. We don't test that here or in extratests, so I didn't work around it, but we can.