### PR TITLE
Harmonize message when `eval_time` is not needed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 1.1.2.9019
+Version: 1.1.2.9020
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/checks.R
+++ b/R/checks.R
@@ -619,8 +619,8 @@ check_eval_time <- function(eval_time, metrics) {
   metric_types <- tibble::as_tibble(metrics)$class
   needs_eval_time <- any(metric_types %in% dyn_inputs)
   if (!is.null(eval_time) & !needs_eval_time) {
-    rlang::abort(
-      "Evaluation times are only used for dynamic and integrated survival metrics.",
+    cli::cli_abort(
+      "{.arg eval_time} is only used for dynamic and integrated survival metrics.",
       call = NULL
     )
   }

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -104,9 +104,9 @@ choose_eval_time <- function(x, metric, eval_time = NULL, quietly = FALSE, call 
 
   if (!contains_survival_metric(mtr_info)) {
     if (!is.null(eval_time) & !quietly) {
-      cli::cli_warn("Evaluation times are only required when the model
-                     mode is {.val censored regression} (and will be ignored).",
-                    call = call)
+      cli::cli_warn(
+        "{.arg eval_time} is only used for models with mode {.val censored regression}.",
+        call = call)
     }
     return(NULL)
   }
@@ -115,10 +115,10 @@ choose_eval_time <- function(x, metric, eval_time = NULL, quietly = FALSE, call 
 
   # If we don't need an eval time but one is passed:
   if (!dyn_metric & !is.null(eval_time) & !quietly) {
-    cli::cli_warn("An evaluation time is only required when a dynamic
-                   metric is selected (and {.arg eval_time} will thus be
-                   ignored).",
-                  call = call)
+    cli::cli_warn(
+      "{.arg eval_time} is only used for dynamic survival metrics.",
+      call = call
+    )
   }
 
   # If we need an eval time, set it to the possible values so that
@@ -314,9 +314,10 @@ check_eval_time_arg <- function(eval_time, mtr_set, call = rlang::caller_env()) 
   # Not a survival metric
   if (!contains_survival_metric(mtr_info)) {
     if (!is.null(eval_time)) {
-      cli::cli_warn("Evaluation times are only required when the model
-                     mode is {.val censored regression} (and will be ignored).",
-                    call = call)
+      cli::cli_warn(
+        "{.arg eval_time} is only used for models with mode {.val censored regression}.",
+        call = call
+      )
     }
     return(NULL)
   }
@@ -332,9 +333,10 @@ check_eval_time_arg <- function(eval_time, mtr_set, call = rlang::caller_env()) 
   check_enough_eval_times(eval_time, mtr_set)
 
   if (max_times_req == 0 & num_times > 0) {
-    cli::cli_warn("Evaluation times are only required when dynamic or
-                   integrated metrics are used (and will be ignored here).",
-                  call = call)
+    cli::cli_warn(
+      "{.arg eval_time} is only used for dynamic or integrated survival metrics.",
+      call = call
+    )
     eval_time <- NULL
   }
 
@@ -381,10 +383,10 @@ check_autoplot_eval_times <- function(x, metric, eval_time, call) {
   } else {
     any_dyn <- any(purrr::map_lgl(metric, ~ is_dyn(.get_tune_metrics(x), .x)))
     if (!any_dyn) {
-      cli::cli_warn("Evaluation times are only required when the results of a \\
-                     dynamic survival metric are being visualized (and will be \\
-                     ignored).",
-                    call = call)
+      cli::cli_warn(
+        "{.arg eval_time} is only used for dynamic survival metrics.",
+        call = call
+      )
       eval_time <- NULL
     }
     check_eval_time_in_tune_results(x, eval_time, call)

--- a/R/plots.R
+++ b/R/plots.R
@@ -101,7 +101,9 @@ autoplot.tune_results <-
 
     if (type == "parameters") {
       if (!is.null(eval_time)) {
-        cli::cli_warn("Evaluation times are not required with {.code autoplot(..., type = 'parameters')}.")
+        cli::cli_warn(
+          "{.arg eval_time} is not used with {.code autoplot(..., type = 'parameters')}."
+        )
       }
       p <- plot_param_vs_iter(object, call)
     } else {

--- a/tests/testthat/_snaps/autoplot.md
+++ b/tests/testthat/_snaps/autoplot.md
@@ -32,5 +32,5 @@
       foo <- autoplot(res, metric = "rmse", eval_time = 10)
     Condition
       Warning in `autoplot()`:
-      Evaluation times are only required when the results of a dynamic survival metric are being visualized (and will be ignored).
+      `eval_time` is only used for dynamic survival metrics.
 

--- a/tests/testthat/_snaps/censored-reg.md
+++ b/tests/testthat/_snaps/censored-reg.md
@@ -21,7 +21,7 @@
       eval_time = 1)
     Condition
       Warning in `tune_grid()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
       Warning:
       No tuning parameters have been detected, performance will be evaluated using the resamples with no tuning. Did you want to [tune()] parameters?
     Output

--- a/tests/testthat/_snaps/eval-time-args.md
+++ b/tests/testthat/_snaps/eval-time-args.md
@@ -11,7 +11,7 @@
       check_eval_time_arg(times, met_reg)
     Condition
       Warning:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
     Output
       NULL
 
@@ -21,7 +21,7 @@
       res <- fit_resamples(wflow, rs, eval_time = times)
     Condition
       Warning in `fit_resamples()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
 
 ---
 
@@ -30,7 +30,7 @@
       res <- tune_grid(wflow_tune, rs, eval_time = times)
     Condition
       Warning in `tune_grid()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
 
 ---
 
@@ -39,7 +39,7 @@
       res <- tune_bayes(wflow_tune, rs, iter = 1, eval_time = times)
     Condition
       Warning in `tune_bayes()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
 
 ---
 
@@ -47,7 +47,7 @@
       res <- last_fit(wflow, split, eval_time = times)
     Condition
       Warning in `last_fit()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
 
 # eval time are checked for classification models
 
@@ -62,7 +62,7 @@
       check_eval_time_arg(times, met_cls)
     Condition
       Warning:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
     Output
       NULL
 
@@ -72,7 +72,7 @@
       res <- fit_resamples(wflow, rs, eval_time = times)
     Condition
       Warning in `fit_resamples()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
 
 ---
 
@@ -81,7 +81,7 @@
       res <- tune_grid(wflow_tune, rs, eval_time = times)
     Condition
       Warning in `tune_grid()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
 
 ---
 
@@ -90,7 +90,7 @@
       res <- tune_bayes(wflow_tune, rs, iter = 1, eval_time = times)
     Condition
       Warning in `tune_bayes()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
 
 ---
 
@@ -98,7 +98,7 @@
       res <- last_fit(wflow, split, eval_time = times)
     Condition
       Warning in `last_fit()`:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
 
 # eval time inputs are checked for censored regression models
 
@@ -177,7 +177,7 @@
       check_eval_time_arg(2, met_stc)
     Condition
       Warning:
-      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+      `eval_time` is only used for dynamic or integrated survival metrics.
     Output
       NULL
 
@@ -248,7 +248,7 @@
       check_eval_time_arg(1:3, met_stc)
     Condition
       Warning:
-      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+      `eval_time` is only used for dynamic or integrated survival metrics.
     Output
       NULL
 
@@ -383,7 +383,7 @@
       res <- fit_resamples(wflow, rs, metrics = met_stc, eval_time = 2)
     Condition
       Warning in `fit_resamples()`:
-      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+      `eval_time` is only used for dynamic or integrated survival metrics.
 
 ---
 
@@ -446,7 +446,7 @@
       res <- fit_resamples(wflow, rs, metrics = met_stc, eval_time = 1:3)
     Condition
       Warning in `fit_resamples()`:
-      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+      `eval_time` is only used for dynamic or integrated survival metrics.
 
 ---
 
@@ -563,7 +563,7 @@
       res <- tune_grid(wflow_tune, rs, metrics = met_stc, eval_time = 2)
     Condition
       Warning in `tune_grid()`:
-      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+      `eval_time` is only used for dynamic or integrated survival metrics.
 
 ---
 
@@ -626,7 +626,7 @@
       res <- tune_grid(wflow_tune, rs, metrics = met_stc, eval_time = 1:3)
     Condition
       Warning in `tune_grid()`:
-      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+      `eval_time` is only used for dynamic or integrated survival metrics.
 
 ---
 
@@ -738,7 +738,7 @@
       res <- last_fit(wflow, split, metrics = met_stc, eval_time = 2)
     Condition
       Warning in `last_fit()`:
-      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+      `eval_time` is only used for dynamic or integrated survival metrics.
 
 ---
 
@@ -801,7 +801,7 @@
       res <- last_fit(wflow, split, metrics = met_stc, eval_time = 1:3)
     Condition
       Warning in `last_fit()`:
-      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+      `eval_time` is only used for dynamic or integrated survival metrics.
 
 ---
 

--- a/tests/testthat/_snaps/eval-time-single-selection.md
+++ b/tests/testthat/_snaps/eval-time-single-selection.md
@@ -77,7 +77,7 @@
       choose_eval_time(surv_res, "concordance_survival", eval_time = 10)
     Condition
       Warning:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       NULL
 
@@ -87,7 +87,7 @@
       choose_eval_time(ames_grid_search, "rmse", 1)
     Condition
       Warning:
-      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+      `eval_time` is only used for models with mode "censored regression".
     Output
       NULL
 

--- a/tests/testthat/_snaps/select_best.md
+++ b/tests/testthat/_snaps/select_best.md
@@ -316,7 +316,7 @@
       show_best(surv_res, metric = "concordance_survival", eval_time = 1)
     Condition
       Warning in `show_best()`:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       # A tibble: 5 x 8
         trees .metric              .estimator .eval_time  mean     n std_err .config  
@@ -333,7 +333,7 @@
       show_best(surv_res, metric = "concordance_survival", eval_time = 1.1)
     Condition
       Warning in `show_best()`:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       # A tibble: 5 x 8
         trees .metric              .estimator .eval_time  mean     n std_err .config  
@@ -458,7 +458,7 @@
       select_best(surv_res, metric = "concordance_survival", eval_time = 1)
     Condition
       Warning in `select_best()`:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -471,7 +471,7 @@
       select_best(surv_res, metric = "concordance_survival", eval_time = 1.1)
     Condition
       Warning in `select_best()`:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -590,7 +590,7 @@
         trees)
     Condition
       Warning in `select_by_one_std_err()`:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -604,7 +604,7 @@
         trees)
     Condition
       Warning in `select_by_one_std_err()`:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -726,7 +726,7 @@
         trees)
     Condition
       Warning in `select_by_pct_loss()`:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       # A tibble: 1 x 2
         trees .config             
@@ -740,7 +740,7 @@
         trees)
     Condition
       Warning in `select_by_pct_loss()`:
-      An evaluation time is only required when a dynamic metric is selected (and `eval_time` will thus be ignored).
+      `eval_time` is only used for dynamic survival metrics.
     Output
       # A tibble: 1 x 2
         trees .config             


### PR DESCRIPTION
closes #811

I went for the concise version of 

```
"{.arg eval_time} is only used for <SITUATION>."
```

More snapshot changes in https://github.com/tidymodels/extratests/pull/199