### PR TITLE
route `eval_time` to agua

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.1.2.9005
+Version: 1.1.2.9007
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -89,6 +89,7 @@ tune_grid_loop_agua <- function(resamples,
                                 workflow,
                                 metrics,
                                 control,
+                                eval_time = NULL,
                                 rng) {
   if (!rlang::is_installed("agua")) {
     rlang::abort("`agua` must be installed to use an h2o parsnip engine.")
@@ -109,6 +110,7 @@ tune_grid_loop_agua <- function(resamples,
     workflow = workflow,
     metrics = metrics,
     control = control,
+    eval_time = eval_time,
     rng = rng,
     parallel_over = parallel_over
   )


### PR DESCRIPTION
PR 1/2 to close #784. PR coming to agua in a moment!

In #619, `tune_grid_loop_tune()` gained an `eval_time` argument, but `tune_grid_loop_agua()` didn't receive one as well. The `unused argument (rng)` error results from `fn_tune_grid_loop()` arguments not being named, so `eval_time` is passed as `tune_grid_loop_agua()`'s `rng` and `rng` doesn't have anywhere to go. 