### PR TITLE
log a backtrace for tuning issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * The package will now log a backtrace for errors and warnings that
   occur during tuning. When a tuning process encounters issues, see the new 
-  `trace` column in `collect_notes(.Last.tune.result)` output to find
+  `trace` column in the `collect_notes(.Last.tune.result)` output to find
   precisely where the error occurred (#873).
 
 # tune 1.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # tune (development version)
 
+* The package will now log a backtrace for errors and warnings that
+  occur during tuning. When a tuning process encounters issues, see the new 
+  `trace` column in `collect_notes(.Last.tune.result)` output to find
+  precisely where the error occurred (#873).
+
 # tune 1.2.0
 
 ## New Features

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -354,7 +354,10 @@ tune_grid_loop_iter <- function(split,
   out_all_outcome_names <- list()
   out_notes <-
     tibble::new_tibble(list(
-      location = character(0), type = character(0), note = character(0)
+      location = character(0),
+      type = character(0),
+      note = character(0),
+      trace = list()
     ))
 
   model_params <- vctrs::vec_slice(params, params$source == "model_spec")

--- a/R/logging.R
+++ b/R/logging.R
@@ -307,8 +307,10 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
     wrn_msg <- unique(wrn_msg)
     wrn_msg <- paste(wrn_msg, collapse = ", ")
 
+    wrn_traces <- purrr::map(wrn, `$`, "trace")
+
     wrn_msg <- tibble::new_tibble(
-      list(location = loc, type = "warning", note = wrn_msg),
+      list(location = loc, type = "warning", note = wrn_msg, trace = list(wrn_traces[[1]])),
       nrow = 1
     )
 
@@ -322,15 +324,16 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
     }
   }
   if (inherits(res$res, "try-error")) {
+    err_cnd <- attr(res$res, "condition")
     if (should_catalog) {
-      err_msg <- conditionMessage(attr(res$res, "condition"))
+      err_msg <- conditionMessage(err_cnd)
     } else {
-      err_msg <- as.character(attr(res$res, "condition"))
+      err_msg <- as.character(err_cnd)
       err_msg <- gsub("\n$", "", err_msg)
     }
 
     err_msg <- tibble::new_tibble(
-      list(location = loc, type = "error", note = err_msg),
+      list(location = loc, type = "error", note = err_msg, trace = list(err_cnd$trace)),
       nrow = 1
     )
 

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -374,7 +374,12 @@ tune_bayes_workflow <- function(object,
     for (i in seq_len(iter) + score_card$overall_iter) {
       .notes <-
         tibble::new_tibble(
-          list(location = character(0), type = character(0), note = character(0)),
+          list(
+            location = character(0),
+            type = character(0),
+            note = character(0),
+            trace = list()
+          ),
           nrow = 0
         )
 

--- a/tests/testthat/_snaps/bayes.md
+++ b/tests/testthat/_snaps/bayes.md
@@ -148,16 +148,16 @@
       # A tibble: 30 x 5
          splits         id     .metrics         .notes           .iter
          <list>         <chr>  <list>           <list>           <int>
-       1 <split [28/4]> Fold01 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       2 <split [28/4]> Fold02 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       3 <split [29/3]> Fold03 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       4 <split [29/3]> Fold04 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       5 <split [29/3]> Fold05 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       6 <split [29/3]> Fold06 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       7 <split [29/3]> Fold07 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       8 <split [29/3]> Fold08 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       9 <split [29/3]> Fold09 <tibble [4 x 5]> <tibble [0 x 3]>     0
-      10 <split [29/3]> Fold10 <tibble [4 x 5]> <tibble [0 x 3]>     0
+       1 <split [28/4]> Fold01 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       2 <split [28/4]> Fold02 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       3 <split [29/3]> Fold03 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       4 <split [29/3]> Fold04 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       5 <split [29/3]> Fold05 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       6 <split [29/3]> Fold06 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       7 <split [29/3]> Fold07 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       8 <split [29/3]> Fold08 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       9 <split [29/3]> Fold09 <tibble [4 x 5]> <tibble [0 x 4]>     0
+      10 <split [29/3]> Fold10 <tibble [4 x 5]> <tibble [0 x 4]>     0
       # i 20 more rows
 
 ---
@@ -199,16 +199,16 @@
       # A tibble: 30 x 5
          splits         id     .metrics         .notes           .iter
          <list>         <chr>  <list>           <list>           <int>
-       1 <split [28/4]> Fold01 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       2 <split [28/4]> Fold02 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       3 <split [29/3]> Fold03 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       4 <split [29/3]> Fold04 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       5 <split [29/3]> Fold05 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       6 <split [29/3]> Fold06 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       7 <split [29/3]> Fold07 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       8 <split [29/3]> Fold08 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       9 <split [29/3]> Fold09 <tibble [4 x 5]> <tibble [0 x 3]>     0
-      10 <split [29/3]> Fold10 <tibble [4 x 5]> <tibble [0 x 3]>     0
+       1 <split [28/4]> Fold01 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       2 <split [28/4]> Fold02 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       3 <split [29/3]> Fold03 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       4 <split [29/3]> Fold04 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       5 <split [29/3]> Fold05 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       6 <split [29/3]> Fold06 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       7 <split [29/3]> Fold07 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       8 <split [29/3]> Fold08 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       9 <split [29/3]> Fold09 <tibble [4 x 5]> <tibble [0 x 4]>     0
+      10 <split [29/3]> Fold10 <tibble [4 x 5]> <tibble [0 x 4]>     0
       # i 20 more rows
 
 ---
@@ -374,16 +374,16 @@
       # A tibble: 30 x 5
          splits         id     .metrics         .notes           .iter
          <list>         <chr>  <list>           <list>           <int>
-       1 <split [28/4]> Fold01 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       2 <split [28/4]> Fold02 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       3 <split [29/3]> Fold03 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       4 <split [29/3]> Fold04 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       5 <split [29/3]> Fold05 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       6 <split [29/3]> Fold06 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       7 <split [29/3]> Fold07 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       8 <split [29/3]> Fold08 <tibble [4 x 5]> <tibble [0 x 3]>     0
-       9 <split [29/3]> Fold09 <tibble [4 x 5]> <tibble [0 x 3]>     0
-      10 <split [29/3]> Fold10 <tibble [4 x 5]> <tibble [0 x 3]>     0
+       1 <split [28/4]> Fold01 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       2 <split [28/4]> Fold02 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       3 <split [29/3]> Fold03 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       4 <split [29/3]> Fold04 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       5 <split [29/3]> Fold05 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       6 <split [29/3]> Fold06 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       7 <split [29/3]> Fold07 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       8 <split [29/3]> Fold08 <tibble [4 x 5]> <tibble [0 x 4]>     0
+       9 <split [29/3]> Fold09 <tibble [4 x 5]> <tibble [0 x 4]>     0
+      10 <split [29/3]> Fold10 <tibble [4 x 5]> <tibble [0 x 4]>     0
       # i 20 more rows
 
 # tune model only - failure in recipe is caught elegantly

--- a/tests/testthat/_snaps/censored-reg.md
+++ b/tests/testthat/_snaps/censored-reg.md
@@ -30,16 +30,16 @@
       # A tibble: 10 x 4
          splits           id     .metrics         .notes          
          <list>           <chr>  <list>           <list>          
-       1 <split [164/20]> Fold01 <tibble [1 x 4]> <tibble [0 x 3]>
-       2 <split [165/19]> Fold02 <tibble [1 x 4]> <tibble [0 x 3]>
-       3 <split [165/19]> Fold03 <tibble [1 x 4]> <tibble [0 x 3]>
-       4 <split [166/18]> Fold04 <tibble [1 x 4]> <tibble [0 x 3]>
-       5 <split [166/18]> Fold05 <tibble [1 x 4]> <tibble [0 x 3]>
-       6 <split [166/18]> Fold06 <tibble [1 x 4]> <tibble [0 x 3]>
-       7 <split [166/18]> Fold07 <tibble [1 x 4]> <tibble [0 x 3]>
-       8 <split [166/18]> Fold08 <tibble [1 x 4]> <tibble [0 x 3]>
-       9 <split [166/18]> Fold09 <tibble [1 x 4]> <tibble [0 x 3]>
-      10 <split [166/18]> Fold10 <tibble [1 x 4]> <tibble [0 x 3]>
+       1 <split [164/20]> Fold01 <tibble [1 x 4]> <tibble [0 x 4]>
+       2 <split [165/19]> Fold02 <tibble [1 x 4]> <tibble [0 x 4]>
+       3 <split [165/19]> Fold03 <tibble [1 x 4]> <tibble [0 x 4]>
+       4 <split [166/18]> Fold04 <tibble [1 x 4]> <tibble [0 x 4]>
+       5 <split [166/18]> Fold05 <tibble [1 x 4]> <tibble [0 x 4]>
+       6 <split [166/18]> Fold06 <tibble [1 x 4]> <tibble [0 x 4]>
+       7 <split [166/18]> Fold07 <tibble [1 x 4]> <tibble [0 x 4]>
+       8 <split [166/18]> Fold08 <tibble [1 x 4]> <tibble [0 x 4]>
+       9 <split [166/18]> Fold09 <tibble [1 x 4]> <tibble [0 x 4]>
+      10 <split [166/18]> Fold10 <tibble [1 x 4]> <tibble [0 x 4]>
 
 ---
 

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -49,9 +49,9 @@
       # A tibble: 3 x 5
         splits          id         .metrics         .notes           .extracts       
         <list>          <chr>      <list>           <list>           <list>          
-      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
-      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
-      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 4]> <tibble [1 x 2]>
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 4]> <tibble [1 x 2]>
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [1 x 4]> <tibble [1 x 2]>
       
       There were issues with some computations:
       
@@ -69,9 +69,9 @@
       # A tibble: 3 x 5
         splits          id         .metrics         .notes           .extracts       
         <list>          <chr>      <list>           <list>           <list>          
-      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
-      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
-      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 4]> <tibble [1 x 2]>
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [1 x 4]> <tibble [1 x 2]>
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [1 x 4]> <tibble [1 x 2]>
       
       There were issues with some computations:
       
@@ -89,9 +89,9 @@
       # A tibble: 3 x 5
         splits          id         .metrics         .notes           .extracts       
         <list>          <chr>      <list>           <list>           <list>          
-      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [2 x 3]> <tibble [1 x 2]>
-      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [2 x 3]> <tibble [1 x 2]>
-      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [2 x 3]> <tibble [1 x 2]>
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [2 x 4]> <tibble [1 x 2]>
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [2 x 4]> <tibble [1 x 2]>
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [2 x 4]> <tibble [1 x 2]>
       
       There were issues with some computations:
       
@@ -110,9 +110,9 @@
       # A tibble: 3 x 5
         splits          id         .metrics         .notes           .extracts       
         <list>          <chr>      <list>           <list>           <list>          
-      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 3]> <tibble [1 x 2]>
-      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [0 x 3]> <tibble [1 x 2]>
-      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [0 x 3]> <tibble [1 x 2]>
+      1 <split [32/13]> Bootstrap1 <tibble [2 x 4]> <tibble [1 x 4]> <tibble [1 x 2]>
+      2 <split [32/17]> Bootstrap2 <tibble [2 x 4]> <tibble [0 x 4]> <tibble [1 x 2]>
+      3 <split [32/11]> Bootstrap3 <tibble [2 x 4]> <tibble [0 x 4]> <tibble [1 x 2]>
       
       There were issues with some computations:
       
