### PR TITLE
Produce errors instead of producing bad autoplot() plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 * `augment()` methods to `tune_results`, `resample_results`, and `last_fit` objects now always returns tibbles (#759).
 
+* `autoplot()` will now meaningfully error if only 1 grid point is present, rather than producing a plot. (#775)
+
 # tune 1.1.2
 
 * `last_fit()` now works with the 3-way validation split objects from `rsample::initial_validation_split()`. `last_fit()` and `fit_best()` now have a new argument `add_validation_set` to include or exclude the validation set in the dataset used to fit the model (#701).

--- a/R/plots.R
+++ b/R/plots.R
@@ -492,7 +492,10 @@ plot_marginals <- function(x, metric = NULL, eval_time = NULL) {
 }
 
 
-plot_regular_grid <- function(x, metric = NULL, eval_time = NULL, ...) {
+plot_regular_grid <- function(x,
+                              metric = NULL,
+                              eval_time = NULL,
+                              call = rlang::caller_env(), ...) {
   # Collect and filter resampling results
 
   is_race <- inherits(x, "tune_race")
@@ -514,7 +517,8 @@ plot_regular_grid <- function(x, metric = NULL, eval_time = NULL, ...) {
   if (all(vctrs::vec_count(dat$.metric)$count == 1)) {
     cli::cli_abort(
       "Only one observation per metric was present. \\
-      Unable to create meaningful plot."
+      Unable to create meaningful plot.",
+      call = call
     )
   }
 

--- a/R/plots.R
+++ b/R/plots.R
@@ -510,6 +510,14 @@ plot_regular_grid <- function(x, metric = NULL, eval_time = NULL, ...) {
   dat <- paste_param_by(dat)
   dat <- dat %>% dplyr::filter(!is.na(mean))
   dat <- filter_plot_eval_time(dat, eval_time)
+
+  if (all(vctrs::vec_count(dat$.metric)$count == 1)) {
+    cli::cli_abort(
+      "Only one observation per metric was present. \\
+      Unable to create meaningful plot."
+    )
+  }
+
   multi_metrics <- length(unique(dat$.metric)) > 1
 
   # ----------------------------------------------------------------------------

--- a/tests/testthat/_snaps/autoplot.md
+++ b/tests/testthat/_snaps/autoplot.md
@@ -23,6 +23,6 @@
     Code
       autoplot(res)
     Condition
-      Error in `plot_regular_grid()`:
+      Error in `autoplot()`:
       ! Only one observation per metric was present. Unable to create meaningful plot.
 

--- a/tests/testthat/_snaps/autoplot.md
+++ b/tests/testthat/_snaps/autoplot.md
@@ -18,3 +18,11 @@
 
     Removed 1 rows containing missing values (`geom_point()`).
 
+# regular grid plot
+
+    Code
+      autoplot(res)
+    Condition
+      Error in `plot_regular_grid()`:
+      ! Only one observation per metric was present. Unable to create meaningful plot.
+

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -326,3 +326,17 @@ test_that("plot_perf_vs_iter with fairness metrics (#773)", {
     c("demographic_parity(am)", "demographic_parity(cyl)", "roc_auc")
   )
 })
+
+test_that("regular grid plot", {
+  set.seed(1)
+  res <-
+    parsnip::svm_rbf(cost = tune()) %>%
+    parsnip::set_engine("kernlab") %>%
+    parsnip::set_mode("regression") %>%
+    tune_grid(mpg ~ ., resamples = rsample::vfold_cv(mtcars, v = 5), grid = 1)
+
+  expect_snapshot(
+    error = TRUE,
+    autoplot(res)
+  )
+})


### PR DESCRIPTION
To close #755 

``` r
library(tidymodels)
library(censored)
#> Loading required package: survival
library(finetune)

set.seed(1)
sim_dat <- prodlim::SimSurv(500) %>%
  mutate(event_time = Surv(time, event)) %>%
  select(event_time, X1, X2)

sim_rs <- vfold_cv(sim_dat)

time_points <- c(10, 1, 5, 15)

mod_spec <-
  decision_tree(tree_depth = tune(), min_n = 4) %>%
  set_engine("partykit") %>%
  set_mode("censored regression")

sint_mtrc <- metric_set(brier_survival_integrated, brier_survival)

grid <- tibble(tree_depth = c(1, 2, 10))
rctrl <- control_race(save_pred = TRUE, verbose_elim = FALSE, verbose = FALSE)

set.seed(2193)

aov_integrated_res <-
  mod_spec %>%
  tune_race_anova(
    event_time ~ X1 + X2,
    resamples = sim_rs,
    grid = grid,
    metrics = sint_mtrc,
    eval_time = time_points,
    control = rctrl
  )
#> Warning: Evaluation times are only required when dynmanic or integrated metrics are
#> selected as the primary metric (and will be ignored).

autoplot(aov_integrated_res, eval_time = 10) 
#> Error in `plot_regular_grid()`:
#> ! Only one observation per metric was present. Unable to create
#>   meaningful plot.
```