### PR TITLE
autoplot() modification for survival

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.1.2.9015
+Version: 1.1.2.9016
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -388,4 +388,13 @@ check_autoplot_eval_times <- function(x, metric, eval_time, call) {
   eval_time
 }
 
-
+check_singular_metric <- function(x, call) {
+  if (all(vctrs::vec_count(x$.metric)$count == 1)) {
+    cli::cli_abort(
+      "Only one observation per metric was present. \\
+      Unable to create meaningful plot.",
+      call = call
+    )
+  }
+  invisible(NULL)
+}

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -355,14 +355,3 @@ req_eval_times <- function(mtr_set) {
 
   max_req_times
 }
-
-# TODO will be removed shortly
-
-middle_eval_time <- function(x) {
-  x <- x[!is.na(x)]
-  times <- unique(x)
-  med_time <- median(x, na.rm = TRUE)
-  ind <- which.min(abs(times - med_time))
-  eval_time <- times[ind]
-  eval_time
-}

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -375,7 +375,7 @@ check_autoplot_eval_times <- function(x, metric, eval_time, call) {
     if (!any(grepl("survival", metric))){
       return(eval_time)
     }
-    eval_time <- .get_tune_eval_time_target(x)
+    eval_time <- .get_tune_eval_times(x)[1]
   } else {
     check_eval_time_in_tune_results(x, eval_time, call)
   }

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -381,7 +381,7 @@ check_autoplot_eval_times <- function(x, metric, eval_time, call) {
   }
 
   # But there could be NA eval times for non-dynamic metrics
