### PR TITLE
remove rsample `Remotes` entry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     purrr (>= 1.0.0),
     recipes (>= 1.0.4),
     rlang (>= 1.1.0),
-    rsample (>= 1.1.1.9001),
+    rsample (>= 1.2.0),
     tibble (>= 3.1.0),
     tidyr (>= 1.2.0),
     tidyselect (>= 1.1.2),
@@ -51,8 +51,6 @@ Suggests:
     testthat (>= 3.0.0),
     xgboost,
     xml2
-Remotes:
-    tidymodels/rsample
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate
 Config/testthat/edition: 3


### PR DESCRIPTION
The `Remotes` entry for rsample was added four months ago:

https://github.com/tidymodels/tune/blob/3f82cb2a91b93d30f1fa48c64f83d4a5c23447f6/DESCRIPTION#L54-L55

and the 1.2.0 rsample release happened in the meantime. I believe we can drop this ref?