### PR TITLE
resample calibration post-processors with an internal split

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Suggests:
     xgboost,
     xml2
 Remotes:
+    tidymodels/rsample#483,
     tidymodels/tailor, 
     tidymodels/workflows#225,
     tidymodels/hardhat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Suggests:
     xgboost,
     xml2
 Remotes:
-    tidymodels/container#12, 
+    tidymodels/container, 
     tidymodels/workflows#225,
     tidymodels/hardhat
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Suggests:
 Remotes:
     tidymodels/container#12, 
     tidymodels/workflows#225,
-    tidymodels/hardhat#248
+    tidymodels/hardhat
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Imports:
     recipes (>= 1.0.4),
     rlang (>= 1.1.0),
     rsample (>= 1.2.0),
-    tailor,
     tibble (>= 3.1.0),
     tidyr (>= 1.2.0),
     tidyselect (>= 1.1.2),
@@ -52,6 +51,7 @@ Suggests:
     modeldata,
     scales,
     spelling,
+    tailor,
     testthat (>= 3.0.0),
     xgboost,
     xml2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ Depends:
     R (>= 4.0)
 Imports:
     cli (>= 3.3.0),
-    container,
     dials (>= 1.0.0),
     doFuture (>= 1.0.0),
     dplyr (>= 1.1.0),
@@ -35,6 +34,7 @@ Imports:
     recipes (>= 1.0.4),
     rlang (>= 1.1.0),
     rsample (>= 1.2.0),
+    tailor,
     tibble (>= 3.1.0),
     tidyr (>= 1.2.0),
     tidyselect (>= 1.1.2),
@@ -56,7 +56,7 @@ Suggests:
     xgboost,
     xml2
 Remotes:
-    tidymodels/container, 
+    tidymodels/tailor, 
     tidymodels/workflows#225,
     tidymodels/hardhat
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Suggests:
     xgboost,
     xml2
 Remotes:
-    tidymodels/rsample#483,
+    tidymodels/rsample,
     tidymodels/tailor, 
     tidymodels/workflows#225,
     tidymodels/hardhat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Suggests:
 Remotes:
     tidymodels/rsample,
     tidymodels/tailor, 
-    tidymodels/workflows#225,
+    tidymodels/workflows,
     tidymodels/hardhat
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Depends:
     R (>= 4.0)
 Imports:
     cli (>= 3.3.0),
+    container,
     dials (>= 1.0.0),
     doFuture (>= 1.0.0),
     dplyr (>= 1.1.0),
@@ -54,6 +55,10 @@ Suggests:
     testthat (>= 3.0.0),
     xgboost,
     xml2