@@ -125,17 +125,17 @@
     Code
       res_extract_warning$.notes[[1]]
     Output
-      # A tibble: 1 x 3
-        location                               type    note 
-        <chr>                                  <chr>   <chr>
-      1 preprocessor 1/1, model 1/1 (extracts) warning AHHH 
+      # A tibble: 1 x 4
+        location                               type    note  trace              
+        <chr>                                  <chr>   <chr> <list>             
+      1 preprocessor 1/1, model 1/1 (extracts) warning AHHH  <rlng_trc [46 x 5]>
 
 ---
 
     Code
       res_extract_error$.extracts[[1]]$.extracts[[1]]
     Output
-      [1] "Error in extractor(object) : AHHH\n"
+      [1] "Error in extractor(object): AHHH\n"
       attr(,"class")
       [1] "try-error"
       attr(,"condition")
@@ -146,17 +146,17 @@
     Code
       res_extract_error$.notes[[1]]
     Output
-      # A tibble: 1 x 3
-        location                               type  note                            
-        <chr>                                  <chr> <chr>                           
-      1 preprocessor 1/1, model 1/1 (extracts) error Error in extractor(object): AHHH
+      # A tibble: 1 x 4
+        location                               type  note                   trace     
+        <chr>                                  <chr> <chr>                  <list>    
+      1 preprocessor 1/1, model 1/1 (extracts) error Error in extractor(ob~ <rlng_trc>
 
 ---
 
     Code
       res_extract_both$.extracts[[1]]$.extracts[[1]]
     Output
-      [1] "Error in extractor(object) : AHHH\n"
+      [1] "Error in extractor(object): AHHH\n"
       attr(,"class")
       [1] "try-error"
       attr(,"condition")
@@ -167,7 +167,7 @@
     Code
       res_extract_error_once$.extracts[[1]]$.extracts[[1]]
     Output
-      [1] "Error in extractor(object) : oh no\n"
+      [1] "Error in extractor(object): oh no\n"
       attr(,"class")
       [1] "try-error"
       attr(,"condition")

--- a/tests/testthat/_snaps/grid.md
+++ b/tests/testthat/_snaps/grid.md
@@ -66,14 +66,14 @@
       # A tibble: 10 x 4
          splits         id     .metrics         .notes          
          <list>         <chr>  <list>           <list>          
-       1 <split [28/4]> Fold01 <tibble [4 x 5]> <tibble [0 x 3]>
-       2 <split [28/4]> Fold02 <tibble [4 x 5]> <tibble [0 x 3]>
-       3 <split [29/3]> Fold03 <tibble [4 x 5]> <tibble [0 x 3]>
-       4 <split [29/3]> Fold04 <tibble [4 x 5]> <tibble [0 x 3]>
-       5 <split [29/3]> Fold05 <tibble [4 x 5]> <tibble [0 x 3]>
-       6 <split [29/3]> Fold06 <tibble [4 x 5]> <tibble [0 x 3]>
-       7 <split [29/3]> Fold07 <tibble [4 x 5]> <tibble [0 x 3]>
-       8 <split [29/3]> Fold08 <tibble [4 x 5]> <tibble [0 x 3]>
-       9 <split [29/3]> Fold09 <tibble [4 x 5]> <tibble [0 x 3]>
-      10 <split [29/3]> Fold10 <tibble [4 x 5]> <tibble [0 x 3]>
+       1 <split [28/4]> Fold01 <tibble [4 x 5]> <tibble [0 x 4]>
+       2 <split [28/4]> Fold02 <tibble [4 x 5]> <tibble [0 x 4]>
+       3 <split [29/3]> Fold03 <tibble [4 x 5]> <tibble [0 x 4]>
+       4 <split [29/3]> Fold04 <tibble [4 x 5]> <tibble [0 x 4]>
+       5 <split [29/3]> Fold05 <tibble [4 x 5]> <tibble [0 x 4]>
+       6 <split [29/3]> Fold06 <tibble [4 x 5]> <tibble [0 x 4]>
+       7 <split [29/3]> Fold07 <tibble [4 x 5]> <tibble [0 x 4]>
+       8 <split [29/3]> Fold08 <tibble [4 x 5]> <tibble [0 x 4]>
+       9 <split [29/3]> Fold09 <tibble [4 x 5]> <tibble [0 x 4]>
+      10 <split [29/3]> Fold10 <tibble [4 x 5]> <tibble [0 x 4]>
 

--- a/tests/testthat/_snaps/last-fit.md
+++ b/tests/testthat/_snaps/last-fit.md
@@ -28,7 +28,7 @@
       # A tibble: 1 x 6
         splits         id               .metrics         .notes           .predictions     .workflow 
         <list>         <chr>            <list>           <list>           <list>           <list>    
-      1 <split [24/8]> train/test split <tibble [2 x 4]> <tibble [0 x 3]> <tibble [8 x 4]> <workflow>
+      1 <split [24/8]> train/test split <tibble [2 x 4]> <tibble [0 x 4]> <tibble [8 x 4]> <workflow>
 
 # argument order gives errors for recipe/formula
 

--- a/tests/testthat/_snaps/logging.md
+++ b/tests/testthat/_snaps/logging.md
@@ -71,16 +71,16 @@
 # log issues
 
     Code
-      expect_equal(tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_1, bad_only = FALSE),
-      dplyr::bind_rows(note_1, note_2))
+      problems_1 <- tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_1,
+        bad_only = FALSE)
     Message
       x Fold01: toledo: Error in log("a"): non-numeric argument to mathematical function
 
 ---
 
     Code
