### PR TITLE
muffle "X should be in range (0, 1)" warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.1.2.9004
+Version: 1.1.2.9005
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -578,13 +578,23 @@ fit_gp <- function(dat, pset, metric, control, eval_time = NULL, ...) {
   }
 
   opts <- list(...)
+
+  withCallingHandlers({
   if (any(names(opts) == "trace") && opts$trace) {
     gp_fit <- GPfit::GP_fit(X = x, Y = dat$mean, ...)
   } else {
     tmp_output <- utils::capture.output(
-      gp_fit <- GPfit::GP_fit(X = x, Y = dat$mean, ...)
+      withCallingHandlers(
+        gp_fit <- GPfit::GP_fit(X = x, Y = dat$mean, ...)
+      )
     )
-  }
+  }},
+    warning = function(w) {
+      if (w$message == "X should be in range (0, 1)") {
+        rlang::cnd_muffle(w)
+      }
+    }
+  )
 
   gp_fit
 }

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -584,9 +584,7 @@ fit_gp <- function(dat, pset, metric, control, eval_time = NULL, ...) {
     gp_fit <- GPfit::GP_fit(X = x, Y = dat$mean, ...)
   } else {
     tmp_output <- utils::capture.output(
-      withCallingHandlers(
-        gp_fit <- GPfit::GP_fit(X = x, Y = dat$mean, ...)
-      )
+      gp_fit <- GPfit::GP_fit(X = x, Y = dat$mean, ...)
     )
   }},
     warning = function(w) {

--- a/tests/testthat/_snaps/bayes.md
+++ b/tests/testthat/_snaps/bayes.md
@@ -451,8 +451,6 @@
     Message
       ! The Gaussian process model is being fit using 1 features but only has 2
         data points to do so. This may cause errors or a poor model fit.
-      ! Gaussian process model: X should be in range (0, 1)
-      ! Gaussian process model: X should be in range (0, 1)
 
 # too few starting values
 
@@ -523,42 +521,32 @@
         the Gaussian process model.
       ! The Gaussian process model is being fit using 1 features but only has 2
         data points to do so. This may cause errors or a poor model fit.
-      ! Gaussian process model: X should be in range (0, 1)
       ! For the rsq estimates, 1 missing value was found and removed before fitting
         the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! For the rsq estimates, 2 missing values were found and removed before
         fitting the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! For the rsq estimates, 3 missing values were found and removed before
         fitting the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! For the rsq estimates, 4 missing values were found and removed before
         fitting the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! For the rsq estimates, 5 missing values were found and removed before
         fitting the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! For the rsq estimates, 6 missing values were found and removed before
         fitting the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! For the rsq estimates, 7 missing values were found and removed before
         fitting the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! For the rsq estimates, 8 missing values were found and removed before
         fitting the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! For the rsq estimates, 9 missing values were found and removed before
         fitting the Gaussian process model.
-      ! Gaussian process model: X should be in range (0, 1)
       ! validation: internal: A correlation computation is required, but `estimate` is constant and ha...
       ! No improvement for 10 iterations; returning current results.
 


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/tune/issues/758.

A calling handler is used, and when then warning `"X should be in range (0, 1)"` is found, then it is muffled