### PR TITLE
pass `labels(split)` rather than `split` to internal functions

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -175,7 +175,7 @@ check_parameters <- function(wflow, pset = NULL, data, grid_names = character(0)
       msg <- paste0(msg, "s: ", paste0("'", unk_names, "'", collapse = ", "))
     }
 
-    tune_log(list(verbose = TRUE), split = NULL, msg, type = "info")
+    tune_log(list(verbose = TRUE), split_labels = NULL, msg, type = "info")
 
     x <- workflows::.fit_pre(wflow, data)$pre$mold$predictors
     pset$object <- purrr::map(pset$object, dials::finalize, x = x)
@@ -409,11 +409,11 @@ bayes_msg <- "`initial` should be a positive integer or the results of [tune_gri
 #' @param wflow A `workflow` object.
 #' @param resamples An `rset` object.
 #' @param ctrl A `control_grid` object.
-check_initial <- function(x, 
-                          pset, 
-                          wflow, 
+check_initial <- function(x,
+                          pset,
+                          wflow,
                           resamples,
-                          metrics, 
+                          metrics,
                           eval_time,
                           ctrl,
                           checks = "grid") {
@@ -425,7 +425,7 @@ check_initial <- function(x,
     if (ctrl$verbose) {
       message()
       msg <- paste0(" Generating a set of ", nrow(x), " initial parameter results")
-      tune_log(ctrl, split = NULL, msg, type = "go")
+      tune_log(ctrl, split_labels = NULL, msg, type = "go")
     }
 
     grid_ctrl <- ctrl
@@ -441,7 +441,7 @@ check_initial <- function(x,
     )
 
     if (ctrl$verbose) {
-      tune_log(ctrl, split = NULL, "Initialization complete", type = "success")
+      tune_log(ctrl, split_labels = NULL, "Initialization complete", type = "success")
       message()
     }
   } else {

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -346,6 +346,7 @@ tune_grid_loop_iter <- function(split,
   # post-processing. however, we want the original split to persist so we can
   # use it (particularly `labels(split_orig)`) in logging
   split_orig <- split
+  split_labels <- labels(split)
 
   load_pkgs(workflow)
   .load_namespace(control$pkgs)
@@ -434,7 +435,7 @@ tune_grid_loop_iter <- function(split,
     workflow <- .catch_and_log(
       .expr = .fit_pre(workflow, analysis),
       control,
-      split_orig,
+      split_labels,
       iter_msg_preprocessor,
       notes = out_notes
     )
@@ -469,7 +470,7 @@ tune_grid_loop_iter <- function(split,
       workflow <- .catch_and_log_fit(
         .expr = .fit_model(workflow, control_workflow),
         control,
-        split_orig,
+        split_labels,
         iter_msg_model,
         notes = out_notes
       )
@@ -498,12 +499,12 @@ tune_grid_loop_iter <- function(split,
         elt_extract <- .catch_and_log(
           extract_details(workflow, control$extract),
           control,
-          split_orig,
+          split_labels,
           paste(iter_msg_model, "(extracts)"),
           bad_only = TRUE,
           notes = out_notes
         )
-        elt_extract <- make_extracts(elt_extract, iter_grid, split_orig, .config = iter_config)
+        elt_extract <- make_extracts(elt_extract, iter_grid, split_labels, .config = iter_config)
         out_extracts <- append_extracts(out_extracts, elt_extract)
       }
 
@@ -513,7 +514,7 @@ tune_grid_loop_iter <- function(split,
         predict_model(split, workflow, iter_grid, metrics, iter_submodels,
                       metrics_info = metrics_info, eval_time = eval_time),
         control,
-        split_orig,
+        split_labels,
         iter_msg_predictions,
         bad_only = TRUE,
         notes = out_notes
@@ -548,12 +549,12 @@ tune_grid_loop_iter <- function(split,
         elt_extract <- .catch_and_log(
           extract_details(workflow_with_post, control$extract),
           control,
-          split_orig,
+          split_labels,
           paste(iter_msg_model, "(extracts)"),
           bad_only = TRUE,
           notes = out_notes
         )
-        elt_extract <- make_extracts(elt_extract, iter_grid, split_orig, .config = iter_config)
+        elt_extract <- make_extracts(elt_extract, iter_grid, split_labels, .config = iter_config)
         out_extracts <- append_extracts(out_extracts, elt_extract)
 
 
@@ -565,7 +566,7 @@ tune_grid_loop_iter <- function(split,
                         iter_submodels, metrics_info = metrics_info,
                         eval_time = eval_time),
           control,
-          split_orig,
+          split_labels,
           paste(iter_msg_model, "(predictions with post-processor)"),
           bad_only = TRUE,
           notes = out_notes
@@ -581,7 +582,7 @@ tune_grid_loop_iter <- function(split,
         param_names = param_names,
         outcome_name = outcome_names,
         event_level = event_level,
-        split = split_orig,
+        split_labels = split_labels,
         .config = iter_config,
         metrics_info = metrics_info
       )
@@ -591,7 +592,7 @@ tune_grid_loop_iter <- function(split,
       out_predictions <- append_predictions(
         collection = out_predictions,
         predictions = iter_predictions,
-        split = split_orig,
+        split_labels = split_labels,
         control = control,
         .config = iter_config_metrics
       )
@@ -657,7 +658,7 @@ tune_grid_loop_iter_safely <- function(fn_tune_grid_loop_iter,
 
   problems <- list(res = res, signals = warnings)
 
-  notes <- log_problems(notes, control, split, "internal", problems)
+  notes <- log_problems(notes, control, labels(split), "internal", problems)
 
   # Need an output template
   if (!is.null(error)) {

--- a/R/logging.R
+++ b/R/logging.R
@@ -262,7 +262,7 @@ siren <- function(x, type = "info") {
   message(paste(symb, msg))
 }
 
-tune_log <- function(control, split = NULL, task, type = "success", catalog = TRUE) {
+tune_log <- function(control, split_labels = NULL, task, type = "success", catalog = TRUE) {
   if (!any(control$verbose, control$verbose_iter)) {
     return(invisible(NULL))
   }
@@ -272,9 +272,8 @@ tune_log <- function(control, split = NULL, task, type = "success", catalog = TR
     return(NULL)
   }
 
-  if (!is.null(split)) {
-    labs <- labels(split)
-    labs <- rev(unlist(labs))
+  if (!is.null(split_labels)) {
+    labs <- rev(unlist(split_labels))
     labs <- paste0(labs, collapse = ", ")
     labs <- paste0(labs, ": ")
   } else {
@@ -293,7 +292,7 @@ is_testing <- function() {
   identical(Sys.getenv("TESTTHAT"), "true")
 }
 
-log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
+log_problems <- function(notes, control, split_labels, loc, res, bad_only = FALSE) {
   # Always log warnings and errors
   control2 <- control
   control2$verbose <- TRUE
@@ -320,7 +319,7 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
       tune_catalog(dplyr::filter(notes, type == "warning" & location == loc))
     } else {
       wrn_msg <- format_msg(loc, wrn_msg$note)
-      tune_log(control2, split, wrn_msg, type = "warning")
+      tune_log(control2, split_labels, wrn_msg, type = "warning")
     }
   }
   if (inherits(res$res, "try-error")) {
@@ -343,11 +342,11 @@ log_problems <- function(notes, control, split, loc, res, bad_only = FALSE) {
       tune_catalog(dplyr::filter(notes, type == "error" & location == loc))
     } else {
       err_msg <- format_msg(loc, err_msg$note)
-      tune_log(control2, split, err_msg, type = "danger")
+      tune_log(control2, split_labels, err_msg, type = "danger")
     }
   } else {
     if (!bad_only) {
-      tune_log(control, split, loc, type = "success")
+      tune_log(control, split_labels, loc, type = "success")
     }
   }
   notes
@@ -438,7 +437,7 @@ log_best <- function(control, iter, info, digits = 4) {
       info$best_iter,
       ")"
     )
-  tune_log(control, split = NULL, task = msg, type = "info", catalog = FALSE)
+  tune_log(control, split_labels = NULL, task = msg, type = "info", catalog = FALSE)
 }
 
 check_and_log_flow <- function(control, results) {
@@ -448,11 +447,11 @@ check_and_log_flow <- function(control, results) {
 
   if (all(is.na(results$.mean))) {
     if (nrow(results) < 2) {
-      tune_log(control, split = NULL, task = "Halting search",
+      tune_log(control, split_labels = NULL, task = "Halting search",
                type = "danger", catalog = FALSE)
       eval.parent(parse(text = "break"))
     } else {
-      tune_log(control, split = NULL, task = "Skipping to next iteration",
+      tune_log(control, split_labels = NULL, task = "Skipping to next iteration",
                type = "danger", catalog = FALSE)
       eval.parent(parse(text = "next"))
     }
@@ -530,7 +529,7 @@ acq_summarizer <- function(control, iter, objective = NULL, digits = 4) {
     }
   }
   if (!is.null(val)) {
-    tune_log(control, split = NULL, task = val, type = "info", catalog = FALSE)
+    tune_log(control, split_labels = NULL, task = val, type = "info", catalog = FALSE)
   }
   invisible(NULL)
 }

--- a/R/pull.R
+++ b/R/pull.R
@@ -143,7 +143,7 @@ append_metrics <- function(collection,
                            param_names,
                            outcome_name,
                            event_level,
-                           split,
+                           split_labels,
                            .config = NULL,
                            metrics_info) {
   if (inherits(predictions, "try-error")) {
@@ -159,7 +159,7 @@ append_metrics <- function(collection,
     metrics_info = metrics_info
   )
 
-  tmp_est <- cbind(tmp_est, labels(split))
+  tmp_est <- cbind(tmp_est, split_labels)
 
   if (!rlang::is_null(.config)) {
     tmp_est <- cbind(tmp_est, .config)
@@ -168,7 +168,7 @@ append_metrics <- function(collection,
   dplyr::bind_rows(collection, tmp_est)
 }
 
-append_predictions <- function(collection, predictions, split, control, .config = NULL) {
+append_predictions <- function(collection, predictions, split_labels, control, .config = NULL) {
   if (!control$save_pred) {
     return(NULL)
   }
@@ -176,7 +176,7 @@ append_predictions <- function(collection, predictions, split, control, .config 
     return(collection)
   }
 
-  predictions <- vec_cbind(predictions, labels(split))
+  predictions <- vec_cbind(predictions, split_labels)
 
   if (!rlang::is_null(.config)) {
     by <- setdiff(names(.config), ".config")
@@ -196,8 +196,8 @@ append_extracts <- function(collection, extracts) {
   dplyr::bind_rows(collection, extracts)
 }
 
-make_extracts <- function(extract, grid, split, .config = NULL) {
-  extracts <- dplyr::bind_cols(grid, labels(split))
+make_extracts <- function(extract, grid, split_labels, .config = NULL) {
+  extracts <- dplyr::bind_cols(grid, split_labels)
   extracts$.extracts <- list(extract)
 
   if (!rlang::is_null(.config)) {

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -486,7 +486,7 @@ tune_bayes_workflow <- function(object,
                      objective = opt_metric_name, eval_time = opt_metric_time)
       } else {
         if (all_bad) {
-          tune_log(control, split = NULL, task = "All models failed", type = "danger")
+          tune_log(control, split_labels = NULL, task = "All models failed", type = "danger")
         }
         score_card$last_impr <- score_card$last_impr + 1
       }
@@ -648,13 +648,13 @@ pred_gp <- function(object, pset, size = 5000, current = NULL, control) {
       msg <- "An error occurred when creating candidates parameters: "
       msg <- paste(msg, as.character(object))
     }
-    tune_log(control, split = NULL, task = msg, type = "warning")
+    tune_log(control, split_labels = NULL, task = msg, type = "warning")
     return(pred_grid %>% dplyr::mutate(.mean = NA_real_, .sd = NA_real_))
   }
 
   tune_log(
     control,
-    split = NULL,
+    split_labels = NULL,
     task = paste("Generating", nrow(pred_grid), "candidates"),
     type = "info",
     catalog = FALSE
@@ -663,7 +663,7 @@ pred_gp <- function(object, pset, size = 5000, current = NULL, control) {
   x <- encode_set(pred_grid, pset, as_matrix = TRUE)
   gp_pred <- predict(object, x)
 
-  tune_log(control, split = NULL, task = "Predicted candidates", type = "info", catalog = FALSE)
+  tune_log(control, split_labels = NULL, task = "Predicted candidates", type = "info", catalog = FALSE)
 
   pred_grid %>%
     dplyr::mutate(.mean = gp_pred$Y_hat, .sd = sqrt(gp_pred$MSE))
@@ -770,7 +770,7 @@ initial_info <- function(stats, metrics, maximize, eval_time) {
 
 more_results <- function(object, resamples, candidates, metrics,
                          eval_time = NULL, control, param_info) {
-  tune_log(control, split = NULL, task = "Estimating performance", type = "info")
+  tune_log(control, split_labels = NULL, task = "Estimating performance", type = "info")
 
   candidates <- candidates[, !(names(candidates) %in% c(".mean", ".sd", "objective"))]
   p_chr <- paste0(names(candidates), "=", format(as.data.frame(candidates), digits = 3))
@@ -792,7 +792,7 @@ more_results <- function(object, resamples, candidates, metrics,
   if (inherits(tmp_res, "try-error")) {
     tune_log(
       control,
-      split = NULL, task = "Couldn't estimate performance",
+      split_labels = NULL, task = "Couldn't estimate performance",
       type = "danger"
     )
   } else {
@@ -800,12 +800,12 @@ more_results <- function(object, resamples, candidates, metrics,
     if (all_bad) {
       p_chr <- glue::glue_collapse(p_chr, width = options()$width - 28, sep = ", ")
       msg <- paste("All models failed for:", p_chr)
-      tune_log(control, split = NULL, task = msg, type = "danger")
+      tune_log(control, split_labels = NULL, task = msg, type = "danger")
       tmp_res <- simpleError(msg)
     } else {
       tune_log(
         control,
-        split = NULL, task = "Estimating performance",
+        split_labels = NULL, task = "Estimating performance",
         type = "success"
       )
     }

--- a/tests/testthat/_snaps/logging.md
+++ b/tests/testthat/_snaps/logging.md
@@ -85,7 +85,7 @@
 # catch and log issues
 
     Code
-      out_1 <- .catch_and_log(log("a"), control = ctrl_f, split = rs, "toledo",
+      out_1 <- .catch_and_log(log("a"), control = ctrl_f, split_labels = rs, "toledo",
       bad_only = FALSE, notes = null)
     Message
       x Fold01: toledo: Error in log("a"): non-numeric argument to mathematical function
@@ -93,7 +93,7 @@
 ---
 
     Code
-      out_3 <- .catch_and_log(log(-1), control = ctrl_f, split = rs, "toledo",
+      out_3 <- .catch_and_log(log(-1), control = ctrl_f, split_labels = rs, "toledo",
       bad_only = FALSE, notes = null)
     Message
       ! Fold01: toledo: NaNs produced
@@ -101,16 +101,16 @@
 ---
 
     Code
-      out_5 <- .catch_and_log(log("a"), control = ctrl_f, split = NULL, "toledo",
-      bad_only = FALSE, notes = null)
+      out_5 <- .catch_and_log(log("a"), control = ctrl_f, split_labels = NULL,
+      "toledo", bad_only = FALSE, notes = null)
     Message
       x toledo: Error in log("a"): non-numeric argument to mathematical function
 
 ---
 
     Code
-      out_6 <- .catch_and_log(log(-1), control = ctrl_f, split = NULL, "toledo",
-      bad_only = FALSE, notes = null)
+      out_6 <- .catch_and_log(log(-1), control = ctrl_f, split_labels = NULL,
+      "toledo", bad_only = FALSE, notes = null)
     Message
       ! toledo: NaNs produced
 

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -15,7 +15,7 @@ test_that("low-level messages", {
 test_that("tune_log", {
   ctrl_t <- control_grid(verbose = TRUE)
   ctrl_f <- control_grid(verbose = FALSE)
-  rs <- rsample::vfold_cv(mtcars)$splits[[1]]
+  rs <- labels(rsample::vfold_cv(mtcars)$splits[[1]])
 
   expect_snapshot(tune_log(ctrl_t, rs, task = "cube", type = "go"))
   expect_snapshot(tune_log(ctrl_t, NULL, task = "cube", type = "go"))
@@ -28,7 +28,7 @@ test_that("tune_log", {
 test_that("log issues", {
   ctrl_f <- control_grid(verbose = FALSE)
 
-  rs <- rsample::vfold_cv(mtcars)$splits[[1]]
+  rs <- labels(rsample::vfold_cv(mtcars)$splits[[1]])
 
   res_1 <- catcher(log("a"))
   res_2 <- catcher(log(1))
@@ -70,14 +70,14 @@ test_that("log issues", {
 
 test_that("catch and log issues", {
   ctrl_f <- control_grid(verbose = FALSE)
-  rs <- rsample::vfold_cv(mtcars)$splits[[1]]
+  rs <- labels(rsample::vfold_cv(mtcars)$splits[[1]])
   null <- NULL
 
   expect_snapshot(
     out_1 <- .catch_and_log(
       log("a"),
       control = ctrl_f,
-      split = rs,
+      split_labels = rs,
       "toledo",
       bad_only = FALSE,
       notes = null
@@ -87,7 +87,7 @@ test_that("catch and log issues", {
   expect_silent(out_2 <- .catch_and_log(
     log(1),
     control = ctrl_f,
-    split = rs,
+    split_labels = rs,
     "toledo",
     bad_only = FALSE,
     notes = null
@@ -97,7 +97,7 @@ test_that("catch and log issues", {
     out_3 <- .catch_and_log(
       log(-1),
       control = ctrl_f,
-      split = rs,
+      split_labels = rs,
       "toledo",
       bad_only = FALSE,
       notes = null
@@ -108,7 +108,7 @@ test_that("catch and log issues", {
     out_5 <- .catch_and_log(
       log("a"),
       control = ctrl_f,
-      split = NULL,
+      split_labels = NULL,
       "toledo",
       bad_only = FALSE,
       notes = null
@@ -119,7 +119,7 @@ test_that("catch and log issues", {
     out_6 <- .catch_and_log(
       log(-1),
       control = ctrl_f,
-      split = NULL,
+      split_labels = NULL,
       "toledo",
       bad_only = FALSE,
       notes = null


### PR DESCRIPTION
Closes #893.

Affects:

* `tune_log()`
* `log_problems()`
* `.catch_and_log*()`

The `.catch_and_log*()` functions are exported, so will need revdepchecks.