### PR TITLE
update snapshot for ggplot2 v3.5.0

### DIFF
--- a/tests/testthat/_snaps/autoplot.md
+++ b/tests/testthat/_snaps/autoplot.md
@@ -16,7 +16,7 @@
 
 # coord_obs_pred
 
-    Removed 1 rows containing missing values (`geom_point()`).
+    Removed 1 row containing missing values or values outside the scale range (`geom_point()`).
 
 # regular grid plot
 


### PR DESCRIPTION
Alternatively: remove the snapshot since it covers a warning emitted from ggplot2, not tune.