### PR TITLE
`augment()` quietly choosing eval_time when necessary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.1.2.9015
+Version: 1.1.2.9016
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/augment.R
+++ b/R/augment.R
@@ -9,7 +9,9 @@
 #'  objects should have used the option `save_pred = TRUE`.
 #' @param parameters A data frame with a single row that indicates what
 #' tuning parameters should be used to generate the predictions (for `tune_*()`
-#' objects only). If `NULL`, `select_best(x)` will be used.
+#' objects only). If `NULL`, `select_best(x)` will be used with the first 
+#' metric and, if applicable, the first evaluation time point, used to 
+#' create `x`.
 #' @param ... Not currently used.
 #' @return A data frame with one or more additional columns for model
 #' predictions.
@@ -47,7 +49,13 @@ augment.tune_results <- function(x, parameters = NULL, ...) {
   # check/determine best settings
   if (is.null(parameters)) {
     obj_fun <- .get_tune_metric_names(x)[1]
-    parameters <- select_best(x, metric = obj_fun)
+    obj_eval_time <- choose_eval_time(
+      x, 
+      metric = obj_fun, 
+      eval_time = NULL,
+      quietly = TRUE
+    )
+    parameters <- select_best(x, metric = obj_fun, eval_time = obj_eval_time)
   } else {
     if (!is.data.frame(parameters) || nrow(parameters) > 1) {
       rlang::abort("'parameters' should be a single row data frame")

--- a/man/augment.tune_results.Rd
+++ b/man/augment.tune_results.Rd
@@ -19,7 +19,9 @@ objects should have used the option \code{save_pred = TRUE}.}
 
 \item{parameters}{A data frame with a single row that indicates what
 tuning parameters should be used to generate the predictions (for \verb{tune_*()}
-objects only). If \code{NULL}, \code{select_best(x)} will be used.}
+objects only). If \code{NULL}, \code{select_best(x)} will be used with the first
+metric and, if applicable, the first evaluation time point, used to
+create \code{x}.}
 
 \item{...}{Not currently used.}
 }

--- a/man/choose_metric.Rd
+++ b/man/choose_metric.Rd
@@ -33,6 +33,7 @@ first_eval_time(
   metric = NULL,
   eval_time = NULL,
   ...,
+  quietly = FALSE,
   call = rlang::caller_env()
 )
 
@@ -53,6 +54,8 @@ check_eval_time_arg(eval_time, mtr_set, call = rlang::caller_env())
 
 \item{eval_time}{An optional vector of times to compute dynamic and/or
 integrated metrics.}
+
+\item{quietly}{Logical. Should warnings be muffled?}
 
 \item{mtr_set}{A \code{\link[yardstick:metric_set]{yardstick::metric_set()}}.}
 


### PR DESCRIPTION
to close #810, as an alternative to #825

updates to the corresponding extratests PR https://github.com/tidymodels/extratests/pull/178 will come as suggestions