-  met <- collect_metrics(x) %>% dplyr::filter(.metric %in% metric)
+  met <- estimate_tune_results(x) %>% dplyr::filter(.metric %in% metric)
   if (any(is.na(met$.eval_time))) {
     eval_time <- unique(c(NA, eval_time))
   }

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -142,7 +142,7 @@ is_dyn <- function(mtr_set, metric) {
 check_eval_time_in_tune_results <- function(x, eval_time, call = rlang::caller_env()) {
   given_times <- .get_tune_eval_times(x)
   if (!is.null(eval_time)) {
-    if (!any(eval_time == given_times)) {
+    if (!any(eval_time %in% given_times)) {
       print_time <- format(eval_time, digits = 3)
       cli::cli_abort("Evaluation time {print_time} is not in the results.",
                      call = call)
@@ -355,3 +355,37 @@ req_eval_times <- function(mtr_set) {
 
   max_req_times
 }
+
+# ------------------------------------------------------------------------------
+# functions for autoplot
+
+check_autoplot_metrics <- function(x, metric, call) {
+  all_met <- .get_tune_metrics(x)
+  all_info <- tibble::as_tibble(all_met)
+  if (is.null(metric)) {
+    metric <- all_info$metric
+  } else {
+    check_metric_in_tune_results(all_info, metric, call = call)
+  }
+  metric
+}
+
+check_autoplot_eval_times <- function(x, metric, eval_time, call) {
+  if (is.null(eval_time)) {
+    if (!any(grepl("survival", metric))){
+      return(eval_time)
+    }
+    eval_time <- .get_tune_eval_time_target(x)
+  } else {
+    check_eval_time_in_tune_results(x, eval_time, call)
+  }
+
+  # But there could be NA eval times for non-dynamic metrics
+  met <- collect_metrics(x) %>% dplyr::filter(.metric %in% metric)
+  if (any(is.na(met$.eval_time))) {
+    eval_time <- unique(c(NA, eval_time))
+  }
+  eval_time
+}
+
+

--- a/R/plots.R
+++ b/R/plots.R
@@ -175,59 +175,6 @@ paste_param_by <- function(x) {
   x
 }
 
-# TODO remove this.
-default_eval_time <- function(eval_time, x, call = rlang::caller_env()) {
-  if (!any(names(x) == ".eval_time")) {
-    if (!is.null(eval_time)) {
-      rlang::warn("The 'eval_time' argument is not needed for this data set.")
-    }
-    return(NULL)
-  }
-  if (is.null(eval_time)) {
-    eval_time <- middle_eval_time(x$.eval_time)
-    msg <- cli::pluralize("No evaluation time was set; a value of {eval_time} was used.")
-    rlang::warn(msg, call = call)
-  }
-  eval_time
-}
-
-# TODO remove this.
-filter_plot_eval_time <- function(x, eval_time) {
-  if (!any(names(x) == ".eval_time")) {
-    return(x)
-  }
-  if (all(is.na(x$.eval_time))) {
-    return(x %>% dplyr::select(-.eval_time))
-  }
-
-  eval_time <- default_eval_time(eval_time, x)
-
-  times <- x$.eval_time
-  is_miss_time <- is.na(times)
-  times <- unique(times[!is_miss_time])
-  time_dif <- setdiff(eval_time, times)
-  if (length(time_dif) > 0) {
-    bad_times <- paste0(format(time_dif, digits = 3), collapse = ", ")
-    msg <- cli::pluralize("One or more chosen evaluation times were not in the results: {bad_times}")
-    rlang::warn(msg)
-  }
-  if (any(is_miss_time)) {
-    keep_times <- tibble::tibble(.eval_time = c(eval_time, NA))
-  } else {
-    keep_times <- tibble::tibble(.eval_time = c(eval_time))
-  }
-  x <-
-    dplyr::inner_join(x, keep_times, by = ".eval_time") %>%
-    dplyr::mutate(
-      nice_time = format(.eval_time, digits = 3),
-      time_metric = paste0(.metric, " @", nice_time),
-      .metric = ifelse(is.na(.eval_time), .metric, time_metric)
-    ) %>%
-    dplyr::select(-nice_time, -time_metric, -.eval_time)
-  x
-}
-
-
 # ------------------------------------------------------------------------------
 
 is_factorial <- function(x, cutoff = 0.95) {

--- a/R/plots.R
+++ b/R/plots.R
@@ -13,6 +13,7 @@
 #' @param eval_time A numeric vector of time points where dynamic event time
 #' metrics should be chosen (e.g. the time-dependent ROC curve, etc). The
 #' values should be consistent with the values used to create `object`.
+#' @param call The call to be displayed in warnings or errors.
 #' @param ... For plots with a regular grid, this is passed to `format()` and is
 #' applied to a parameter used to color points. Otherwise, it is not used.
 #' @return A `ggplot2` object.

--- a/R/plots.R
+++ b/R/plots.R
@@ -228,7 +228,15 @@ use_regular_grid_plot <- function(x) {
 # ------------------------------------------------------------------------------
 
 process_autoplot_metrics <- function(x, metric, eval_time) {
-  x <- collect_metrics(x) %>%
+  x <- estimate_tune_results(x)
+  # This next line updates the .metric columns to be consistent with what the
+  # metric set produces. For example, in the data, there might be a value of
+  # "demographic_parity" but the metric set knows about
+  # "demographic_parity(cyl)". `paste_param_by()` makes sure that they both
+  # have the same value (if any).
+  x <- paste_param_by(x)
+
+  x <- x %>%
     dplyr::filter(.metric %in% metric) %>%
     dplyr::filter(!is.na(mean))
 
@@ -259,7 +267,6 @@ plot_perf_vs_iter <- function(x, metric = NULL, width = NULL, eval_time = NULL,
   eval_time <- check_autoplot_eval_times(x, metric, eval_time, call)
 
   x <- process_autoplot_metrics(x, metric, eval_time)
-  x <- paste_param_by(x)
 
   search_iter <-
     x %>%
@@ -360,7 +367,6 @@ plot_marginals <- function(x, metric = NULL, eval_time = NULL, call = rlang::cal
   eval_time <- check_autoplot_eval_times(x, metric, eval_time, call)
 
   x <- process_autoplot_metrics(x, metric, eval_time)
-  x <- paste_param_by(x)
 
   # ----------------------------------------------------------------------------
   # Check types of parameters then sort by unique values
@@ -481,7 +487,6 @@ plot_regular_grid <- function(x,
   eval_time <- check_autoplot_eval_times(x, metric, eval_time, call)
 
   dat <- process_autoplot_metrics(x, metric, eval_time)
-  dat <- paste_param_by(dat)
 
   check_singular_metric(dat, call)
 

--- a/R/plots.R
+++ b/R/plots.R
@@ -333,9 +333,13 @@ plot_param_vs_iter <- function(x, call = rlang::caller_env()) {
   p <-
     ggplot(x, aes(x = .iter, y = value)) +
     geom_point() +
-    xlab("Iteration") +
-    ylab("") +
-    facet_wrap(~name, scales = "free_y")
+    xlab("Iteration")
+
+  if (length(param_cols) == 1) {
+    p <- p  + ylab(param_cols)
+  } else {
+    p <- p + ylab("") + facet_wrap(~name, scales = "free_y")
+  }
 
   p
 }

--- a/R/plots.R
+++ b/R/plots.R
@@ -356,13 +356,11 @@ plot_marginals <- function(x, metric = NULL, eval_time = NULL, call = rlang::cal
 
   is_race <- inherits(x, "tune_race")
 
-  x <- collect_metrics(x)
-  if (!is.null(metric)) {
-    x <- x %>% dplyr::filter(.metric %in% metric)
-  }
+  metric <- check_autoplot_metrics(x, metric, call)
+  eval_time <- check_autoplot_eval_times(x, metric, eval_time, call)
+
+  x <- process_autoplot_metrics(x, metric, eval_time)
   x <- paste_param_by(x)
-  x <- x %>% dplyr::filter(!is.na(mean))
-  x <- filter_plot_eval_time(x, eval_time)
 
   # ----------------------------------------------------------------------------
   # Check types of parameters then sort by unique values
@@ -479,27 +477,13 @@ plot_regular_grid <- function(x,
 
   is_race <- inherits(x, "tune_race")
 
-  dat <- collect_metrics(x)
-  if (!is.null(metric)) {
-    dat <- dat %>% dplyr::filter(.metric %in% metric)
-    if (nrow(dat) == 0) {
-      rlang::abort(paste0(
-        "After filtering for metric '", metric, "', there were ",
-        "no data points."
-      ))
-    }
-  }
-  dat <- paste_param_by(dat)
-  dat <- dat %>% dplyr::filter(!is.na(mean))
-  dat <- filter_plot_eval_time(dat, eval_time)
+  metric <- check_autoplot_metrics(x, metric, call)
+  eval_time <- check_autoplot_eval_times(x, metric, eval_time, call)
 
-  if (all(vctrs::vec_count(dat$.metric)$count == 1)) {
-    cli::cli_abort(
-      "Only one observation per metric was present. \\
-      Unable to create meaningful plot.",
-      call = call
-    )
-  }
+  dat <- process_autoplot_metrics(x, metric, eval_time)
+  dat <- paste_param_by(dat)
+
+  check_singular_metric(dat, call)
 
   multi_metrics <- length(unique(dat$.metric)) > 1
 

--- a/man/autoplot.tune_results.Rd
+++ b/man/autoplot.tune_results.Rd
@@ -10,6 +10,7 @@
   metric = NULL,
   width = NULL,
   eval_time = NULL,
+  call = rlang::current_env(),
   ...
 )
 }

--- a/man/autoplot.tune_results.Rd
+++ b/man/autoplot.tune_results.Rd
@@ -33,6 +33,8 @@ the entries in \code{.metric} column of \code{collect_metrics(object)}.}
 metrics should be chosen (e.g. the time-dependent ROC curve, etc). The
 values should be consistent with the values used to create \code{object}.}
 
+\item{call}{The call to be displayed in warnings or errors.}
+
 \item{...}{For plots with a regular grid, this is passed to \code{format()} and is
 applied to a parameter used to color points. Otherwise, it is not used.}
 }


### PR DESCRIPTION
Closes #808

Creates some new functions to process/filter the arguments and data. 

For `eval_time`, we use the first value if the user does not pass anything. Since `autoplot()` takes multiple methods and doesn't recalculate anything, the required changes are not exactly the same as those used for `select_*/show_*/augment()` or `int_pctl()`. 

Tests for survival models are coming to extratests. 