### PR TITLE
exclude apparent resample when summarizing metrics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Fixes bug where `.config` entries in the `.extracts` column in `tune_bayes()` output didn't align with the entries they ought to in the `.metrics` and `.predictions` columns (#715).
 
+* Metrics from apparent resamples are no longer included when estimating performance with `estimate_tune_results()` (and thus with `collect_metrics(..., summarize = TRUE)` and `compute_metrics(..., summarize = TRUE)`). (#714)
+
 # tune 1.1.2
 
 * `last_fit()` now works with the 3-way validation split objects from `rsample::initial_validation_split()`. `last_fit()` and `fit_best()` now have a new argument `add_validation_set` to include or exclude the validation set in the dataset used to fit the model (#701).

--- a/R/collect.R
+++ b/R/collect.R
@@ -531,6 +531,7 @@ estimate_tune_results <- function(x, col_name = ".metrics", ...) {
 
   x <- x %>%
     tibble::as_tibble() %>%
+    vctrs::vec_slice(., .$id != "Apparent") %>%
     dplyr::group_by(!!!rlang::syms(param_names), .metric, .estimator,
                     !!!rlang::syms(group_cols)) %>%
     dplyr::summarize(

--- a/tests/testthat/test-compute_metrics.R
+++ b/tests/testthat/test-compute_metrics.R
@@ -29,6 +29,36 @@ test_that("gives same output as collect_metrics() when metrics match", {
   expect_equal(collected_unsum, computed_unsum)
 })
 
+test_that("gives same output as collect_metrics() when metrics match (apparent)", {
+  skip_on_cran()
+  skip_if_not_installed("kknn")
+
+  library(parsnip)
+  library(rsample)
+  library(yardstick)
+
+  m_set <- metric_set(rmse)
+
+  res <-
+    fit_resamples(
+      nearest_neighbor("regression"),
+      mpg ~ cyl + hp,
+      bootstraps(mtcars, 5, apparent = TRUE),
+      metrics = m_set,
+      control = control_grid(save_pred = TRUE)
+    )
+
+  collected_sum <- collect_metrics(res)
+  computed_sum <- compute_metrics(res, m_set)
+
+  expect_equal(collected_sum, computed_sum)
+
+  collected_unsum <- collect_metrics(res, summarize = FALSE)
+  computed_unsum <- compute_metrics(res, m_set, summarize = FALSE)
+
+  expect_equal(collected_unsum, computed_unsum)
+})
+
 test_that("`metrics` argument works (numeric metrics)", {
   skip_on_cran()
   skip_if_not_installed("kknn")


### PR DESCRIPTION
Closes #714. :)

Another approach here would be not to calculate metrics from that resample at all, returning early from `append_metrics()` with a 0-row tibble. This feels somewhat user-hostile, though also we'd need some way to attach the resample id `"Apparent"` and `.config` entry to that tibble—dropping NAs in the rest of a 1-row tibble could be an option, but `collect_metrics()` would still need to know what to know about the NAs in that case. This PRs opts to make `estimate_tune_results()` (and thus `collect_metrics()` and `compute_metrics()`) aware of apparent resamples, still calculating metrics for them as normal but excluding them from summarizations.