### PR TITLE
Move eval time check to avoid extra warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.1.2.9009
+Version: 1.1.2.9010
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.1.2.9008
+Version: 1.1.2.9009
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,4 +61,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.2.3

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -74,6 +74,8 @@ contains_survival_metric <- function(mtr_info) {
   any(grepl("_survival", mtr_info$class))
 }
 
+
+# choose_eval_time() is called by show_best() and select_best()
 #' @rdname choose_metric
 #' @export
 choose_eval_time <- function(x, metric, eval_time = NULL, ..., call = rlang::caller_env()) {
@@ -90,9 +92,18 @@ choose_eval_time <- function(x, metric, eval_time = NULL, ..., call = rlang::cal
     return(NULL)
   }
 
+  dyn_metric <- is_dyn(mtr_set, metric)
+
+  # If we don't need an eval time but one is passed:
+  if (!dyn_metric & !is.null(eval_time)) {
+    cli::cli_warn("Evaluation times are only required when dynmanic or
+                     integrated metrics are selected as the primary metric
+                     (and will be ignored).")
+  }
+
   # If we need an eval time, set it to the possible values so that
   # we can choose the first value
-  if (is_dyn(mtr_set, metric) && is.null(eval_time)) {
+  if (dyn_metric && is.null(eval_time)) {
     eval_time <- .get_tune_eval_times(x)
   }
 
@@ -129,6 +140,9 @@ first_metric <- function(mtr_set) {
   tibble::as_tibble(mtr_set)[1,]
 }
 
+# first_eval_time() is called by show_best() and select_best() (by way of
+# choose_eval_time()) and directly by functions that need an objective function
+# such as tune_bayes().
 #' @rdname choose_metric
 #' @export
 first_eval_time <- function(mtr_set, metric = NULL, eval_time = NULL) {
@@ -150,11 +164,6 @@ first_eval_time <- function(mtr_set, metric = NULL, eval_time = NULL) {
   # Not a metric that requires an eval_time
   no_time_req <- c("static_survival_metric", "integrated_survival_metric")
   if (mtr_info$class %in% no_time_req) {
-    if (num_times > 0) {
-      cli::cli_warn("Evaluation times are only required when dynmanic or
-                     integrated metrics are selected as the primary metric
-                     (and will be ignored).")
-    }
     return(NULL)
   }
 

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -96,8 +96,9 @@ choose_eval_time <- function(x, metric, eval_time = NULL, ..., call = rlang::cal
 
   # If we don't need an eval time but one is passed:
   if (!dyn_metric & !is.null(eval_time)) {
-    cli::cli_warn("An evaluation time is only required when a dynamic 
-                         metric is selected (and {.arg eval_time} will thus be ignored).")
+    cli::cli_warn("An evaluation time is only required when a dynamic
+                   metric is selected (and {.arg eval_time} will thus be
+                   ignored).")
   }
 
   # If we need an eval time, set it to the possible values so that

--- a/tests/testthat/_snaps/eval-time-single-selection.md
+++ b/tests/testthat/_snaps/eval-time-single-selection.md
@@ -1,16 +1,6 @@
 # selecting single eval time - pure metric sets
 
     Code
-      stc_one <- first_eval_time(met_stc, eval_time = times_1)
-
----
-
-    Code
-      stc_multi <- first_eval_time(met_stc, eval_time = times_2)
-
----
-
-    Code
       first_eval_time(met_dyn, eval_time = NULL)
     Condition
       Error in `first_eval_time()`:
@@ -31,36 +21,6 @@
     Condition
       Warning:
       2 evaluation times were specified during tuning; the first (0.714) will be used.
-
----
-
-    Code
-      int_1 <- first_eval_time(met_int, eval_time = times_1)
-
----
-
-    Code
-      int_multi <- first_eval_time(met_int, eval_time = times_2)
-
-# selecting single eval time - mixed metric sets - static first
-
-    Code
-      stc_1 <- first_eval_time(met_mix_stc, eval_time = times_1)
-
----
-
-    Code
-      stc_multi <- first_eval_time(met_mix_stc, eval_time = times_2)
-
----
-
-    Code
-      stc_1 <- first_eval_time(met_mix_stc_all, eval_time = times_1)
-
----
-
-    Code
-      stc_multi <- first_eval_time(met_mix_stc_all, eval_time = times_2)
 
 # selecting single eval time - mixed metric sets - dynamic first
 
@@ -93,30 +53,6 @@
     Condition
       Warning:
       2 evaluation times were specified during tuning; the first (0.714) will be used.
-
-# selecting single eval time - mixed metric sets - integrated first
-
-    Code
-      first_eval_time(met_mix_int, eval_time = times_1)
-    Output
-      NULL
-
----
-
-    Code
-      int_multi <- first_eval_time(met_mix_int, eval_time = times_2)
-
----
-
-    Code
-      first_eval_time(met_mix_int_all, eval_time = times_1)
-    Output
-      NULL
-
----
-
-    Code
-      int_multi <- first_eval_time(met_mix_int_all, eval_time = times_2)
 
 # selecting an evaluation time
 

--- a/tests/testthat/_snaps/eval-time-single-selection.md
+++ b/tests/testthat/_snaps/eval-time-single-selection.md
@@ -77,7 +77,7 @@
       choose_eval_time(surv_res, "concordance_survival", eval_time = 10)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       NULL
 

--- a/tests/testthat/_snaps/eval-time-single-selection.md
+++ b/tests/testthat/_snaps/eval-time-single-selection.md
@@ -2,17 +2,11 @@
 
     Code
       stc_one <- first_eval_time(met_stc, eval_time = times_1)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 ---
 
     Code
       stc_multi <- first_eval_time(met_stc, eval_time = times_2)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 ---
 
@@ -42,49 +36,31 @@
 
     Code
       int_1 <- first_eval_time(met_int, eval_time = times_1)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 ---
 
     Code
       int_multi <- first_eval_time(met_int, eval_time = times_2)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 # selecting single eval time - mixed metric sets - static first
 
     Code
       stc_1 <- first_eval_time(met_mix_stc, eval_time = times_1)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 ---
 
     Code
       stc_multi <- first_eval_time(met_mix_stc, eval_time = times_2)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 ---
 
     Code
       stc_1 <- first_eval_time(met_mix_stc_all, eval_time = times_1)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 ---
 
     Code
       stc_multi <- first_eval_time(met_mix_stc_all, eval_time = times_2)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 # selecting single eval time - mixed metric sets - dynamic first
 
@@ -122,9 +98,6 @@
 
     Code
       first_eval_time(met_mix_int, eval_time = times_1)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
     Output
       NULL
 
@@ -132,17 +105,11 @@
 
     Code
       int_multi <- first_eval_time(met_mix_int, eval_time = times_2)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 ---
 
     Code
       first_eval_time(met_mix_int_all, eval_time = times_1)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
     Output
       NULL
 
@@ -150,9 +117,6 @@
 
     Code
       int_multi <- first_eval_time(met_mix_int_all, eval_time = times_2)
-    Condition
-      Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
 
 # selecting an evaluation time
 

--- a/tests/testthat/_snaps/select_best.md
+++ b/tests/testthat/_snaps/select_best.md
@@ -316,7 +316,7 @@
       show_best(surv_res, metric = "concordance_survival", eval_time = 1)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 5 x 8
         trees .metric              .estimator .eval_time  mean     n std_err .config  
@@ -333,7 +333,7 @@
       show_best(surv_res, metric = "concordance_survival", eval_time = 1.1)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 5 x 8
         trees .metric              .estimator .eval_time  mean     n std_err .config  
@@ -458,7 +458,7 @@
       select_best(surv_res, metric = "concordance_survival", eval_time = 1)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -471,7 +471,7 @@
       select_best(surv_res, metric = "concordance_survival", eval_time = 1.1)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -590,7 +590,7 @@
         trees)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -604,7 +604,7 @@
         trees)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -726,7 +726,7 @@
         trees)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -740,7 +740,7 @@
         trees)
     Condition
       Warning:
-      Evaluation times are only required when dynmanic or integrated metrics are selected as the primary metric (and will be ignored).
+      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 1 x 2
         trees .config             

--- a/tests/testthat/test-eval-time-single-selection.R
+++ b/tests/testthat/test-eval-time-single-selection.R
@@ -27,12 +27,12 @@ test_that("selecting single eval time - pure metric sets", {
   expect_null(first_eval_time(met_stc, eval_time = NULL))
   expect_null(first_eval_time(met_stc, "concordance_survival", eval_time = NULL))
 
-  expect_snapshot(
+  expect_silent(
     stc_one <- first_eval_time(met_stc, eval_time = times_1)
   )
   expect_null(stc_one)
 
-  expect_snapshot(
+  expect_silent(
     stc_multi <- first_eval_time(met_stc, eval_time = times_2)
   )
   expect_null(stc_multi)
@@ -66,12 +66,12 @@ test_that("selecting single eval time - pure metric sets", {
     first_eval_time(met_int, "brier_survival_integrated", eval_time = NULL)
   )
 
-  expect_snapshot(
+  expect_silent(
     int_1 <- first_eval_time(met_int, eval_time = times_1)
   )
   expect_null(int_1)
 
-  expect_snapshot(
+  expect_silent(
     int_multi <- first_eval_time(met_int, eval_time = times_2)
   )
   expect_null(int_multi)
@@ -92,12 +92,12 @@ test_that("selecting single eval time - mixed metric sets - static first", {
     first_eval_time(met_mix_stc, eval_time = NULL)
   )
 
-  expect_snapshot(
+  expect_silent(
     stc_1 <- first_eval_time(met_mix_stc, eval_time = times_1)
   )
   expect_null(stc_1)
 
-  expect_snapshot(
+  expect_silent(
     stc_multi <- first_eval_time(met_mix_stc, eval_time = times_2)
   )
   expect_null(stc_multi)
@@ -109,12 +109,12 @@ test_that("selecting single eval time - mixed metric sets - static first", {
     first_eval_time(met_mix_stc_all, eval_time = NULL)
   )
 
-  expect_snapshot(
+  expect_silent(
     stc_1 <- first_eval_time(met_mix_stc_all, eval_time = times_1)
   )
   expect_null(stc_1)
 
-  expect_snapshot(
+  expect_silent(
     stc_multi <- first_eval_time(met_mix_stc_all, eval_time = times_2)
   )
   expect_null(stc_multi)
@@ -180,10 +180,10 @@ test_that("selecting single eval time - mixed metric sets - integrated first", {
 
   expect_null(first_eval_time(met_mix_int, eval_time = NULL))
 
-  expect_snapshot(
+  expect_silent(
     first_eval_time(met_mix_int, eval_time = times_1)
   )
-  expect_snapshot(
+  expect_silent(
     int_multi <- first_eval_time(met_mix_int, eval_time = times_2)
   )
   expect_null(int_multi)
@@ -193,10 +193,10 @@ test_that("selecting single eval time - mixed metric sets - integrated first", {
 
   expect_null(first_eval_time(met_mix_int_all, eval_time = NULL))
 
-  expect_snapshot(
+  expect_silent(
     first_eval_time(met_mix_int_all, eval_time = times_1)
   )
-  expect_snapshot(
+  expect_silent(
     int_multi <- first_eval_time(met_mix_int_all, eval_time = times_2)
   )
   expect_null(int_multi)


### PR DESCRIPTION
Closes #802 

This PR moves a check to see if eval time is set for statistic or integrated metrics. Previously, there were similar checks in three places: 

- `check_eval_time_arg()`
  - once for non-survival models
  - once for static/integrated metrics
- `choose_eval_time()`
  - once for non-survival models
- `first_eval_time()`
  - once for static/integrated metrics

This PR removes the check in `first_eval_time()` since it is used for cases where an objective function is required (and this isn’t needed there; see the linked examples). 

The check is now moved to `choose_eval_time()` since this is called by `select_best()` and `show_best()`. That will correctly warn when someone wants to select using an integrated metric but passes 1+ evaluation times (which are not needed).

Tests in tidymodels/extratests#158 will need snapshots updated. 