### PR TITLE
Pass call from `select_best()` to `show_best()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.1.2.9012
+Version: 1.1.2.9014
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/select_best.R
+++ b/R/select_best.R
@@ -33,6 +33,7 @@
 #' @param eval_time A numeric vector of time points where dynamic event time
 #' metrics should be chosen (e.g., the time-dependent ROC curve, etc). The
 #' values should be consistent with the values used to create `x`.
+#' @param call The call to be shown in errors and warnings.
 #' @return A tibble with columns for the parameters. [show_best()] also
 #'  includes columns for performance metrics.
 #' @details
@@ -75,11 +76,13 @@ show_best.default <- function(x, ...) {
 
 #' @export
 #' @rdname show_best
-show_best.tune_results <- function(x, metric = NULL, n = 5, eval_time = NULL, ...) {
-  metric_info <- choose_metric(x, metric)
+show_best.tune_results <- function(x, metric = NULL, n = 5, eval_time = NULL, ..., call = rlang::current_env()) {
+  rlang::check_dots_empty()
+
+  metric_info <- choose_metric(x, metric, call = call)
   metric <- metric_info$metric
 
-  eval_time <- choose_eval_time(x, metric, eval_time = eval_time)
+  eval_time <- choose_eval_time(x, metric, eval_time = eval_time, call = call)
 
   summary_res <- .filter_perf_metrics(x, metric, eval_time)
 
@@ -111,12 +114,14 @@ select_best.default <- function(x, ...) {
 #' @export
 #' @rdname show_best
 select_best.tune_results <- function(x, metric = NULL, eval_time = NULL, ...) {
+  rlang::check_dots_empty()
+
   metric_info <- choose_metric(x, metric)
   metric <- metric_info$metric
 
   param_names <- .get_tune_parameter_names(x)
 
-  res <- show_best(x, metric = metric, n = 1, eval_time = eval_time)
+  res <- show_best(x, metric = metric, n = 1, eval_time = eval_time, call = rlang::current_env())
   res %>% dplyr::select(dplyr::all_of(param_names), .config)
 
 }

--- a/man/show_best.Rd
+++ b/man/show_best.Rd
@@ -19,7 +19,14 @@ show_best(x, ...)
 
 \method{show_best}{default}(x, ...)
 
-\method{show_best}{tune_results}(x, metric = NULL, n = 5, eval_time = NULL, ...)
+\method{show_best}{tune_results}(
+  x,
+  metric = NULL,
+  n = 5,
+  eval_time = NULL,
+  ...,
+  call = rlang::current_env()
+)
 
 select_best(x, ...)
 
@@ -61,6 +68,8 @@ a warning is issued).}
 \item{eval_time}{A numeric vector of time points where dynamic event time
 metrics should be chosen (e.g., the time-dependent ROC curve, etc). The
 values should be consistent with the values used to create \code{x}.}
+
+\item{call}{The call to be shown in errors and warnings.}
 
 \item{limit}{The limit of loss of performance that is acceptable (in percent
 units). See details below.}

--- a/tests/testthat/_snaps/select_best.md
+++ b/tests/testthat/_snaps/select_best.md
@@ -386,7 +386,7 @@
     Condition
       Warning in `select_best()`:
       No value of `metric` was given; "brier_survival" will be used.
-      Warning in `show_best()`:
+      Warning in `select_best()`:
       4 evaluation times are available; the first will be used (i.e. `eval_time = 10`).
     Output
       # A tibble: 1 x 2
@@ -419,7 +419,7 @@
     Code
       select_best(surv_res, metric = "brier_survival")
     Condition
-      Warning in `show_best()`:
+      Warning in `select_best()`:
       4 evaluation times are available; the first will be used (i.e. `eval_time = 10`).
     Output
       # A tibble: 1 x 2
@@ -434,7 +434,7 @@
     Condition
       Warning in `select_best()`:
       2 metrics were given; "brier_survival" will be used.
-      Warning in `show_best()`:
+      Warning in `select_best()`:
       4 evaluation times are available; the first will be used (i.e. `eval_time = 10`).
     Output
       # A tibble: 1 x 2
@@ -457,7 +457,7 @@
     Code
       select_best(surv_res, metric = "concordance_survival", eval_time = 1)
     Condition
-      Warning in `show_best()`:
+      Warning in `select_best()`:
       An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 1 x 2
@@ -470,7 +470,7 @@
     Code
       select_best(surv_res, metric = "concordance_survival", eval_time = 1.1)
     Condition
-      Warning in `show_best()`:
+      Warning in `select_best()`:
       An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
     Output
       # A tibble: 1 x 2
@@ -483,7 +483,7 @@
     Code
       select_best(surv_res, metric = "brier_survival", eval_time = 1.1)
     Condition
-      Error in `show_best()`:
+      Error in `select_best()`:
       ! Evaluation time 1.1 is not in the results.
 
 ---
@@ -491,7 +491,7 @@
     Code
       select_best(surv_res, metric = "brier_survival", eval_time = 1:2)
     Condition
-      Warning in `show_best()`:
+      Warning in `select_best()`:
       2 evaluation times are available; the first will be used (i.e. `eval_time = 1`).
     Output
       # A tibble: 1 x 2
@@ -504,9 +504,9 @@
     Code
       select_best(surv_res, metric = "brier_survival", eval_time = 3:4)
     Condition
-      Warning in `show_best()`:
+      Warning in `select_best()`:
       2 evaluation times are available; the first will be used (i.e. `eval_time = 3`).
-      Error in `show_best()`:
+      Error in `select_best()`:
       ! Evaluation time 3 is not in the results.
 
 # select_by_one_std_err with survival models


### PR DESCRIPTION
closes #819 and closes #820

updates to tests in extratests to follow after https://github.com/tidymodels/extratests/pull/179 is merged

``` r
# issue 819 ---------------------------------------------------------------

library(tidymodels)
library(censored)
#> Loading required package: survival

lung_surv <- lung %>%
  dplyr::mutate(surv = Surv(time, status), .keep = "unused")

set.seed(2193)
tune_res <-
  proportional_hazards(penalty = tune(), engine = "glmnet") %>%
  tune_grid(
    surv ~ .,
    resamples = vfold_cv(lung_surv, 2),
    grid = 2,
    control = control_grid(save_pred = TRUE, save_workflow = TRUE),
    metrics = metric_set(concordance_survival, brier_survival_integrated, brier_survival),
    eval_time = c(10, 20)
  )
# show select_best() as call, not show_best()
foo <- select_best(tune_res, metric = "concordance_survival", eval_time = 0)
#> Warning in select_best(tune_res, metric = "concordance_survival", eval_time = 0): An evaluation time is only required when a dynamic metric is selected (and
#> `eval_time` will thus be ignored).


# issue 820 ---------------------------------------------------------------

library(tidymodels)
library(censored)

lung_surv <- lung %>%
  dplyr::mutate(surv = Surv(time, status), .keep = "unused")

set.seed(2193)
tune_res <-
  proportional_hazards(penalty = tune(), engine = "glmnet") %>%
  tune_grid(
    surv ~ .,
    resamples = vfold_cv(lung_surv, 2),
    grid = 2,
    control = control_grid(save_pred = TRUE, save_workflow = TRUE),
    metrics = metric_set(brier_survival),
    eval_time = c(10, 20)
  )

foo <- select_best(tune_res)
#> Warning in select_best(tune_res): No value of `metric` was given;
#> "brier_survival" will be used.
#> Warning in select_best(tune_res): 2 evaluation times are available; the first will be used (i.e. `eval_time =
#> 10`).
```

<sup>Created on 2024-01-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>