### PR TITLE
address issue with logging exit handlers

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -170,6 +170,10 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
   if (identical(parallel_over, "resamples")) {
     seeds <- generate_seeds(rng, n_splits)
 
+    # Evaluate the call to foreach in a local environment using
+    # `(function() expr)()` so that foreach doesn't touch the exit
+    # handlers attached to the execution environment of this function
+    # by `initialize_catalog()` (#828, #845).
     results <- (function() {
       suppressPackageStartupMessages(
         foreach::foreach(
@@ -204,6 +208,10 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
 
     seeds <- generate_seeds(rng, n_splits * n_grid_info)
 
+    # Evaluate the call to foreach in a local environment using
+    # `(function() expr)()` so that foreach doesn't touch the exit
+    # handlers attached to the execution environment of this function
+    # by `initialize_catalog()` (#828, #845).
     results <- (function() {
       suppressPackageStartupMessages(
         foreach::foreach(

--- a/R/logging.R
+++ b/R/logging.R
@@ -88,6 +88,13 @@ catalog_is_active <- function() {
 # initializes machinery for the tune catalog inside of an environment.
 # the `env` should be an execution environment that persists throughout the
 # tuning process for a given tuning approach and exits once tuning is completed.
+#
+# this function attaches an exit handler (see `on.exit()`) to the execution
+# environment of the function it's called within, by default. pay close
+# attention when other exit handlers are attached to the same environment;
+# a call to `on.exit()` in `env` after this function is called will cause
+# issues with the catalog. (see #845.)
+#
 #' @rdname tune-internal-functions
 #' @export
 initialize_catalog <- function(control, env = rlang::caller_env()) {

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -299,6 +299,10 @@ tune_bayes_workflow <-
     # Pull outcome names from initialization run
     outcomes <- peek_tune_results_outcomes(unsummarized)
 
+    # Evaluate this portion of the function in a local environment using
+    # `(function() expr)()` so that `on.exit()` doesn't touch the exit
+    # handlers attached to the execution environment of this function
+    # by `initialize_catalog()` (#828, #845).
     (function() {
     # Return whatever we have if there is a error (or execution is stopped)
     on.exit({


### PR DESCRIPTION
Not quite all the way there (and I haven't tested against extratests), but solves the documented issue in #828. It does surface another issue (that I don't reproduce with withr v2.5.2) where the exit handlers calling `cli_progress_done()` aren't triggered when calling `tune_bayes()` with an initial grid. I see:


``` r
library(tidymodels)

# data setup ------------------------------------------------------------------
ames_narrow <- modeldata::ames[, c(72, 40:45)]
spec_dt <- parsnip::decision_tree(mode = "regression")
spec_dt_tune <- parsnip::decision_tree(
  cost_complexity = tune(), min_n = tune(), mode = "regression"
)
form <- Sale_Price ~ .
set.seed(1)
folds <- rsample::vfold_cv(ames_narrow, 10)

# purposefully trigger errors while tuning:
raise_error <- function(x) {stop("AHHhH")}

# this is as expected
set.seed(1)
res_grid <-
  tune_grid(spec_dt_tune, form, folds, grid = 5,
            control = control_grid(extract = raise_error))
#> → A | error:   AHHhH
#> There were issues with some computations   A: x50

# this should trigger 50 (n_folds * n_iterations) failures,
# but fewer are documented. when i debug on `cli_progress_done()`,
# it's not triggered:
set.seed(1)
res_grid <-
  tune_bayes(spec_dt_tune, form, folds, iter = 5,
             control = control_bayes(extract = raise_error),
             initial = res_grid)
#> → A | error:   AHHhH
#> There were issues with some computations   A: x21



# as a result, the next time a tuning process is ran, it's suffixed with
# the `cli_progress_done()` result from the previous process:
set.seed(1)
res_grid <-
  tune_grid(spec_dt_tune, form, folds, grid = 5,
            control = control_grid(extract = raise_error))
#> → A | error:   AHHhH
#> There were issues with some computations   A: x50
#> There were issues with some computations   A: x21
```

<sup>Created on 2024-02-13 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

Note that `A: x21` is "leftover" from the tuning process above.

Reprex edited to reflect premature progress bar printing.

To see the expected results, use `pak::pak("r-lib/withr@v2.5.2")`.