-      expect_equal(tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_3, bad_only = FALSE),
-      dplyr::bind_rows(note_1, note_3))
+      problems_2 <- tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_3,
+        bad_only = FALSE)
     Message
       ! Fold01: toledo: NaNs produced
 

--- a/tests/testthat/_snaps/resample.md
+++ b/tests/testthat/_snaps/resample.md
@@ -92,8 +92,8 @@
       # A tibble: 2 x 4
         splits          id    .metrics         .notes          
         <list>          <chr> <list>           <list>          
-      1 <split [16/16]> Fold1 <tibble [2 x 4]> <tibble [0 x 3]>
-      2 <split [16/16]> Fold2 <tibble [2 x 4]> <tibble [0 x 3]>
+      1 <split [16/16]> Fold1 <tibble [2 x 4]> <tibble [0 x 4]>
+      2 <split [16/16]> Fold2 <tibble [2 x 4]> <tibble [0 x 4]>
 
 # argument order gives errors for recipe/formula
 
@@ -126,8 +126,8 @@
       # A tibble: 2 x 4
         splits          id    .metrics         .notes          
         <list>          <chr> <list>           <list>          
-      1 <split [16/16]> Fold1 <tibble [2 x 4]> <tibble [0 x 3]>
-      2 <split [16/16]> Fold2 <tibble [2 x 4]> <tibble [0 x 3]>
+      1 <split [16/16]> Fold1 <tibble [2 x 4]> <tibble [0 x 4]>
+      2 <split [16/16]> Fold2 <tibble [2 x 4]> <tibble [0 x 4]>
 
 # `fit_resamples()` when objects need tuning
 

