### PR TITLE
Error early on permutation samples

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -16,6 +16,9 @@ check_rset <- function(x) {
   if (inherits(x, "nested_cv")) {
     rlang::abort("Nested resampling is not currently supported with tune.")
   }
+  if (inherits(x, "permutations")) {
+    rlang::abort("Permutation samples are not suitable for tuning.")
+  }
   invisible(NULL)
 }
 

--- a/tests/testthat/_snaps/checks.md
+++ b/tests/testthat/_snaps/checks.md
@@ -14,6 +14,14 @@
       Error in `tune:::check_rset()`:
       ! Nested resampling is not currently supported with tune.
 
+---
+
+    Code
+      tune:::check_rset(obj_permut)
+    Condition
+      Error in `tune:::check_rset()`:
+      ! Permutation samples are not suitable for tuning.
+
 # grid objects
 
     Code

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -2,9 +2,11 @@ test_that("rsample objects", {
   obj_cv <- rsample::vfold_cv(mtcars)
   obj_loo <- rsample::loo_cv(mtcars)
   obj_nst <- rsample::nested_cv(mtcars, obj_cv, inside = rsample::bootstraps())
+  obj_permut <- rsample::permutations(mtcars, hp)
   expect_error(tune:::check_rset(obj_cv), regexp = NA)
   expect_snapshot(error = TRUE, tune:::check_rset(obj_loo))
   expect_snapshot(error = TRUE, tune:::check_rset(obj_nst))
+  expect_snapshot(error = TRUE, tune:::check_rset(obj_permut))
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
closes #895 

``` r
library(tidymodels)

rs <- permutations(mtcars, hp, times = 2)

workflow(mpg ~ ., linear_reg(penalty = tune(), engine = "glmnet")) %>% 
  tune_grid(rs, grid = 5)
#> Error in `check_rset()`:
#> ! Permutation samples are not suitable for tuning.
```

<sup>Created on 2024-05-20 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>