### PR TITLE
fix `int_pctl.tune_results()` with PSOCK

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* Addressed issue in `int_pctl()` where the function would error when parallelized using `makePSOCKcluster()` (#885).
+
 * The package will now warn when parallel processing has been enabled with foreach but not with future. See [`?parallelism`](https://tune.tidymodels.org/dev/reference/parallelism.html) to learn more about transitioning your code to future (#878, #866).
 
 * The package will now log a backtrace for errors and warnings that

--- a/R/int_pctl.R
+++ b/R/int_pctl.R
@@ -171,7 +171,13 @@ boostrap_metrics_by_config <- function(config, seed, x, metrics, times, allow_pa
 
   rs$.metrics <-
     for_each %op% {
-      comp_metrics(rs$splits[[i]], y_nm, metrics, event_level, metrics_info)
+      asNamespace("tune")$comp_metrics(
+        rs$splits[[i]],
+        y_nm,
+        metrics,
+        event_level,
+        metrics_info
+      )
     }
   if (any(grepl("survival", .get_tune_metric_names(x)))) {
     # compute by evaluation time


### PR DESCRIPTION
Closes #885 using [a trick](https://github.com/tidymodels/stacks/blob/f95369f45353d09a8c81fd3592ebcf8bc8232d6b/R/fit_members.R#L138) that @topepo showed me some years back to work around this PSOCK/foreach oddity. With this PR:

``` r
library(tidymodels)

set.seed(991)
delivery_split <- initial_validation_split(deliveries, prop = c(0.6, 0.2), 
                                           strata = time_to_delivery)
delivery_rs <- validation_set(delivery_split)

lm_res <- 
  linear_reg() %>% 
  fit_resamples(
    time_to_delivery ~ .,
    resamples = delivery_rs,
    control = control_resamples(save_pred = TRUE)
  )

res_seq <- int_pctl(lm_res)

library(doMC)
#> Loading required package: foreach
#> 
#> Attaching package: 'foreach'
#> The following objects are masked from 'package:purrr':
#> 
#>     accumulate, when
#> Loading required package: iterators
#> Loading required package: parallel

registerDoMC(cores = 5)

res_mc <- int_pctl(lm_res)
#> Warning: ! tune detected a parallel backend registered with foreach but no backend
#>   registered with future.
#> ℹ Support for parallel processing with foreach was soft-deprecated in tune
#>   1.2.1.
#> ℹ See ?parallelism (`?tune::parallelism()`) to learn more.

library(doParallel)
cl <- makePSOCKcluster(parallel::detectCores(logical = FALSE))
registerDoParallel(cl)

res_psoc <- int_pctl(lm_res)
#> Warning: ! tune detected a parallel backend registered with foreach but no backend
#>   registered with future.
#> ℹ Support for parallel processing with foreach was soft-deprecated in tune
#>   1.2.1.
#> ℹ See ?parallelism (`?tune::parallelism()`) to learn more.

res_psoc
#> # A tibble: 2 × 6
#>   .metric .estimator .lower .estimate .upper .config             
#>   <chr>   <chr>       <dbl>     <dbl>  <dbl> <chr>               
#> 1 rmse    bootstrap   3.59      3.76   3.96  Preprocessor1_Model1
#> 2 rsq     bootstrap   0.689     0.713  0.735 Preprocessor1_Model1
```

<sup>Created on 2024-04-17 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

Since we've discussed writing out the internal `comp_metrics()` function before—and since it's named so similarly to `compute_metrics()`—this seems preferable to me to newly exporting it.