### PR TITLE
fix error with `plan(multisession)` when `parallel_over = "everything"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* Addressed issue where tuning functions would raise the error `object 'iteration' not found` with `plan(multisession)` and the control option `parallel_over = "everything"` (#888).
+
 * The package will now warn when parallel processing has been enabled with foreach but not with future. See [`?parallelism`](https://tune.tidymodels.org/dev/reference/parallelism.html) to learn more about transitioning your code to future (#878, #866).
 
 * The package will now log a backtrace for errors and warnings that

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -225,6 +225,8 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
 
     seeds <- generate_seeds(rng, n_splits * n_grid_info)
 
+    slice_seeds <- slice_seeds
+
     # Evaluate the call to foreach in a local environment using a clone of
     # the current environment so that foreach doesn't touch the exit
     # handlers attached to the execution environment of this function
@@ -243,7 +245,6 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
           foreach::foreach(
             row = rows,
             .combine = iter_combine,
-            seed = slice_seeds(seeds, iteration, n_grid_info),
             .options.future = list(seed = NULL, packages = packages)
           )
       } else {
@@ -257,7 +258,6 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
           foreach::foreach(
             row = rows,
             .combine = iter_combine,
-            seed = slice_seeds(seeds, iteration, n_grid_info),
             .packages = packages,
             .errorhandling = "pass"
           )
@@ -266,6 +266,7 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
       suppressPackageStartupMessages(
         for_each %op% {
             grid_info_row <- vctrs::vec_slice(grid_info, row)
+            seed <- slice_seeds(seeds, iteration, n_grid_info)[[1]]
 
             # Likely want to debug with `debugonce(tune_grid_loop_iter)`
             fn_tune_grid_loop_iter_safely(

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -225,6 +225,9 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
 
     seeds <- generate_seeds(rng, n_splits * n_grid_info)
 
+    # Make `slice_seeds` available in the environment that foreach will
+    # search for it in; resolves issue with PSOCK/multisession parallelism
+    # (#888, #889).
     slice_seeds <- slice_seeds
 
     # Evaluate the call to foreach in a local environment using a clone of


### PR DESCRIPTION
Closes #888. Opening as draft because _I do not like it_ but for some reason, with `plan(multisession)` in this context, foreach/doFuture is unable to find counters defined in the outer loop from the inner loop. Will come back to this in a few hours.