### PR TITLE
speed up `int_pctl.tune_results()`

### DIFF
--- a/R/int_pctl.R
+++ b/R/int_pctl.R
@@ -159,12 +159,15 @@ boostrap_metrics_by_config <- function(config, seed, x, metrics, times, allow_pa
   } else {
     res <- rsample::int_pctl(rs, .metrics, alpha = alpha)
   }
-  res %>%
-    dplyr::mutate(.estimator = "bootstrap") %>%
-    dplyr::rename(.metric = term) %>%
-    dplyr::relocate(.estimator, .after = .metric) %>%
-    dplyr::select(-.alpha, -.method) %>%
-    cbind(config)
+
+  res$.metric <- res$term
+  res$term <- NULL
+  res$.estimator <- "bootstrap"
+  res$.alpha <- NULL
+  res$.method <- NULL
+  res <- cbind(res, config)
+  first_cols <- c(".metric", ".estimator")
+  res[c(first_cols, setdiff(names(res), first_cols))]
 }
 
 fake_term <- function(x) {
@@ -237,9 +240,12 @@ comp_metrics <- function(split,
       metrics_info = metrics_info
     )
 
-  res %>%
-    dplyr::rename(term = .metric, estimate = .estimate) %>%
-    dplyr::select(-.estimator)
+  res$term <- res$.metric
+  res$.metric <- NULL
+  res$estimate <- res$.estimate
+  res$.estimate <- NULL
+  res$.estimator <- NULL
+  res
 }
 
 # ------------------------------------------------------------------------------

--- a/R/int_pctl.R
+++ b/R/int_pctl.R
@@ -73,6 +73,9 @@ int_pctl.tune_results <- function(.data, metrics = NULL, eval_time = NULL,
 
   rlang::check_dots_empty()
 
+  # performance speedup, enables tidymodels/yardstick#428
+  initialize_catalog(control_resamples(allow_par = TRUE))
+
   if (is.null(metrics)) {
     metrics <- .get_tune_metrics(.data)
   } else {


### PR DESCRIPTION
With `main`:

``` r
library(tune)
library(rsample)
library(parsnip)
library(yardstick)

data(two_class_dat, package = "modeldata")
set.seed(13)
cls_rs <- vfold_cv(two_class_dat)

c5_res <-
  decision_tree(min_n = tune()) %>%
  set_engine("C5.0") %>%
  set_mode("classification") %>%
  tune_grid(
    Class ~.,
    resamples = cls_rs,
    grid = dplyr::tibble(min_n = c(5, 20, 40)),
    metrics = metric_set(sens),
    control = control_grid(save_pred = TRUE)
  )

set.seed(1)
bench::mark(
  int_res_old = int_pctl(c5_res)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 int_res_old    7.38s    7.38s     0.136     476MB     5.69
```

<sup>Created on 2024-03-04 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

With this PR:

``` r
set.seed(1)
bench::mark(
  int_res_new = int_pctl(c5_res)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 int_res_new    4.39s    4.39s     0.228     443MB     6.84
```

The last major slowdown is that each metric calculation is its own call to the metric function's `data.frame` method (inside of `.estimate_metrics()`), and each of those calls making its own tidyselect call:

<img width="823" alt="Screenshot of profiling output." src="https://github.com/tidymodels/tune/assets/35748691/37c2cde6-583b-4722-92e8-1a900a976413">


I think we can write that out by hooking into yardsticks "known selections" tools (tidymodels/yardstick#428). (EDIT: now done.)

Note that these changes don't just affect constant "overhead," but slowdowns that increase with `times`.