### PR TITLE
Make `fit_best()` more ergonomic

### DIFF
--- a/R/fit_best.R
+++ b/R/fit_best.R
@@ -12,7 +12,9 @@
 #' a column for each tuning parameter. This tibble should have columns for each
 #' tuning parameter identifier (e.g. `"my_param"` if `tune("my_param")` was used).
 #' If `NULL`, this argument will be set to
-#' [`select_best(metric)`][tune::select_best.tune_results].
+#' [`select_best(metric, eval_time)`][tune::select_best.tune_results]. 
+#' If not `NULL`, `parameters` overwrites the specification via `metric`, and 
+#' `eval_time`.
 #' @param verbose A logical for printing logging.
 #' @param add_validation_set When the resamples embedded in `x` are a split into
 #' training set and validation set, should the validation set be included in the
@@ -116,6 +118,15 @@ fit_best.tune_results <- function(x,
     parameters <- select_best(x, metric = metric, eval_time = eval_time)
     if (verbose) {
       format_final_param(parameters, metric)
+    }
+  } else {
+    if (!is.null(metric)) {
+      cli::cli_warn("{.arg metric} is being ignored because {.arg parameters}
+      has been specified.")
+    }
+    if (!is.null(eval_time)) {
+      cli::cli_warn("{.arg eval_time} is being ignored because {.arg parameters}
+      has been specified.")
     }
   }
 

--- a/R/fit_best.R
+++ b/R/fit_best.R
@@ -89,9 +89,9 @@ fit_best.default <- function(x, ...) {
 #' @rdname fit_best
 fit_best.tune_results <- function(x,
                                   metric = NULL,
-                                  eval_time = NULL,
                                   parameters = NULL,
                                   verbose = FALSE,
+                                  eval_time = NULL,
                                   add_validation_set = NULL,
                                   ...) {
   if (length(list(...))) {

--- a/man/fit_best.Rd
+++ b/man/fit_best.Rd
@@ -39,7 +39,9 @@ default will automatically use the first evaluation time used by \code{x}.}
 a column for each tuning parameter. This tibble should have columns for each
 tuning parameter identifier (e.g. \code{"my_param"} if \code{tune("my_param")} was used).
 If \code{NULL}, this argument will be set to
-\code{\link[=select_best.tune_results]{select_best(metric)}}.}
+\code{\link[=select_best.tune_results]{select_best(metric, eval_time)}}.
+If not \code{NULL}, \code{parameters} overwrites the specification via \code{metric}, and
+\code{eval_time}.}
 
 \item{verbose}{A logical for printing logging.}
 

--- a/man/fit_best.Rd
+++ b/man/fit_best.Rd
@@ -13,9 +13,9 @@ fit_best(x, ...)
 \method{fit_best}{tune_results}(
   x,
   metric = NULL,
-  eval_time = NULL,
   parameters = NULL,
   verbose = FALSE,
+  eval_time = NULL,
   add_validation_set = NULL,
   ...
 )
@@ -30,11 +30,6 @@ fit_best(x, ...)
 \item{metric}{A character string (or \code{NULL}) for which metric to optimize. If
 \code{NULL}, the first metric is used.}
 
-\item{eval_time}{A single numeric time point where dynamic event time
-metrics should be chosen (e.g., the time-dependent ROC curve, etc). The
-values should be consistent with the values used to create \code{x}. The \code{NULL}
-default will automatically use the first evaluation time used by \code{x}.}
-
 \item{parameters}{An optional 1-row tibble of tuning parameter settings, with
 a column for each tuning parameter. This tibble should have columns for each
 tuning parameter identifier (e.g. \code{"my_param"} if \code{tune("my_param")} was used).
@@ -44,6 +39,11 @@ If not \code{NULL}, \code{parameters} overwrites the specification via \code{met
 \code{eval_time}.}
 
 \item{verbose}{A logical for printing logging.}
+
+\item{eval_time}{A single numeric time point where dynamic event time
+metrics should be chosen (e.g., the time-dependent ROC curve, etc). The
+values should be consistent with the values used to create \code{x}. The \code{NULL}
+default will automatically use the first evaluation time used by \code{x}.}
 
 \item{add_validation_set}{When the resamples embedded in \code{x} are a split into
 training set and validation set, should the validation set be included in the

--- a/tests/testthat/_snaps/fit_best.md
+++ b/tests/testthat/_snaps/fit_best.md
@@ -68,3 +68,21 @@
 
     x The control option `save_workflow = TRUE` should be used when tuning.
 
+# fit_best() warns when metric or eval_time are specified in addition to parameters
+
+    Code
+      manual_wf <- fit_best(res, metric = "rmse", parameters = tune_params)
+    Condition
+      Warning:
+      `metric` is being ignored because `parameters` has been specified.
+
+---
+
+    Code
+      manual_wf <- fit_best(res, metric = "rmse", eval_time = 10, parameters = tune_params)
+    Condition
+      Warning:
+      `metric` is being ignored because `parameters` has been specified.
+      Warning:
+      `eval_time` is being ignored because `parameters` has been specified.
+

--- a/tests/testthat/test-fit_best.R
+++ b/tests/testthat/test-fit_best.R
@@ -128,3 +128,24 @@ test_that("fit_best() works with validation split: 2x 2-way splits", {
 
   expect_equal(pred, exp_pred)
 })
+
+test_that(
+  "fit_best() warns when metric or eval_time are specified in addition to parameters", {
+  skip_if_not_installed("kknn")
+
+  knn_mod <- nearest_neighbor(neighbors = tune()) %>% set_mode("regression")
+  res <-
+      tune_grid(
+      workflow(mpg ~ ., knn_mod),
+      bootstraps(mtcars),
+      control = control_grid(save_workflow = TRUE)
+   )
+   
+   tune_params <- select_best(res, metric = "rmse")
+   expect_snapshot(
+    manual_wf <- fit_best(res, metric = "rmse", parameters = tune_params)
+   )
+   expect_snapshot(
+    manual_wf <- fit_best(res, metric = "rmse", eval_time = 10, parameters = tune_params)
+   )
+})


### PR DESCRIPTION
closes  #852

This PR clarifies the specification of "best" for `fit_best()` _and_ changes the position of the `eval_time` argument, see additional discussion in the issue for the motivations.

@topepo should we also change the position of the `eval_time` argument in `int_pctl()` or keep it as is? `int_pctl()` is entirely new to tune and not yet in a previous CRAN release.