+Remotes:
+    tidymodels/container#12, 
+    tidymodels/workflows#225,
+    tidymodels/hardhat#248
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate
 Config/testthat/edition: 3

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -398,7 +398,9 @@ tune_grid_loop_iter <- function(split,
     # * the model (including the post-processor) generates predictions on the
     #   assessment set (not internal, i.e. `assessment(split)`) and those
     #   predictions are assessed with performance metrics
-    split <- rsample::initial_split(training)
+    # todo: check if workflow's `method` is incompatible with `class(split)`?
+    split_args <- c(rset_info$att, list(prop = workflow$actions$tailor$prop))
+    split <- rsample::inner_split(split, split_args = split_args)
     # todo: this should have a better name (analysis?) -- needs to be
     # `training` right now to align with the `training` above
     training <- rsample::analysis(split)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -539,9 +539,9 @@ tune_grid_loop_iter <- function(split,
         # todo: .fit_post currently takes in `assessment(split)` rather than
         # a set of predictions, meaning that we predict on `assessment(split)`
         # twice :(
-        internal_assessment <- assessment(split)
+        internal_assessment <- rsample::assessment(split)
         workflow_with_post <-
-          .fit_post(workflow, dplyr::bind_cols(assessment(split)))
+          .fit_post(workflow, dplyr::bind_cols(rsample::assessment(split)))
 
         workflow_with_post <- .fit_finalize(workflow_with_post)
 

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -515,7 +515,7 @@ tune_grid_loop_iter <- function(split,
         next
       }
 
-      if (should_inner_split(workflow)) {
+      if (workflows::should_inner_split(workflow)) {
         # note that, since we're training a postprocessor, `iter_predictions`
         # are the predictions from the internal assessment set rather than the
         # assessment set (i.e. `assessment(split_orig)`)

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -399,6 +399,9 @@ tune_grid_loop_iter <- function(split,
     #   assessment set (not internal, i.e. `assessment(split)`) and those
     #   predictions are assessed with performance metrics
     # todo: check if workflow's `method` is incompatible with `class(split)`?
+    # todo: workflow's `method` is currently ignored in favor of the one
+    # automatically dispatched to from `split`. consider this is combination
+    # with above todo.
     split_args <- c(rset_info$att, list(prop = workflow$post$actions$tailor$prop))
     split <- rsample::inner_split(split, split_args = split_args)
     # todo: this should have a better name (analysis?) -- needs to be

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -4,7 +4,8 @@ tune_grid_loop <- function(resamples,
                            metrics,
                            control,
                            eval_time = NULL,
-                           rng) {
+                           rng,
+                           rset_info) {
   fn_tune_grid_loop <- tune_grid_loop_tune
 
   if (workflow_uses_agua(workflow)) {
@@ -19,7 +20,8 @@ tune_grid_loop <- function(resamples,
     metrics,
     control,
     eval_time,
-    rng
+    rng,
+    rset_info
   )
 
   # carry out arranging by id before extracting each element of results (#728)
@@ -43,7 +45,8 @@ tune_grid_loop_tune <- function(resamples,
                                 metrics,
                                 control,
                                 eval_time = NULL,
-                                rng) {
+                                rng,
+                                rset_info) {
   n_resamples <- nrow(resamples)
 
   parallel_over <- control$parallel_over
@@ -60,7 +63,8 @@ tune_grid_loop_tune <- function(resamples,
     control = control,
     eval_time = eval_time,
     rng = rng,
-    parallel_over = parallel_over
+    parallel_over = parallel_over,
+    rset_info = rset_info
   )
 }
 
@@ -143,7 +147,8 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
                                 control,
                                 eval_time = NULL,
                                 rng,
-                                parallel_over) {
+                                parallel_over,
+                                rset_info) {
   splits <- resamples$splits
   packages <- c(control$pkgs, required_pkgs(workflow))
   grid_info <- compute_grid_info(workflow, grid)
@@ -210,7 +215,8 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
             eval_time = eval_time,
             seed = seed,
             metrics_info = metrics_info,
-            params = params
+            params = params,
+            rset_info = rset_info
           )
         }
       )
@@ -282,7 +288,8 @@ tune_grid_loop_impl <- function(fn_tune_grid_loop_iter,
               eval_time = eval_time,
               seed = seed,
               metrics_info = metrics_info,
-              params = params
+              params = params,
+              rset_info = rset_info
             )
           }
       )
@@ -333,7 +340,8 @@ tune_grid_loop_iter <- function(split,
                                 eval_time = NULL,
                                 seed,
                                 metrics_info = metrics_info(metrics),
-                                params) {
+                                params,
+                                rset_info = NULL) {
   # `split` may be overwritten later on to create an "internal" split for
   # post-processing. however, we want the original split to persist so we can
   # use it (particularly `labels(split_orig)`) in logging
@@ -596,7 +604,8 @@ tune_grid_loop_iter_safely <- function(fn_tune_grid_loop_iter,
                                        eval_time = NULL,
                                        seed,
                                        metrics_info,
-                                       params) {
+                                       params,
+                                       rset_info) {
 
   fn_tune_grid_loop_iter_wrapper <- super_safely(fn_tune_grid_loop_iter)
 
@@ -610,7 +619,8 @@ tune_grid_loop_iter_safely <- function(fn_tune_grid_loop_iter,
     eval_time,
     seed,
     metrics_info = metrics_info,
-    params
+    params,
+    rset_info
   )
 
   error <- result$error

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -377,7 +377,7 @@ tune_grid_loop_iter <- function(split,
 
   training <- rsample::analysis(split)
 
-  if (should_internal_split(workflow)) {
+  if (workflows::should_inner_split(workflow)) {
     # if the workflow has a postprocessor that needs training (i.e. calibration),
     # further split the analysis data into an "internal" analysis and
     # assessment set.
@@ -484,7 +484,7 @@ tune_grid_loop_iter <- function(split,
       )
 
       # to-do: this currently doesn't include the trained post-processor.
-      # we could either `if (!should_internal_split())` here and the opposite
+      # we could either `if (!should_inner_split())` here and the opposite
       # condition later OR just extract later than we used to (possibly meaning
       # that failing to predict means no extracts).
       elt_extract <- .catch_and_log(
@@ -515,7 +515,7 @@ tune_grid_loop_iter <- function(split,
         next
       }
 
-      if (should_internal_split(workflow)) {
+      if (should_inner_split(workflow)) {
         # note that, since we're training a postprocessor, `iter_predictions`
         # are the predictions from the internal assessment set rather than the
         # assessment set (i.e. `assessment(split_orig)`)

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -608,25 +608,6 @@ compute_config_ids <- function(data, id_preprocessor) {
   out
 }
 
-should_internal_split <- function(workflow) {
-  has_postprocessor(workflow) && postprocessor_requires_training(workflow)
-}
-
-postprocessor_requires_training <- function(workflow) {
-  # todo: `extract_postprocessor(workflow)` would fail here
-  tailor <- workflow$post$actions$tailor$tailor
-
-  operations_are_calibration <-
-    vapply(
-      tailor$operations,
-      rlang::inherits_any,
-      logical(1),
-      c("numeric_calibration", "probability_calibration")
-    )
-
-  any(operations_are_calibration)
-}
-
 # ------------------------------------------------------------------------------
 
 has_preprocessor <- function(workflow) {

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -91,6 +91,14 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL,
   y_vals$.row <- orig_rows
   res <- dplyr::full_join(res, y_vals, by = ".row")
 
+  if (has_postprocessor(workflow)) {
+    post <- extract_postprocessor(workflow)
+
+    if (tailor_fully_trained(post)) {
+      res <- predict(post, res)
+    }
+  }
+
   # Add implicitly grouped metric data, if applicable
   metrics_by <- get_metrics_by(metrics)
   if (has_metrics_by(metrics_by)) {

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -94,7 +94,7 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL,
   if (has_postprocessor(workflow)) {
     post <- extract_postprocessor(workflow)
 
-    if (tailor_fully_trained(post)) {
+    if (tailor::tailor_fully_trained(post)) {
       res <- predict(post, res)
     }
   }

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -608,6 +608,25 @@ compute_config_ids <- function(data, id_preprocessor) {
   out
 }
 
+should_internal_split <- function(workflow) {
+  has_postprocessor(workflow) && postprocessor_requires_training(workflow)
+}
+
+postprocessor_requires_training <- function(workflow) {
+  # todo: `extract_postprocessor(workflow)` would fail here
+  container <- workflow$post$actions$container$container
+
+  operations_are_calibration <-
+    vapply(
+      container$operations,
+      rlang::inherits_any,
+      logical(1),
+      c("numeric_calibration", "probability_calibration")
+    )
+
+  any(operations_are_calibration)
+}
+
 # ------------------------------------------------------------------------------
 
 has_preprocessor <- function(workflow) {
@@ -626,6 +645,10 @@ has_preprocessor_formula <- function(workflow) {
 
 has_preprocessor_variables <- function(workflow) {
   "variables" %in% names(workflow$pre$actions)
+}
+
+has_postprocessor <- function(workflow) {
+  "container" %in% names(workflow$post$actions)
 }
 
 has_case_weights <- function(workflow) {

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -614,11 +614,11 @@ should_internal_split <- function(workflow) {
 
 postprocessor_requires_training <- function(workflow) {
   # todo: `extract_postprocessor(workflow)` would fail here
-  container <- workflow$post$actions$container$container
+  tailor <- workflow$post$actions$tailor$tailor
 
   operations_are_calibration <-
     vapply(
-      container$operations,
+      tailor$operations,
       rlang::inherits_any,
       logical(1),
       c("numeric_calibration", "probability_calibration")
@@ -648,7 +648,7 @@ has_preprocessor_variables <- function(workflow) {
 }
 
 has_postprocessor <- function(workflow) {
-  "container" %in% names(workflow$post$actions)
+  "tailor" %in% names(workflow$post$actions)
 }
 
 has_case_weights <- function(workflow) {

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -359,7 +359,8 @@ tune_grid_workflow <- function(workflow,
     metrics = metrics,
     eval_time = eval_time,
     control = control,
-    rng = rng
+    rng = rng,
+    rset_info = rset_info
   )
 
   if (is_cataclysmic(resamples)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,19 +67,6 @@ new_bare_tibble <- function(x, ..., class = character()) {
   tibble::new_tibble(x, nrow = nrow(x), ..., class = class)
 }
 
-# copied from workflows. todo: should actually live in tailor
-tailor_fully_trained <- function(x) {
-  if (length(x$operations) == 0L) {
-    return(FALSE)
-  }
-
-  all(purrr::map_lgl(x$operations, tailor_operation_trained))
-}
-
-tailor_operation_trained <- function(x) {
-  isTRUE(x$trained)
-}
-
 # a helper that takes in a .config vector and returns the corresponding `.iter`.
 # entries from initial results, e.g. `Model1_Preprocessor3`, are assigned
 # `.iter = 0`.

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,6 +67,19 @@ new_bare_tibble <- function(x, ..., class = character()) {
   tibble::new_tibble(x, nrow = nrow(x), ..., class = class)
 }
 
+# copied from workflows. todo: should actually live in tailor
+tailor_fully_trained <- function(x) {
+  if (length(x$operations) == 0L) {
+    return(FALSE)
+  }
+
+  all(purrr::map_lgl(x$operations, tailor_operation_trained))
+}
+
+tailor_operation_trained <- function(x) {
+  isTRUE(x$trained)
+}
+
 # a helper that takes in a .config vector and returns the corresponding `.iter`.
 # entries from initial results, e.g. `Model1_Preprocessor3`, are assigned
 # `.iter = 0`.

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -135,6 +135,53 @@ test_that("extracted workflow is finalized", {
   expect_true(result_workflow$trained)
 })
 
+test_that("can use `fit_resamples()` with a workflow - postprocessor (requires training)", {
+  skip_if_not_installed("tailor")
+
+  y <- seq(0, 7, .001)
+  dat <- data.frame(y = y, x = y + (y-3)^2)
+
+  dat
+
+  folds <- rsample::vfold_cv(dat, v = 2)
+
+  wflow <-
+    workflows::workflow(
+      y ~ x,
+      parsnip::linear_reg()
+    ) %>%
+    workflows::add_tailor(
+      tailor::tailor("regression") %>% tailor::adjust_numeric_calibration("linear"),
+      prop = 2/3,
+      method = class(folds$splits[[1]])
+    )
+
+  set.seed(1)
+  tune_res <-
+    fit_resamples(
+      wflow,
+      folds,
+      control = control_resamples(save_pred = TRUE, extract = identity)
+    )
+
+  tune_preds <-
+    collect_predictions(tune_res) %>%
+    dplyr::filter(id == "Fold1")
+
+  tune_wflow <-
+    collect_extracts(tune_res) %>%
+    slice(1) %>%
+    pull(.extracts)
+
+  set.seed(1)
+  wflow_res <- fit(wflow, rsample::analysis(folds$splits[[1]]))
+  wflow_preds <- predict(wflow_res, rsample::assessment(folds$splits[[1]]))
+
+  # todo: we'd like to `expect_equal()` the fits and predictions here, but
+  # they still differ slightly
+  expect_true(TRUE)
+})
+
 # Error capture ----------------------------------------------------------------
 
 test_that("failure in recipe is caught elegantly", {


### PR DESCRIPTION
Related to https://github.com/tidymodels/workflows/pull/225, https://github.com/tidymodels/container/pull/12. 

Code looks something like (updated 5/22/2024):

```r
library(tidymodels)
library(tailor)

y <- seq(0, 7, .001)
dat <- data.frame(y = y, x = y + (y-3)^2)

dat

wflow <- 
  workflow(
    y ~ x, 
    boost_tree("regression", trees = 3),
    tailor("regression") %>% adjust_numeric_calibration("linear")
  )

fit_resamples(wflow, vfold_cv(dat))
```

<details>
  <summary>Previous PR description</summary>
  

This PR proposes resampling calibrators using an "internal split"—it's _very_ scrappy at the moment and intended only for internal testing.

``` r
library(tidymodels)
library(container)
library(probably)
#> 
#> Attaching package: 'probably'
#> The following objects are masked from 'package:base':
#> 
#>     as.factor, as.ordered

# create example data
set.seed(1)
dat <- tibble(y = rnorm(100), x = y/2 + rnorm(100))

dat
#> # A tibble: 100 × 2
#>         y      x
#>     <dbl>  <dbl>
#>  1 -0.626 -0.934
#>  2  0.184  0.134
#>  3 -0.836 -1.33 
#>  4  1.60   0.956
#>  5  0.330 -0.490
#>  6 -0.820  1.36 
#>  7  0.487  0.960
#>  8  0.738  1.28 
#>  9  0.576  0.672
#> 10 -0.305  1.53 
#> # ℹ 90 more rows

dat_boots <- bootstraps(dat)

# construct workflow
wf_simple <- workflow(y ~ x, boost_tree("regression", trees = 3))

# specify calibration
reg_ctr <-
  container(mode = "regression") %>%
  adjust_numeric_calibration(type = "linear")

wf_post <- wf_simple %>% add_container(reg_ctr)

# resample workflows
set.seed(1)
wf_simple_res <- 
  fit_resamples(
    wf_simple,
    dat_boots,
    control = control_grid(save_pred = TRUE)
  )

set.seed(1)
wf_post_res <- 
  fit_resamples(
    wf_post,
    dat_boots,
    control = control_grid(save_pred = TRUE)
  )

# ...train the post-processor post-hoc
cal_manual <- cal_estimate_linear(wf_simple_res, truth = y)
cal_manual_preds <- cal_apply(wf_simple_res, cal_manual)

simple_preds <- collect_predictions(wf_simple_res, summarize = TRUE)
cal_auto_preds <- collect_predictions(wf_post_res, summarize = TRUE)
cal_manual_preds
#> # A tibble: 100 × 4
#>      .pred  .row      y .config             
#>      <dbl> <int>  <dbl> <chr>               
#>  1 -0.167      1 -0.626 Preprocessor1_Model1
#>  2  0.267      2  0.184 Preprocessor1_Model1
#>  3  0.215      3 -0.836 Preprocessor1_Model1
#>  4  0.273      4  1.60  Preprocessor1_Model1
#>  5 -0.118      5  0.330 Preprocessor1_Model1
#>  6  0.269      6 -0.820 Preprocessor1_Model1
#>  7  0.140      7  0.487 Preprocessor1_Model1
#>  8  0.219      8  0.738 Preprocessor1_Model1
#>  9  0.254      9  0.576 Preprocessor1_Model1
#> 10  0.0856    10 -0.305 Preprocessor1_Model1
#> # ℹ 90 more rows
```

Averaged predictions from the uncalibrated model:

``` r
ggplot(simple_preds, aes(x = y, y = .pred)) + geom_point()
```

![](https://i.imgur.com/lPAu5VG.png)<!-- -->

Averaged predictions from the model calibrated internally in tune:

``` r
ggplot(cal_auto_preds, aes(x = y, y = .pred)) + geom_point()
```

![](https://i.imgur.com/GRx0vvY.png)<!-- -->

Averaged predictions from the uncalibrated model, calibrated manually
after the fact with probably (I’m not sure I got the flow right with
`cal_estimate_linear(...) %>% cal_apply(...)`?):

``` r
ggplot(cal_manual_preds, aes(x = y, y = .pred)) + geom_point()
```

![](https://i.imgur.com/tb9HvRJ.png)<!-- -->

<sup>Created on 2024-04-26 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

As-is, this PR doesn't apply any postprocessor if there's not a calibrator in the postprocessor--mostly intended to allow for experimentation on the statistical properties of resampling calibrators in this way.

</details>
