### PR TITLE
Fix regression from fea8b02

### DIFF
--- a/R/collect.R
+++ b/R/collect.R
@@ -528,7 +528,7 @@ estimate_tune_results <- function(x, col_name = ".metrics", ...) {
     x <- dplyr::distinct(x)
   }
 
-  group_cols <- c(".metric", ".estimator")
+  group_cols <- c(group_cols, ".metric", ".estimator")
   if (".by" %in% names(x)) {
     group_cols <- c(group_cols, ".by")
   }


### PR DESCRIPTION
An unintended regression caused by fea8b02 . Test cases for survival models are in PRs, so there was very little chance of catching this. 

We might consider adding at least one live test case but that means adding survival to Suggests (which causes a bunch of other issues). 