--- a/tests/testthat/test-collect.R
+++ b/tests/testthat/test-collect.R
@@ -178,7 +178,7 @@ test_that("collecting notes - fit_resamples", {
   nts <- collect_notes(lm_splines)
   expect_true(all(nts$type == "warning"))
   expect_true(all(grepl("rank", nts$note)))
-  expect_equal(names(nts), c("id", "location", "type", "note"))
+  expect_equal(names(nts), c("id", "location", "type", "note", "trace"))
 })
 
 test_that("collecting notes - last_fit", {
@@ -201,7 +201,7 @@ test_that("collecting notes - last_fit", {
   nts <- collect_notes(lst)
   expect_true(all(nts$type == "warning"))
   expect_true(all(grepl("rank", nts$note)))
-  expect_equal(names(nts), c("location", "type", "note"))
+  expect_equal(names(nts), c("location", "type", "note", "trace"))
 })
 
 test_that("`collect_notes()` errors informatively applied to unsupported class", {

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -38,21 +38,33 @@ test_that("log issues", {
   note_2 <- tibble::tibble(location = "toledo", type = "error", note = "Error in log(\"a\"): non-numeric argument to mathematical function")
 
   expect_snapshot(
-    expect_equal(
-      tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_1, bad_only = FALSE),
-      dplyr::bind_rows(note_1, note_2)
-    )
+    problems_1 <-
+      tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_1, bad_only = FALSE)
   )
+
+  expect_equal(
+    dplyr::select(problems_1, -trace),
+    dplyr::bind_rows(note_1, note_2)
+  )
+
+  expect_null(problems_1$trace[[1]])
+  expect_s3_class(problems_1$trace[[2]], "rlang_trace")
 
   expect_silent(tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_2, bad_only = FALSE))
 
   note_3 <- tibble::tibble(location = "toledo", type = "warning", note = "NaNs produced")
   expect_snapshot(
-    expect_equal(
-      tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_3, bad_only = FALSE),
-      dplyr::bind_rows(note_1, note_3)
-    )
+    problems_2 <-
+      tune:::log_problems(note_1, ctrl_f, rs, "toledo", res_3, bad_only = FALSE)
   )
+
+  expect_equal(
+    dplyr::select(problems_2, -trace),
+    dplyr::bind_rows(note_1, note_3)
+  )
+
+  expect_null(problems_2$trace[[1]])
+  expect_s3_class(problems_2$trace[[2]], "rlang_trace")
 })
 
 


