### PR TITLE
differentiate fairness metrics in `autoplot()`

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -158,6 +158,17 @@ get_param_label <- function(x, id_val) {
   res
 }
 
+paste_param_by <- function(x) {
+  if (".by" %in% colnames(x)) {
+    x <- x %>% dplyr::mutate(.metric = case_when(
+      !is.na(.by) ~ paste0(.metric, "(", .by, ")"),
+      .default = .metric
+    ))
+  }
+
+  x
+}
+
 # TODO remove this.
 default_eval_time <- function(eval_time, x, call = rlang::caller_env()) {
   if (!any(names(x) == ".eval_time")) {
@@ -270,6 +281,7 @@ plot_perf_vs_iter <- function(x, metric = NULL, width = NULL, eval_time = NULL) 
   if (!is.null(metric)) {
     x <- x %>% dplyr::filter(.metric %in% metric)
   }
+  x <- paste_param_by(x)
   x <- x %>% dplyr::filter(!is.na(mean))
   x <- filter_plot_eval_time(x, eval_time)
 
@@ -368,6 +380,7 @@ plot_marginals <- function(x, metric = NULL, eval_time = NULL) {
   if (!is.null(metric)) {
     x <- x %>% dplyr::filter(.metric %in% metric)
   }
+  x <- paste_param_by(x)
   x <- x %>% dplyr::filter(!is.na(mean))
   x <- filter_plot_eval_time(x, eval_time)
 
@@ -493,6 +506,7 @@ plot_regular_grid <- function(x, metric = NULL, eval_time = NULL, ...) {
       ))
     }
   }
+  dat <- paste_param_by(dat)
   dat <- dat %>% dplyr::filter(!is.na(mean))
   dat <- filter_plot_eval_time(dat, eval_time)
   multi_metrics <- length(unique(dat$.metric)) > 1

--- a/R/plots.R
+++ b/R/plots.R
@@ -6,7 +6,8 @@
 #'  (each parameter versus search iteration), or `"performance"` (performance
 #'  versus iteration). The latter two choices are only used for [tune_bayes()].
 #' @param metric A character vector or `NULL` for which metric to plot. By
-#' default, all metrics will be shown via facets.
+#' default, all metrics will be shown via facets. Possible options are
+#' the entries in `.metric` column of `collect_metrics(object)`.
 #' @param width A number for the width of the confidence interval bars when
 #' `type = "performance"`. A value of zero prevents them from being shown.
 #' @param eval_time A numeric vector of time points where dynamic event time

