### PR TITLE
require optional arguments to be named

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,8 +45,9 @@
 
 ## Breaking Change
 
-* Several functions gain an `eval_time` argument for the evaluation time of dynamic metrics for censored regression. The placement of the argument breaks passing-by-position for one or more other arguments to `fit_best.tune_results()`, `show_best.tune_results()`, and the developer-focused `check_initial()` (#857).
+* Several functions gained an `eval_time` argument for the evaluation time of dynamic metrics for censored regression. The placement of the argument breaks passing-by-position for one or more other arguments to `autoplot.tune_results()` and the developer-focused `check_initial()` (#857).
 
+* Ellipses (...) are now used consistently in the package to require optional arguments to be named. For functions that previously had ellipses at the end of the function signature, they have been moved to follow the last argument without a default value: this applies to `augment.tune_results()`, `collect_predictions.tune_results()`, `collect_metrics.tune_results()`, and the developer-focused `estimate_tune_results()`, `load_pkgs()`, and `encode_set()`. Several other functions that previously did not have ellipses in their signatures gained them: this applies to `conf_mat_resampled()` and the developer-focused `check_workflow()`. Optional arguments previously passed by position will now error informatively prompting them to be named (#862).
 
 # tune 1.1.2
 

--- a/R/augment.R
+++ b/R/augment.R
@@ -7,12 +7,12 @@
 #' @param x An object resulting from one of the `tune_*()` functions,
 #'  `fit_resamples()`, or `last_fit()`. The control specifications for these
 #'  objects should have used the option `save_pred = TRUE`.
+#' @param ... Not currently used.
 #' @param parameters A data frame with a single row that indicates what
 #' tuning parameters should be used to generate the predictions (for `tune_*()`
 #' objects only). If `NULL`, `select_best(x)` will be used with the first 
 #' metric and, if applicable, the first evaluation time point, used to 
 #' create `x`.
-#' @param ... Not currently used.
 #' @return A data frame with one or more additional columns for model
 #' predictions.
 #'
@@ -34,7 +34,7 @@
 #' results.
 #'
 #' @export
-augment.tune_results <- function(x, parameters = NULL, ...) {
+augment.tune_results <- function(x, ..., parameters = NULL) {
   dots <- rlang::list2(...)
   if (length(dots) > 0) {
     rlang::abort(

--- a/R/checks.R
+++ b/R/checks.R
@@ -288,6 +288,8 @@ check_workflow <- function(x, ..., pset = NULL, check_dials = FALSE, call = call
     rlang::abort("A parsnip model is required.")
   }
 
+  rlang::check_dots_empty(call = call)
+
   if (check_dials) {
     if (is.null(pset)) {
       pset <- hardhat::extract_parameter_set_dials(x)

--- a/R/checks.R
+++ b/R/checks.R
@@ -275,7 +275,7 @@ check_param_objects <- function(pset) {
 #' @keywords internal
 #' @rdname empty_ellipses
 #' @param check_dials A logical for check for a NULL parameter object.
-check_workflow <- function(x, pset = NULL, check_dials = FALSE, call = caller_env()) {
+check_workflow <- function(x, ..., pset = NULL, check_dials = FALSE, call = caller_env()) {
   if (!inherits(x, "workflow")) {
     rlang::abort("The `object` argument should be a 'workflow' object.")
   }

--- a/R/collect.R
+++ b/R/collect.R
@@ -140,6 +140,8 @@ collect_predictions.default <- function(x, ...) {
 #' @export
 #' @rdname collect_predictions
 collect_predictions.tune_results <- function(x, ..., summarize = FALSE, parameters = NULL) {
+  rlang::check_dots_empty()
+  
   names <- colnames(x)
   coll_col <- ".predictions"
 
@@ -455,6 +457,7 @@ collect_metrics.default <- function(x, ...) {
 #' @export
 #' @rdname collect_predictions
 collect_metrics.tune_results <- function(x, ..., summarize = TRUE, type = c("long", "wide")) {
+  rlang::check_dots_empty()
   rlang::arg_match0(type, values = c("long", "wide"))
 
   if (inherits(x, "last_fit")) {
@@ -552,6 +555,7 @@ collector <- function(x, coll_col = ".predictions") {
 #' @keywords internal
 #' @rdname empty_ellipses
 estimate_tune_results <- function(x, ..., col_name = ".metrics") {
+  rlang::check_dots_empty()
   param_names <- .get_tune_parameter_names(x)
   id_names <- grep("^id", names(x), value = TRUE)
   group_cols <- .get_extra_col_names(x)

--- a/R/collect.R
+++ b/R/collect.R
@@ -3,6 +3,7 @@
 #' @param x The results of [tune_grid()], [tune_bayes()], [fit_resamples()],
 #'  or [last_fit()]. For [collect_predictions()], the control option `save_pred
 #'  = TRUE` should have been used.
+#' @param ... Not currently used.
 #' @param summarize A logical; should metrics be summarized over resamples
 #' (`TRUE`) or return the values for each individual resample. Note that, if `x`
 #' is created by [last_fit()], `summarize` has no effect. For the other object
@@ -16,8 +17,7 @@
 #'  `.estimate`/`mean` gives the values for the `.metric`. When `type = "wide"`,
 #'  each metric has its own column and the `n` and `std_err` columns are removed,
 #'  if they exist.
-#'
-#' @param ... Not currently used.
+#' 
 #' @return A tibble. The column names depend on the results and the mode of the
 #' model.
 #'
@@ -139,7 +139,7 @@ collect_predictions.default <- function(x, ...) {
 
 #' @export
 #' @rdname collect_predictions
-collect_predictions.tune_results <- function(x, summarize = FALSE, parameters = NULL, ...) {
+collect_predictions.tune_results <- function(x, ..., summarize = FALSE, parameters = NULL) {
   names <- colnames(x)
   coll_col <- ".predictions"
 
@@ -454,7 +454,7 @@ collect_metrics.default <- function(x, ...) {
 
 #' @export
 #' @rdname collect_predictions
-collect_metrics.tune_results <- function(x, summarize = TRUE, type = c("long", "wide"), ...) {
+collect_metrics.tune_results <- function(x, ..., summarize = TRUE, type = c("long", "wide")) {
   rlang::arg_match0(type, values = c("long", "wide"))
 
   if (inherits(x, "last_fit")) {

--- a/R/collect.R
+++ b/R/collect.R
@@ -551,7 +551,7 @@ collector <- function(x, coll_col = ".predictions") {
 #' @export
 #' @keywords internal
 #' @rdname empty_ellipses
-estimate_tune_results <- function(x, col_name = ".metrics", ...) {
+estimate_tune_results <- function(x, ..., col_name = ".metrics") {
   param_names <- .get_tune_parameter_names(x)
   id_names <- grep("^id", names(x), value = TRUE)
   group_cols <- .get_extra_col_names(x)

--- a/R/compute_metrics.R
+++ b/R/compute_metrics.R
@@ -83,9 +83,9 @@ compute_metrics.default <- function(x,
 #' @rdname compute_metrics
 compute_metrics.tune_results <- function(x,
                                          metrics,
+                                         ...,
                                          summarize = TRUE,
-                                         event_level = "first",
-                                         ...) {
+                                         event_level = "first") {
   if (!".predictions" %in% names(x)) {
     rlang::abort(paste0(
       "`x` must have been generated with the ",

--- a/R/compute_metrics.R
+++ b/R/compute_metrics.R
@@ -86,6 +86,7 @@ compute_metrics.tune_results <- function(x,
                                          ...,
                                          summarize = TRUE,
                                          event_level = "first") {
+  rlang::check_dots_empty()
   if (!".predictions" %in% names(x)) {
     rlang::abort(paste0(
       "`x` must have been generated with the ",

--- a/R/conf_mat_resampled.R
+++ b/R/conf_mat_resampled.R
@@ -5,6 +5,7 @@
 #'
 #' @param x An object with class `tune_results` that was used with a
 #' classification model that was run with `control_*(save_pred = TRUE)`.
+#' @param ... Currently unused, must be empty.
 #' @param parameters A tibble with a single tuning parameter combination. Only
 #' one tuning parameter combination (if any were used) is allowed here.
 #' @param tidy Should the results come back in a tibble (`TRUE`) or a `conf_mat`
@@ -30,7 +31,8 @@
 #' conf_mat_resampled(res)
 #' conf_mat_resampled(res, tidy = FALSE)
 #' @export
-conf_mat_resampled <- function(x, parameters = NULL, tidy = TRUE) {
+conf_mat_resampled <- function(x, ..., parameters = NULL, tidy = TRUE) {
+  rlang::check_dots_empty()
   if (!inherits(x, "tune_results")) {
     rlang::abort(
       "The first argument needs to be an object with class 'tune_results'."

--- a/R/fit_best.R
+++ b/R/fit_best.R
@@ -6,6 +6,7 @@
 #' @param x The results of class `tune_results` (coming from functions such as
 #' [tune_grid()], [tune_bayes()], etc). The control option
 #' [`save_workflow = TRUE`][tune::control_grid] should have been used.
+#' @param ... Not currently used, must be empty.
 #' @param metric A character string (or `NULL`) for which metric to optimize. If
 #' `NULL`, the first metric is used.
 #' @param parameters An optional 1-row tibble of tuning parameter settings, with
@@ -22,7 +23,6 @@
 #' `NULL`, the validation set is not used for resamples originating from
 #' [rsample::validation_set()] while it is used for resamples originating
 #' from [rsample::validation_split()].
-#' @param ... Not currently used.
 #' @inheritParams select_best
 #' @details
 #' This function is a shortcut for the manual steps of:
@@ -88,15 +88,13 @@ fit_best.default <- function(x, ...) {
 #' @export
 #' @rdname fit_best
 fit_best.tune_results <- function(x,
+                                  ...,
                                   metric = NULL,
                                   eval_time = NULL,
                                   parameters = NULL,
                                   verbose = FALSE,
-                                  add_validation_set = NULL,
-                                  ...) {
-  if (length(list(...))) {
-    cli::cli_abort(c("x" = "The `...` are not used by this function."))
-  }
+                                  add_validation_set = NULL) {
+  rlang::check_dots_empty()
   wflow <- .get_tune_workflow(x)
   if (is.null(wflow)) {
     cli::cli_abort(c("x" = "The control option `save_workflow = TRUE` should be used when tuning."))

--- a/R/load_ns.R
+++ b/R/load_ns.R
@@ -8,7 +8,7 @@
 #' @return An invisible NULL.
 #' @keywords internal
 #' @export
-load_pkgs <- function(x, infra = TRUE, ...) {
+load_pkgs <- function(x, ..., infra = TRUE) {
   UseMethod("load_pkgs")
 }
 
@@ -18,7 +18,7 @@ load_pkgs.character <- function(x, ...) {
 }
 
 #' @export
-load_pkgs.model_spec <- function(x, infra = TRUE, ...) {
+load_pkgs.model_spec <- function(x, ..., infra = TRUE) {
   pkgs <- required_pkgs(x)
   if (infra) {
     pkgs <- c(infra_pkgs, pkgs)
@@ -27,7 +27,7 @@ load_pkgs.model_spec <- function(x, infra = TRUE, ...) {
 }
 
 #' @export
-load_pkgs.workflow <- function(x, infra = TRUE, ...) {
+load_pkgs.workflow <- function(x, ..., infra = TRUE) {
   load_pkgs.model_spec(extract_spec_parsnip(x), infra = infra)
 }
 

--- a/R/load_ns.R
+++ b/R/load_ns.R
@@ -14,11 +14,13 @@ load_pkgs <- function(x, ..., infra = TRUE) {
 
 #' @export
 load_pkgs.character <- function(x, ...) {
+  rlang::check_dots_empty()
   withr::with_preserve_seed(.load_namespace(x))
 }
 
 #' @export
 load_pkgs.model_spec <- function(x, ..., infra = TRUE) {
+  rlang::check_dots_empty()
   pkgs <- required_pkgs(x)
   if (infra) {
     pkgs <- c(infra_pkgs, pkgs)
@@ -28,6 +30,7 @@ load_pkgs.model_spec <- function(x, ..., infra = TRUE) {
 
 #' @export
 load_pkgs.workflow <- function(x, ..., infra = TRUE) {
+  rlang::check_dots_empty()
   load_pkgs.model_spec(extract_spec_parsnip(x), infra = infra)
 }
 

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -68,7 +68,7 @@ check_mult_metrics <- function(metric, ..., call = rlang::caller_env()) {
 
 #' @rdname choose_metric
 #' @export
-check_metric_in_tune_results <- function(mtr_info, metric, call = rlang::caller_env()) {
+check_metric_in_tune_results <- function(mtr_info, metric, ..., call = rlang::caller_env()) {
   if (!any(mtr_info$metric == metric)) {
     cli::cli_abort("{.val {metric}} was not in the metric set. Please choose
                     from: {.val {mtr_info$metric}}.", call = call)
@@ -97,7 +97,7 @@ contains_survival_metric <- function(mtr_info) {
 # choose_eval_time() is called by show_best(), select_best(), and augment()
 #' @rdname choose_metric
 #' @export
-choose_eval_time <- function(x, metric, eval_time = NULL, quietly = FALSE, call = rlang::caller_env()) {
+choose_eval_time <- function(x, metric, ..., eval_time = NULL, quietly = FALSE, call = rlang::caller_env()) {
 
   mtr_set <- .get_tune_metrics(x)
   mtr_info <- tibble::as_tibble(mtr_set)
@@ -253,7 +253,7 @@ first_eval_time <- function(mtr_set, metric = NULL, eval_time = NULL, ..., quiet
 
 #' @rdname choose_metric
 #' @export
-check_metrics_arg <- function(mtr_set, wflow, call = rlang::caller_env()) {
+check_metrics_arg <- function(mtr_set, wflow, ..., call = rlang::caller_env()) {
   mode <- extract_spec_parsnip(wflow)$mode
 
   if (is.null(mtr_set)) {
@@ -308,7 +308,7 @@ check_metrics_arg <- function(mtr_set, wflow, call = rlang::caller_env()) {
 
 #' @rdname choose_metric
 #' @export
-check_eval_time_arg <- function(eval_time, mtr_set, call = rlang::caller_env()) {
+check_eval_time_arg <- function(eval_time, mtr_set, ..., call = rlang::caller_env()) {
   mtr_info <- tibble::as_tibble(mtr_set)
 
   # Not a survival metric

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -184,7 +184,7 @@ first_metric <- function(mtr_set) {
 # such as tune_bayes().
 #' @rdname choose_metric
 #' @export
-first_eval_time <- function(mtr_set, metric = NULL, eval_time = NULL, ..., quietly = FALSE, call = rlang::caller_env()) {
+first_eval_time <- function(mtr_set, ..., metric = NULL, eval_time = NULL, quietly = FALSE, call = rlang::caller_env()) {
   rlang::check_dots_empty()
 
   num_times <- length(eval_time)

--- a/R/metric-selection.R
+++ b/R/metric-selection.R
@@ -69,6 +69,7 @@ check_mult_metrics <- function(metric, ..., call = rlang::caller_env()) {
 #' @rdname choose_metric
 #' @export
 check_metric_in_tune_results <- function(mtr_info, metric, ..., call = rlang::caller_env()) {
+  rlang::check_dots_empty(call = call)
   if (!any(mtr_info$metric == metric)) {
     cli::cli_abort("{.val {metric}} was not in the metric set. Please choose
                     from: {.val {mtr_info$metric}}.", call = call)
@@ -98,7 +99,7 @@ contains_survival_metric <- function(mtr_info) {
 #' @rdname choose_metric
 #' @export
 choose_eval_time <- function(x, metric, ..., eval_time = NULL, quietly = FALSE, call = rlang::caller_env()) {
-
+  rlang::check_dots_empty(call = call)
   mtr_set <- .get_tune_metrics(x)
   mtr_info <- tibble::as_tibble(mtr_set)
 
@@ -254,6 +255,7 @@ first_eval_time <- function(mtr_set, metric = NULL, eval_time = NULL, ..., quiet
 #' @rdname choose_metric
 #' @export
 check_metrics_arg <- function(mtr_set, wflow, ..., call = rlang::caller_env()) {
+  rlang::check_dots_empty(call = call)
   mode <- extract_spec_parsnip(wflow)$mode
 
   if (is.null(mtr_set)) {
@@ -309,6 +311,7 @@ check_metrics_arg <- function(mtr_set, wflow, ..., call = rlang::caller_env()) {
 #' @rdname choose_metric
 #' @export
 check_eval_time_arg <- function(eval_time, mtr_set, ..., call = rlang::caller_env()) {
+  rlang::check_dots_empty(call = call)
   mtr_info <- tibble::as_tibble(mtr_set)
 
   # Not a survival metric

--- a/R/plots.R
+++ b/R/plots.R
@@ -1,8 +1,6 @@
 #' Plot tuning search results
 #'
 #' @param object A tibble of results from [tune_grid()] or [tune_bayes()].
-#' @param ... For plots with a regular grid, this is passed to `format()` and is
-#' applied to a parameter used to color points. Otherwise, it is not used.
 #' @param type A single character value. Choices are `"marginals"` (for a plot
 #'  of each predictor versus performance; see Details below), `"parameters"`
 #'  (each parameter versus search iteration), or `"performance"` (performance
@@ -16,6 +14,8 @@
 #' metrics should be chosen (e.g. the time-dependent ROC curve, etc). The
 #' values should be consistent with the values used to create `object`.
 #' @param call The call to be displayed in warnings or errors.
+#' @param ... For plots with a regular grid, this is passed to `format()` and is
+#' applied to a parameter used to color points. Otherwise, it is not used.
 #' @return A `ggplot2` object.
 #' @details
 #'
@@ -76,12 +76,12 @@
 #' @export
 autoplot.tune_results <-
   function(object,
-           ...,
            type = c("marginals", "parameters", "performance"),
            metric = NULL,
            eval_time = NULL,
            width = NULL,
-           call = rlang::current_env()) {
+           call = rlang::current_env(),
+           ...) {
     type <- match.arg(type)
     has_iter <- any(names(object) == ".iter")
     if (!has_iter && type != "marginals") {

--- a/R/plots.R
+++ b/R/plots.R
@@ -1,6 +1,8 @@
 #' Plot tuning search results
 #'
 #' @param object A tibble of results from [tune_grid()] or [tune_bayes()].
+#' @param ... For plots with a regular grid, this is passed to `format()` and is
+#' applied to a parameter used to color points. Otherwise, it is not used.
 #' @param type A single character value. Choices are `"marginals"` (for a plot
 #'  of each predictor versus performance; see Details below), `"parameters"`
 #'  (each parameter versus search iteration), or `"performance"` (performance
@@ -14,8 +16,6 @@
 #' metrics should be chosen (e.g. the time-dependent ROC curve, etc). The
 #' values should be consistent with the values used to create `object`.
 #' @param call The call to be displayed in warnings or errors.
-#' @param ... For plots with a regular grid, this is passed to `format()` and is
-#' applied to a parameter used to color points. Otherwise, it is not used.
 #' @return A `ggplot2` object.
 #' @details
 #'
@@ -76,12 +76,12 @@
 #' @export
 autoplot.tune_results <-
   function(object,
+           ...,
            type = c("marginals", "parameters", "performance"),
            metric = NULL,
            eval_time = NULL,
            width = NULL,
-           call = rlang::current_env(),
-           ...) {
+           call = rlang::current_env()) {
     type <- match.arg(type)
     has_iter <- any(names(object) == ".iter")
     if (!has_iter && type != "marginals") {

--- a/R/select_best.R
+++ b/R/select_best.R
@@ -15,6 +15,12 @@
 #'  performance is within some acceptable limit.
 #'
 #' @param x The results of [tune_grid()] or [tune_bayes()].
+#' @param ... For [select_by_one_std_err()] and [select_by_pct_loss()], this
+#' argument is passed directly to [dplyr::arrange()] so that the user can sort
+#' the models from *most simple to most complex*. That is, for a parameter `p`,
+#' pass the unquoted expression `p` if smaller values of `p` indicate a simpler
+#' model, or `desc(p)` if larger values indicate a simpler model. At
+#' least one term is required for these two functions. See the examples below.
 #' @param metric A character value for the metric that will be used to sort
 #'  the models. (See
 #'  \url{https://yardstick.tidymodels.org/articles/metric-types.html} for
@@ -24,12 +30,6 @@
 #' @param n An integer for the number of top results/rows to return.
 #' @param limit The limit of loss of performance that is acceptable (in percent
 #' units). See details below.
-#' @param ... For [select_by_one_std_err()] and [select_by_pct_loss()], this
-#' argument is passed directly to [dplyr::arrange()] so that the user can sort
-#' the models from *most simple to most complex*. That is, for a parameter `p`,
-#' pass the unquoted expression `p` if smaller values of `p` indicate a simpler
-#' model, or `desc(p)` if larger values indicate a simpler model. At
-#' least one term is required for these two functions. See the examples below.
 #' @param eval_time A single numeric time point where dynamic event time
 #' metrics should be chosen (e.g., the time-dependent ROC curve, etc). The
 #' values should be consistent with the values used to create `x`. The `NULL` 
@@ -78,10 +78,10 @@ show_best.default <- function(x, ...) {
 #' @export
 #' @rdname show_best
 show_best.tune_results <- function(x, 
+                                   ...,
                                    metric = NULL, 
                                    eval_time = NULL,
                                    n = 5, 
-                                   ..., 
                                    call = rlang::current_env()) {
   rlang::check_dots_empty()
 
@@ -119,7 +119,7 @@ select_best.default <- function(x, ...) {
 
 #' @export
 #' @rdname show_best
-select_best.tune_results <- function(x, metric = NULL, eval_time = NULL, ...) {
+select_best.tune_results <- function(x, ..., metric = NULL, eval_time = NULL) {
   rlang::check_dots_empty()
 
   metric_info <- choose_metric(x, metric)

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -296,7 +296,7 @@ tune_bayes_workflow <- function(object,
     maximize <- opt_metric$direction == "maximize"
 
     eval_time <- check_eval_time_arg(eval_time, metrics, call = call)
-    opt_metric_time <- first_eval_time(metrics, opt_metric_name, eval_time, call = call)
+    opt_metric_time <- first_eval_time(metrics, metric = opt_metric_name, eval_time = eval_time, call = call)
 
     if (is.null(param_info)) {
       param_info <- hardhat::extract_parameter_set_dials(object)

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -548,6 +548,7 @@ check_iter <- function(iter, call) {
 #' @param pset A `parameters` object.
 #' @param as_matrix A logical for the return type.
 encode_set <- function(x, pset, ..., as_matrix = FALSE) {
+  rlang::check_dots_empty()
   # change the numeric variables to the transformed scale (if any)
   has_trans <- purrr::map_lgl(pset$object, ~ !is.null(.x$trans))
   if (any(has_trans)) {

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -547,7 +547,7 @@ check_iter <- function(iter, call) {
 #' @rdname empty_ellipses
 #' @param pset A `parameters` object.
 #' @param as_matrix A logical for the return type.
-encode_set <- function(x, pset, as_matrix = FALSE, ...) {
+encode_set <- function(x, pset, ..., as_matrix = FALSE) {
   # change the numeric variables to the transformed scale (if any)
   has_trans <- purrr::map_lgl(pset$object, ~ !is.null(.x$trans))
   if (any(has_trans)) {

--- a/man/augment.tune_results.Rd
+++ b/man/augment.tune_results.Rd
@@ -6,7 +6,7 @@
 \alias{augment.last_fit}
 \title{Augment data with holdout predictions}
 \usage{
-\method{augment}{tune_results}(x, parameters = NULL, ...)
+\method{augment}{tune_results}(x, ..., parameters = NULL)
 
 \method{augment}{resample_results}(x, ...)
 
@@ -17,13 +17,13 @@
 \code{fit_resamples()}, or \code{last_fit()}. The control specifications for these
 objects should have used the option \code{save_pred = TRUE}.}
 
+\item{...}{Not currently used.}
+
 \item{parameters}{A data frame with a single row that indicates what
 tuning parameters should be used to generate the predictions (for \verb{tune_*()}
 objects only). If \code{NULL}, \code{select_best(x)} will be used with the first
 metric and, if applicable, the first evaluation time point, used to
 create \code{x}.}
-
-\item{...}{Not currently used.}
 }
 \value{
 A data frame with one or more additional columns for model

--- a/man/autoplot.tune_results.Rd
+++ b/man/autoplot.tune_results.Rd
@@ -6,16 +6,19 @@
 \usage{
 \method{autoplot}{tune_results}(
   object,
+  ...,
   type = c("marginals", "parameters", "performance"),
   metric = NULL,
   eval_time = NULL,
   width = NULL,
-  call = rlang::current_env(),
-  ...
+  call = rlang::current_env()
 )
 }
 \arguments{
 \item{object}{A tibble of results from \code{\link[=tune_grid]{tune_grid()}} or \code{\link[=tune_bayes]{tune_bayes()}}.}
+
+\item{...}{For plots with a regular grid, this is passed to \code{format()} and is
+applied to a parameter used to color points. Otherwise, it is not used.}
 
 \item{type}{A single character value. Choices are \code{"marginals"} (for a plot
 of each predictor versus performance; see Details below), \code{"parameters"}
@@ -34,9 +37,6 @@ values should be consistent with the values used to create \code{object}.}
 \code{type = "performance"}. A value of zero prevents them from being shown.}
 
 \item{call}{The call to be displayed in warnings or errors.}
-
-\item{...}{For plots with a regular grid, this is passed to \code{format()} and is
-applied to a parameter used to color points. Otherwise, it is not used.}
 }
 \value{
 A \code{ggplot2} object.

--- a/man/autoplot.tune_results.Rd
+++ b/man/autoplot.tune_results.Rd
@@ -6,19 +6,16 @@
 \usage{
 \method{autoplot}{tune_results}(
   object,
-  ...,
   type = c("marginals", "parameters", "performance"),
   metric = NULL,
   eval_time = NULL,
   width = NULL,
-  call = rlang::current_env()
+  call = rlang::current_env(),
+  ...
 )
 }
 \arguments{
 \item{object}{A tibble of results from \code{\link[=tune_grid]{tune_grid()}} or \code{\link[=tune_bayes]{tune_bayes()}}.}
-
-\item{...}{For plots with a regular grid, this is passed to \code{format()} and is
-applied to a parameter used to color points. Otherwise, it is not used.}
 
 \item{type}{A single character value. Choices are \code{"marginals"} (for a plot
 of each predictor versus performance; see Details below), \code{"parameters"}
@@ -37,6 +34,9 @@ values should be consistent with the values used to create \code{object}.}
 \code{type = "performance"}. A value of zero prevents them from being shown.}
 
 \item{call}{The call to be displayed in warnings or errors.}
+
+\item{...}{For plots with a regular grid, this is passed to \code{format()} and is
+applied to a parameter used to color points. Otherwise, it is not used.}
 }
 \value{
 A \code{ggplot2} object.

--- a/man/choose_metric.Rd
+++ b/man/choose_metric.Rd
@@ -14,11 +14,12 @@
 \usage{
 choose_metric(x, metric, ..., call = rlang::caller_env())
 
-check_metric_in_tune_results(mtr_info, metric, call = rlang::caller_env())
+check_metric_in_tune_results(mtr_info, metric, ..., call = rlang::caller_env())
 
 choose_eval_time(
   x,
   metric,
+  ...,
   eval_time = NULL,
   quietly = FALSE,
   call = rlang::caller_env()
@@ -39,9 +40,9 @@ first_eval_time(
 
 .filter_perf_metrics(x, metric, eval_time)
 
-check_metrics_arg(mtr_set, wflow, call = rlang::caller_env())
+check_metrics_arg(mtr_set, wflow, ..., call = rlang::caller_env())
 
-check_eval_time_arg(eval_time, mtr_set, call = rlang::caller_env())
+check_eval_time_arg(eval_time, mtr_set, ..., call = rlang::caller_env())
 }
 \arguments{
 \item{x}{An object with class \code{tune_results}.}

--- a/man/choose_metric.Rd
+++ b/man/choose_metric.Rd
@@ -31,9 +31,9 @@ first_metric(mtr_set)
 
 first_eval_time(
   mtr_set,
+  ...,
   metric = NULL,
   eval_time = NULL,
-  ...,
   quietly = FALSE,
   call = rlang::caller_env()
 )

--- a/man/collect_predictions.Rd
+++ b/man/collect_predictions.Rd
@@ -16,11 +16,11 @@ collect_predictions(x, ...)
 
 \method{collect_predictions}{default}(x, ...)
 
-\method{collect_predictions}{tune_results}(x, summarize = FALSE, parameters = NULL, ...)
+\method{collect_predictions}{tune_results}(x, ..., summarize = FALSE, parameters = NULL)
 
 collect_metrics(x, ...)
 
-\method{collect_metrics}{tune_results}(x, summarize = TRUE, type = c("long", "wide"), ...)
+\method{collect_metrics}{tune_results}(x, ..., summarize = TRUE, type = c("long", "wide"))
 
 collect_notes(x, ...)
 

--- a/man/compute_metrics.Rd
+++ b/man/compute_metrics.Rd
@@ -10,7 +10,7 @@ compute_metrics(x, metrics, summarize, event_level, ...)
 
 \method{compute_metrics}{default}(x, metrics, summarize = TRUE, event_level = "first", ...)
 
-\method{compute_metrics}{tune_results}(x, metrics, summarize = TRUE, event_level = "first", ...)
+\method{compute_metrics}{tune_results}(x, metrics, ..., summarize = TRUE, event_level = "first")
 }
 \arguments{
 \item{x}{The results of a tuning function like \code{\link[=tune_grid]{tune_grid()}} or

--- a/man/conf_mat_resampled.Rd
+++ b/man/conf_mat_resampled.Rd
@@ -4,11 +4,13 @@
 \alias{conf_mat_resampled}
 \title{Compute average confusion matrix across resamples}
 \usage{
-conf_mat_resampled(x, parameters = NULL, tidy = TRUE)
+conf_mat_resampled(x, ..., parameters = NULL, tidy = TRUE)
 }
 \arguments{
 \item{x}{An object with class \code{tune_results} that was used with a
 classification model that was run with \code{control_*(save_pred = TRUE)}.}
+
+\item{...}{Currently unused, must be empty.}
 
 \item{parameters}{A tibble with a single tuning parameter combination. Only
 one tuning parameter combination (if any were used) is allowed here.}

--- a/man/empty_ellipses.Rd
+++ b/man/empty_ellipses.Rd
@@ -48,7 +48,7 @@ val_class_and_single(x, cls = "numeric", where = NULL)
 
 .config_key_from_metrics(x)
 
-estimate_tune_results(x, col_name = ".metrics", ...)
+estimate_tune_results(x, ..., col_name = ".metrics")
 
 metrics_info(x)
 
@@ -65,7 +65,7 @@ new_iteration_results(
 
 get_tune_colors()
 
-encode_set(x, pset, as_matrix = FALSE, ...)
+encode_set(x, pset, ..., as_matrix = FALSE)
 
 check_time(origin, limit)
 

--- a/man/empty_ellipses.Rd
+++ b/man/empty_ellipses.Rd
@@ -27,7 +27,7 @@ check_rset(x)
 
 check_parameters(wflow, pset = NULL, data, grid_names = character(0))
 
-check_workflow(x, pset = NULL, check_dials = FALSE, call = caller_env())
+check_workflow(x, ..., pset = NULL, check_dials = FALSE, call = caller_env())
 
 check_metrics(x, object)
 
@@ -90,6 +90,8 @@ is_workflow(x)
 
 \item{grid_names}{A character vector of column names from the grid.}
 
+\item{...}{Other options}
+
 \item{check_dials}{A logical for check for a NULL parameter object.}
 
 \item{object}{A \code{workflow} object.}
@@ -106,8 +108,6 @@ metrics should be computed (e.g. the time-dependent ROC curve, etc).}
 \item{cls}{A character vector of possible classes}
 
 \item{where}{A character string for the calling function.}
-
-\item{...}{Other options}
 
 \item{parameters}{A \code{parameters} object.}
 

--- a/man/load_pkgs.Rd
+++ b/man/load_pkgs.Rd
@@ -4,7 +4,7 @@
 \alias{load_pkgs}
 \title{Quietly load package namespace}
 \usage{
-load_pkgs(x, infra = TRUE, ...)
+load_pkgs(x, ..., infra = TRUE)
 }
 \arguments{
 \item{x}{A character vector of packages.}

--- a/man/show_best.Rd
+++ b/man/show_best.Rd
@@ -21,10 +21,10 @@ show_best(x, ...)
 
 \method{show_best}{tune_results}(
   x,
+  ...,
   metric = NULL,
   eval_time = NULL,
   n = 5,
-  ...,
   call = rlang::current_env()
 )
 
@@ -32,7 +32,7 @@ select_best(x, ...)
 
 \method{select_best}{default}(x, ...)
 
-\method{select_best}{tune_results}(x, metric = NULL, eval_time = NULL, ...)
+\method{select_best}{tune_results}(x, ..., metric = NULL, eval_time = NULL)
 
 select_by_pct_loss(x, ...)
 

--- a/tests/testthat/_snaps/collect.md
+++ b/tests/testthat/_snaps/collect.md
@@ -22,58 +22,6 @@
       Error in `filter_predictions()`:
       ! `parameters` should only have columns: 'cost value'
 
-# collecting notes - fit_resamples
-
-    Code
-      lm_splines <- fit_resamples(lin_mod, mpg ~ ., flds)
-    Message
-      ! Bootstrap1: preprocessor 1/1, model 1/1 (predictions): prediction from a rank-deficient fit may be misleading
-      ! Bootstrap2: preprocessor 1/1, model 1/1 (predictions): prediction from a rank-deficient fit may be misleading
-
----
-
-    Code
-      lm_splines
-    Output
-      # Resampling results
-      # Bootstrap sampling 
-      # A tibble: 2 x 4
-        splits          id         .metrics         .notes          
-        <list>          <chr>      <list>           <list>          
-      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]>
-      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 3]>
-      
-      There were issues with some computations:
-      
-        - Warning(s) x2: prediction from a rank-deficient fit may be misleading
-      
-      Run `show_notes(.Last.tune.result)` for more information.
-
-# collecting notes - last_fit
-
-    Code
-      lst <- last_fit(lin_mod, mpg ~ ., split)
-    Message
-      ! train/test split: preprocessor 1/1, model 1/1 (predictions): prediction from a rank-deficient fit may be misleading
-
----
-
-    Code
-      lst
-    Output
-      # Resampling results
-      # Manual resampling 
-      # A tibble: 1 x 6
-        splits         id               .metrics .notes   .predictions     .workflow 
-        <list>         <chr>            <list>   <list>   <list>           <list>    
-      1 <split [24/8]> train/test split <tibble> <tibble> <tibble [8 x 4]> <workflow>
-      
-      There were issues with some computations:
-      
-        - Warning(s) x1: prediction from a rank-deficient fit may be misleading
-      
-      Run `show_notes(.Last.tune.result)` for more information.
-
 # `collect_notes()` errors informatively applied to unsupported class
 
     Code

--- a/tests/testthat/_snaps/conf-mat-resampled.md
+++ b/tests/testthat/_snaps/conf-mat-resampled.md
@@ -50,8 +50,10 @@
 ---
 
     Code
-      conf_mat_resampled(svm_results)
+      conf_mat_resampled(svm_results, argument_that_doesnt_exist = TRUE)
     Condition
       Error in `conf_mat_resampled()`:
-      ! It looks like there are 5 tuning parameter combination(s) in the data. Please use the `parameters` argument to select one combination of parameters.
+      ! `...` must be empty.
+      x Problematic argument:
+      * argument_that_doesnt_exist = TRUE
 

--- a/tests/testthat/_snaps/conf-mat-resampled.md
+++ b/tests/testthat/_snaps/conf-mat-resampled.md
@@ -41,7 +41,8 @@
 ---
 
     Code
-      conf_mat_resampled(broke_results, select_best(broke_results, "accuracy"))
+      conf_mat_resampled(broke_results, parameters = select_best(broke_results,
+        metric = "accuracy"))
     Condition
       Error in `conf_mat_resampled()`:
       ! Cannot determine the proper outcome name

--- a/tests/testthat/_snaps/eval-time-single-selection.md
+++ b/tests/testthat/_snaps/eval-time-single-selection.md
@@ -9,7 +9,7 @@
 ---
 
     Code
-      first_eval_time(met_dyn, "brier_survival", eval_time = NULL)
+      first_eval_time(met_dyn, metric = "brier_survival", eval_time = NULL)
     Condition
       Error:
       ! A single evaluation time is required to use this metric.

--- a/tests/testthat/_snaps/eval-time-single-selection.md
+++ b/tests/testthat/_snaps/eval-time-single-selection.md
@@ -84,7 +84,7 @@
 ---
 
     Code
-      choose_eval_time(ames_grid_search, "rmse", 1)
+      choose_eval_time(ames_grid_search, "rmse", eval_time = 1)
     Condition
       Warning:
       `eval_time` is only used for models with mode "censored regression".

--- a/tests/testthat/_snaps/fit_best.md
+++ b/tests/testthat/_snaps/fit_best.md
@@ -62,7 +62,9 @@
 
 ---
 
-    x The `...` are not used by this function.
+    `...` must be empty.
+    x Problematic argument:
+    * chickens = 2
 
 ---
 

--- a/tests/testthat/test-collect.R
+++ b/tests/testthat/test-collect.R
@@ -47,7 +47,7 @@ svm_tune_class$.predictions <-
   )
 attr(svm_tune_class, "metrics") <- yardstick::metric_set(yardstick::kap)
 
-svm_grd <- show_best(svm_tune, "roc_auc") %>% dplyr::select(`cost value`)
+svm_grd <- show_best(svm_tune, metric = "roc_auc") %>% dplyr::select(`cost value`)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test-conf-mat-resampled.R
+++ b/tests/testthat/test-conf-mat-resampled.R
@@ -64,6 +64,6 @@ test_that("bad argss", {
   })
 
   expect_snapshot(error = TRUE, {
-    conf_mat_resampled(svm_results)
+    conf_mat_resampled(svm_results, argument_that_doesnt_exist = TRUE)
   })
 })

--- a/tests/testthat/test-conf-mat-resampled.R
+++ b/tests/testthat/test-conf-mat-resampled.R
@@ -2,13 +2,13 @@ test_that("appropriate return values", {
   svm_results <- readRDS(test_path("data", "svm_results.rds"))
 
   expect_error(
-    cm_1 <- conf_mat_resampled(svm_results, select_best(svm_results, "accuracy")),
+    cm_1 <- conf_mat_resampled(svm_results, parameters = select_best(svm_results, metric = "accuracy")),
     regex = NA
   )
   expect_true(tibble::is_tibble(cm_1))
 
   expect_error(
-    cm_2 <- conf_mat_resampled(svm_results, select_best(svm_results, "accuracy"), tidy = FALSE),
+    cm_2 <- conf_mat_resampled(svm_results, parameters = select_best(svm_results, metric = "accuracy"), tidy = FALSE),
     regex = NA
   )
   expect_equal(class(cm_2), "conf_mat")
@@ -60,7 +60,7 @@ test_that("bad argss", {
   attr(broke_results, "outcomes") <- NULL
 
   expect_snapshot(error = TRUE, {
-    conf_mat_resampled(broke_results, select_best(broke_results, "accuracy"))
+    conf_mat_resampled(broke_results, parameters = select_best(broke_results, metric = "accuracy"))
   })
 
   expect_snapshot(error = TRUE, {

--- a/tests/testthat/test-eval-time-single-selection.R
+++ b/tests/testthat/test-eval-time-single-selection.R
@@ -25,7 +25,7 @@ test_that("selecting single eval time - pure metric sets", {
   # all static; return NULL and add warning if times are given
 
   expect_null(first_eval_time(met_stc, eval_time = NULL))
-  expect_null(first_eval_time(met_stc, "concordance_survival", eval_time = NULL))
+  expect_null(first_eval_time(met_stc, metric = "concordance_survival", eval_time = NULL))
 
   expect_silent(
     stc_one <- first_eval_time(met_stc, eval_time = times_1)
@@ -45,7 +45,7 @@ test_that("selecting single eval time - pure metric sets", {
     error = TRUE
   )
   expect_snapshot(
-    first_eval_time(met_dyn, "brier_survival", eval_time = NULL),
+    first_eval_time(met_dyn, metric = "brier_survival", eval_time = NULL),
     error = TRUE
   )
 
@@ -63,7 +63,7 @@ test_that("selecting single eval time - pure metric sets", {
 
   expect_null(first_eval_time(met_int, eval_time = NULL))
   expect_null(
-    first_eval_time(met_int, "brier_survival_integrated", eval_time = NULL)
+    first_eval_time(met_int, metric = "brier_survival_integrated", eval_time = NULL)
   )
 
   expect_silent(

--- a/tests/testthat/test-eval-time-single-selection.R
+++ b/tests/testthat/test-eval-time-single-selection.R
@@ -219,5 +219,5 @@ test_that("selecting an evaluation time", {
   )
 
   data("example_ames_knn")
-  expect_snapshot(choose_eval_time(ames_grid_search, "rmse", 1))
+  expect_snapshot(choose_eval_time(ames_grid_search, "rmse", eval_time = 1))
 })


### PR DESCRIPTION
From `NEWS`:

> Ellipses (...) are now used consistently in the package to require optional arguments to be named. For functions that previously had ellipses at the end of the function signature, they have been moved to follow the last argument without a default value: this applies to `augment.tune_results()`, `collect_predictions.tune_results()`, `collect_metrics.tune_results()`, and the developer-focused `estimate_tune_results()`, `load_pkgs()`, and `encode_set()`. Several other functions that previously did not have ellipses in their signatures gained them: this applies to `conf_mat_resampled()` and the developer-focused `check_workflow()`. Optional arguments previously passed by position will now error informatively prompting them to be named. These changes don't apply in cases when the ellipses are currently in use to forward arguments to other functions.

Note that these changes also apply to some other functions that hadn't yet made it to the CRAN version of the package.

Creating as draft as there are many changes here and I'd want to take another look + look into extratests + get started on analogous changes downstream in finetune and agua before calling this ready for review. If you see issues already, though, feel free to chime in.