### PR TITLE
emphasize test object updates in release issue

### DIFF
--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -55,7 +55,7 @@ utils::globalVariables(
 
 release_bullets <- function() {
   c(
-    "Update dependencies with `devtools::install_dev_deps()` and update the test objects via `R CMD BATCH --vanilla inst/test_objects.R`.",
+    "**Do this before checks!**. Update dependencies with `devtools::install_dev_deps()` and update the test objects via `R CMD BATCH --vanilla inst/test_objects.R`.",
     "Confirm issue cataloger gives expected output in `inst/test_catalog.R`."
   )
 }


### PR DESCRIPTION
Looks like the ordering is [hard-coded](https://github.com/r-lib/usethis/blob/9e64daf13ac1636187d59e6446d9526a414d8ba6/R/release.R#L127) is usethis. An alternative could be to try and draw attention to this entry visually? Closes #877.