### PR TITLE
error when `eval_time` isn't needed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 
 * Handles edge cases for `tune_bayes()`' `iter` argument more soundly. For `iter = 0`, the output of `tune_bayes()` should match `tune_grid()`, and `tune_bayes()` will now error when `iter < 0`. `tune_bayes()` will now alter the state of RNG slightly differently, resulting in changed Bayesian optimization search output. (#720)
 
+* Introduces an error in `show_best()`, `select_best()`, and `select_by_*()` functions when an `eval_time` argument is passed but will not be used.
 
 # tune 1.1.2
 

--- a/R/select_best.R
+++ b/R/select_best.R
@@ -92,6 +92,12 @@ show_best.tune_results <- function(x, metric = NULL, n = 5, eval_time = NULL, ..
     metric <- metrics
   }
 
+  # ensure that `eval_time` isn't silently ignored (#704)
+  metric_tbl <- purrr::pluck(attributes(x), "metrics")
+  metric_tbl <- tibble::as_tibble(metric_tbl)
+  metric_tbl <- vctrs::vec_slice(metric_tbl, metric_tbl$metric == metric)
+  check_eval_time(eval_time, metric_tbl)
+
   # get estimates/summarise
   summary_res <- summary_res %>% dplyr::filter(.metric == metric)
   summary_res <- choose_eval_time(summary_res, x, eval_time)

--- a/tests/testthat/_snaps/select_best.md
+++ b/tests/testthat/_snaps/select_best.md
@@ -63,6 +63,14 @@
       Error in `show_best()`:
       ! No `show_best()` exists for this type of object.
 
+# show_best respects `eval_time` argument (#704)
+
+    Code
+      show_best(sr_tune_res, metric = "concordance_survival", eval_time = 10)
+    Condition
+      Error:
+      ! Evaluation times are only used for dynamic and integrated survival metrics.
+
 # one-std error rule
 
     Code


### PR DESCRIPTION
Closes #704.

Rather than throwing a warning, as the issue suggests, I hook right into existing machinery `check_eval_time()` that errors in that case.

``` r
library(tidymodels)
library(censored)
#> Loading required package: survival

tidymodels_prefer()
theme_set(theme_bw())
options(pillar.advice = FALSE, pillar.min_title_chars = Inf)

data("mlc_churn")

mlc_churn <-
  mlc_churn %>%
  mutate(
    churned = ifelse(churn == "yes", 1, 0),
    event_time = Surv(account_length, churned)
  ) %>%
  select(event_time, account_length, voice_mail_plan) %>%
  slice(1:500)

set.seed(6941)
churn_split <- initial_split(mlc_churn, prop = 4/5)
churn_tr <- training(churn_split)
churn_te <- testing(churn_split)
churn_rs <- bootstraps(churn_tr, times = 2)

sr_tune_spec <- survival_reg(dist = tune())
eval_times <- c(10, 100, 150)
event_metrics <- metric_set(brier_survival, brier_survival_integrated,
                            concordance_survival, roc_auc_survival)
sr_grid <- tibble(dist = c("loglogistic", "lognormal"))

sr_tune_res <-
  sr_tune_spec %>%
  tune_grid(
    event_time ~ .,
    resamples = churn_rs,
    metrics = event_metrics,
    eval_time = eval_times,
    grid = sr_grid,
    control = control_grid(save_pred = TRUE)
  )

show_best(sr_tune_res, metric = "brier_survival_integrated", eval_time = 10)
#> # A tibble: 2 × 8
#>   dist        .metric         .estimator .eval_time   mean     n std_err .config
#>   <chr>       <chr>           <chr>           <dbl>  <dbl> <int>   <dbl> <chr>  
#> 1 loglogistic brier_survival… standard           NA 0.0282     2 0.00591 Prepro…
#> 2 lognormal   brier_survival… standard           NA 0.0399     2 0.00479 Prepro…
show_best(sr_tune_res, metric = "concordance_survival", eval_time = 10)
#> Error:
#> ! Evaluation times are only used for dynamic and integrated survival metrics.
#> Backtrace:
#>     ▆
#>  1. ├─tune::show_best(...)
#>  2. └─tune:::show_best.tune_results(...)
#>  3.   └─tune:::check_eval_time(eval_time, metric_tbl)
#>  4.     └─rlang::abort(...)
```

<sup>Created on 2023-10-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>