--- a/man/autoplot.tune_results.Rd
+++ b/man/autoplot.tune_results.Rd
@@ -22,7 +22,8 @@ of each predictor versus performance; see Details below), \code{"parameters"}
 versus iteration). The latter two choices are only used for \code{\link[=tune_bayes]{tune_bayes()}}.}
 
 \item{metric}{A character vector or \code{NULL} for which metric to plot. By
-default, all metrics will be shown via facets.}
+default, all metrics will be shown via facets. Possible options are
+the entries in \code{.metric} column of \code{collect_metrics(object)}.}
 
 \item{width}{A number for the width of the confidence interval bars when
 \code{type = "performance"}. A value of zero prevents them from being shown.}

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -247,7 +247,7 @@ test_that("plot_regular_grid with fairness metrics (#773)", {
     knn, vs ~ mpg + hp + cyl, resamples = boots, grid = n_grid,
     metrics =
       yardstick::metric_set(
-        roc_auc,
+        yardstick::roc_auc,
         yardstick::demographic_parity(cyl),
         yardstick::demographic_parity(am)
       )
@@ -265,7 +265,7 @@ test_that("plot_marginals with fairness metrics (#773)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
 
-  knn <- nearest_neighbor("classification", "kknn", neighbors = tune(), weight_func = tune())
+  knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune(), weight_func = tune())
   mtcars_fair <- mtcars
   mtcars_fair$vs <- as.factor(mtcars_fair$vs)
   mtcars_fair$cyl <- as.factor(mtcars_fair$cyl)
@@ -279,7 +279,7 @@ test_that("plot_marginals with fairness metrics (#773)", {
     knn, vs ~ mpg + hp + cyl, resamples = boots, grid = n_grid,
     metrics =
       yardstick::metric_set(
-        roc_auc,
+        yardstick::roc_auc,
         yardstick::demographic_parity(cyl),
         yardstick::demographic_parity(am)
       )
@@ -312,7 +312,7 @@ test_that("plot_perf_vs_iter with fairness metrics (#773)", {
       knn, vs ~ mpg + hp + cyl, resamples = boots,
       metrics =
         yardstick::metric_set(
-          roc_auc,
+          yardstick::roc_auc,
           yardstick::demographic_parity(cyl),
           yardstick::demographic_parity(am)
         )

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -228,3 +228,101 @@ test_that("1D regular grid x labels", {
     tune_grid(mpg ~ ., resamples = rsample::vfold_cv(mtcars, v = 5), grid = 3)
   expect_equal(autoplot(res)$labels$x, c(cost = "Cost"))
 })
+
+test_that("plot_regular_grid with fairness metrics (#773)", {
+  skip_on_cran()
+  skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+
+  knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
+  mtcars_fair <- mtcars
+  mtcars_fair$vs <- as.factor(mtcars_fair$vs)
+  mtcars_fair$cyl <- as.factor(mtcars_fair$cyl)
+  mtcars_fair$am <- as.factor(mtcars_fair$am)
+  set.seed(4400)
+  boots <- rsample::bootstraps(mtcars_fair, 3)
+  n_grid <- 3
+
+  set.seed(1)
+  res <- tune_grid(
+    knn, vs ~ mpg + hp + cyl, resamples = boots, grid = n_grid,
+    metrics =
+      yardstick::metric_set(
+        roc_auc,
+        yardstick::demographic_parity(cyl),
+        yardstick::demographic_parity(am)
+      )
+  )
+
+  res_plot <- autoplot(res)
+
+  expect_contains(
+    res_plot$data$.metric,
+    c("demographic_parity(am)", "demographic_parity(cyl)", "roc_auc")
+  )
+})
+
+test_that("plot_marginals with fairness metrics (#773)", {
+  skip_on_cran()
+  skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+
+  knn <- nearest_neighbor("classification", "kknn", neighbors = tune(), weight_func = tune())
+  mtcars_fair <- mtcars
+  mtcars_fair$vs <- as.factor(mtcars_fair$vs)
+  mtcars_fair$cyl <- as.factor(mtcars_fair$cyl)
+  mtcars_fair$am <- as.factor(mtcars_fair$am)
+  set.seed(4400)
+  boots <- rsample::bootstraps(mtcars_fair, 3)
+  n_grid <- 3
+
+  set.seed(1)
+  res <- tune_grid(
+    knn, vs ~ mpg + hp + cyl, resamples = boots, grid = n_grid,
+    metrics =
+      yardstick::metric_set(
+        roc_auc,
+        yardstick::demographic_parity(cyl),
+        yardstick::demographic_parity(am)
+      )
+  )
+
+  res_plot <- autoplot(res)
+
+  expect_contains(
+    res_plot$data$.metric,
+    c("demographic_parity(am)", "demographic_parity(cyl)", "roc_auc")
+  )
+})
+
+test_that("plot_perf_vs_iter with fairness metrics (#773)", {
+  skip_on_cran()
+  skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+
+  knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
+  mtcars_fair <- mtcars
+  mtcars_fair$vs <- as.factor(mtcars_fair$vs)
+  mtcars_fair$cyl <- as.factor(mtcars_fair$cyl)
+  mtcars_fair$am <- as.factor(mtcars_fair$am)
+  set.seed(4400)
+  boots <- rsample::bootstraps(mtcars_fair, 3)
+  n_grid <- 3
+
+  set.seed(1)
+  suppressMessages(
+    res <- tune_bayes(
+      knn, vs ~ mpg + hp + cyl, resamples = boots,
+      metrics =
+        yardstick::metric_set(
+          roc_auc,
+          yardstick::demographic_parity(cyl),
+          yardstick::demographic_parity(am)
+        )
+    )
+  )
+
+  res_plot <- autoplot(res, type = "performance")
+
+  expect_contains(
+    res_plot$data$.metric,
+    c("demographic_parity(am)", "demographic_parity(cyl)", "roc_auc")
+  )
+})


### PR DESCRIPTION
The general pattern in this PR is to find the idiom

``` r
dat <- collect_metrics(x)
if (...) {
  dat <- dat %>% dplyr::filter(.metric %in% metric)
}
```

and append a `mutate()` to it. This results in plots being organized by `.metric(.by)` in output when `.by` exists, which I think is the most sound interpretation. This means that, if a user applies the same fairness metric to two different columns, they will need to pass the name in `dat$.metric` rather than the quoted input to `metric_set()`. This feels fine to me since 1) I don't imagine this use case (i.e. calculating the same fairness metric on one column and then only wanting to plot one instantiation) is super common and 2) we can document it well.

With this PR:

``` r
library(tidymodels)

mtcars$vs <- as.factor(mtcars$vs) 
mtcars$cyl <- as.factor(mtcars$cyl)
mtcars$am <- as.factor(mtcars$am)

set.seed(1)

# plot_regular_grid() ----------------------------------------------------------
res <- tune_grid(
  nearest_neighbor("classification", "kknn", neighbors = tune()), 
  vs ~ mpg + hp, 
  resamples = bootstraps(mtcars, 3), 
  grid = 3,
  metrics =
    yardstick::metric_set(
      demographic_parity(cyl),
      demographic_parity(am)
    )
)

autoplot(res)
```

![](https://i.imgur.com/IpkjW8P.png)<!-- -->

``` r

# plot_marginals() -------------------------------------------------------------
res <- tune_grid(
  nearest_neighbor("classification", "kknn", neighbors = tune(), weight_func = tune()), 
  vs ~ mpg + hp, 
  resamples = bootstraps(mtcars, 3), 
  metrics =
    yardstick::metric_set(
      demographic_parity(cyl),
      demographic_parity(am)
    )
)

autoplot(res)
```

![](https://i.imgur.com/mbYvqGe.png)<!-- -->

``` r

# iterative searches -----------------------------------------------------------
res <- tune_bayes(
  nearest_neighbor("classification", "kknn", neighbors = tune()), 
  vs ~ mpg + hp, 
  resamples = bootstraps(mtcars, 3), 
  metrics =
    yardstick::metric_set(
      roc_auc,
      demographic_parity(cyl),
      demographic_parity(am)
    )
)
#> ! No improvement for 10 iterations; returning current results.

#   plot_param_vs_iter() -------------------------------------------------------
#   needs no changes - not a parameter

#   plot_perf_vs_iter() --------------------------------------------------------
autoplot(res, type = "performance")
```

![](https://i.imgur.com/XSRcL91.png)<!-- -->

<sup>Created on 2023-12-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>