### PR DESCRIPTION
Was too excited to wait until Monday to finish this PR.😝 

This PR aims to provide a better entry point to debugging tuning issues. Closes #873, but takes a slightly different approach than what's recommended there. Instead of surfacing one additional error context header (i.e. `Error in log(): ...`), this PR proposes attaching a traceback to errors and warnings and then logging it in the `notes` column. The example from that issue:

``` r
# Create sample data
library(tidymodels)

set.seed(123)
num_samples <- 100
outcome <- rnorm(num_samples, mean = 50, sd = 10)
categorical_predictor <- as.factor(sample(letters[1:4], num_samples, replace = TRUE))

# Create dataframe
df <- data.frame(
  Outcome = outcome,
  Categorical_Predictor = categorical_predictor
)

new_row <- data.frame(
  Outcome = 55,
  Categorical_Predictor = "problem"
)

# Add the new row to the dataframe
df <- rbind(new_row, df)

lr_full_preprocessing <- 
  recipe(Outcome ~ ., data = df) %>%
  # novel categories
  step_novel(all_nominal_predictors())

lr_full <- linear_reg() %>%
  set_engine("lm")

lr_full_wf <- workflow() %>%
  add_recipe(lr_full_preprocessing, blueprint = hardhat::default_recipe_blueprint(allow_novel_levels = FALSE)) %>%
  add_model(lr_full)

set.seed(123)  # for reproducibility
folds <- vfold_cv(df, v = 2, repeats = 1)

lr_full_fit_rs <- lr_full_wf %>% 
  fit_resamples(folds)
#> → A | error:   factor Categorical_Predictor has new levels new
#> There were issues with some computations   A: x1
#> There were issues with some computations   A: x1
#> 

collect_notes(lr_full_fit_rs)
#> # A tibble: 1 × 5
#>   id    location                                  type  note          trace     
#>   <chr> <chr>                                     <chr> <chr>         <list>    
#> 1 Fold1 preprocessor 1/1, model 1/1 (predictions) error factor Categ… <rlng_trc>

collect_notes(lr_full_fit_rs)$trace[[1]]
#>      ▆
#>   1. ├─lr_full_wf %>% fit_resamples(folds)
#>   2. ├─tune::fit_resamples(., folds)
#>   3. ├─tune:::fit_resamples.workflow(., folds)
#>   4. │ └─tune:::resample_workflow(...)
#>   5. │   └─tune:::tune_grid_workflow(...)
#>   6. │     └─tune:::tune_grid_loop(...)
#>   7. │       └─tune (local) fn_tune_grid_loop(...)
#>   8. │         └─tune:::tune_grid_loop_impl(...)
#>   9. │           └─rlang::with_env(...)
#>  10. ├─base::suppressPackageStartupMessages(...)
#>  11. │ └─base::withCallingHandlers(expr, packageStartupMessage = function(c) tryInvokeRestart("muffleMessage"))
#>  12. ├─for_each %op% ...
#>  13. │ └─e$fun(obj, substitute(ex), parent.frame(), e$data)
#>  14. │   ├─base::tryCatch(...)
#>  15. │   │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
#>  16. │   │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>  17. │   │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
#>  18. │   ├─base::tryCatch(eval(xpr, envir = envir), error = function(e) e)
#>  19. │   │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
#>  20. │   │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>  21. │   │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
#>  22. │   └─base::eval(xpr, envir = envir)
#>  23. │     └─base::eval(xpr, envir = envir)
#>  24. │       └─tune (local) fn_tune_grid_loop_iter_safely(...)
#>  25. │         └─tune (local) fn_tune_grid_loop_iter_wrapper(...)
#>  26. │           ├─base::withCallingHandlers(...)
#>  27. │           ├─base::tryCatch(...)
#>  28. │           │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
#>  29. │           │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>  30. │           │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
#>  31. │           └─tune (local) fn(...)
#>  32. │             ├─tune::.catch_and_log(...)
#>  33. │             │ └─tune:::catcher(.expr)
#>  34. │             │   └─rlang::try_fetch(...)
#>  35. │             │     ├─base::tryCatch(...)
#>  36. │             │     │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
#>  37. │             │     │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>  38. │             │     │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
#>  39. │             │     └─base::withCallingHandlers(...)
#>  40. │             └─tune:::predict_model(...)
#>  41. │               └─tune:::predict_wrapper(model, x_vals, type_iter, eval_time)
#>  42. │                 └─rlang::eval_tidy(cl)
#>  43. ├─parsnip::predict.model_fit(...)
#>  44. │ ├─parsnip::predict_numeric(...)
#>  45. │ └─parsnip::predict_numeric.model_fit(...)
#>  46. │   └─rlang::eval_tidy(pred_call)
#>  47. ├─stats::predict(...)
#>  48. ├─stats::predict.lm(...)
#>  49. │ ├─stats::model.frame(Terms, newdata, na.action = na.action, xlev = object$xlevels)
#>  50. │ └─stats::model.frame.default(...)
#>  51. │   └─base::stop(...)
#>  52. └─base::.handleSimpleError(...)
#>  53.   └─rlang (local) h(simpleError(msg, call))
```

<sup>Created on 2024-03-23 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

This is likely more aimed at advanced users (and developers), but I think will be a gamechanger for quickly `debug()`ging into the right functions or spotting the right bit of context that tips me off to what the actual issue is.