### PR TITLE
generate needed objects from `split` first-thing

### DIFF
--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -1,10 +1,8 @@
 
-predict_model <- function(split, workflow, grid, metrics, submodels = NULL,
-                          metrics_info, eval_time = NULL) {
+predict_model <- function(new_data, orig_rows, workflow, grid, metrics,
+                          submodels = NULL, metrics_info, eval_time = NULL) {
 
   model <- extract_fit_parsnip(workflow)
-
-  new_data <- rsample::assessment(split)
 
   forged <- forge_from_workflow(new_data, workflow)
   x_vals <- forged$predictors
@@ -15,8 +13,6 @@ predict_model <- function(split, workflow, grid, metrics, submodels = NULL,
   if (model$spec$mode == "censored regression") {
     model$preproc$y_var <- names(y_vals)
   }
-
-  orig_rows <- as.integer(split, data = "assessment")
 
   if (length(orig_rows) != nrow(x_vals)) {
     msg <- paste0(

--- a/R/utils.R
+++ b/R/utils.R
@@ -78,7 +78,7 @@ new_bare_tibble <- function(x, ..., class = character()) {
   .iter
 }
 
-`%||%` <- function (x, y) {if (is_null(x)) y else x}
+`%||%` <- function (x, y) {if (rlang::is_null(x)) y else x}
 
 ## -----------------------------------------------------------------------------
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -78,6 +78,8 @@ new_bare_tibble <- function(x, ..., class = character()) {
   .iter
 }
 
+`%||%` <- function (x, y) {if (is_null(x)) y else x}
+
 ## -----------------------------------------------------------------------------
 
 #' Various accessor functions


### PR DESCRIPTION
Closes #901, closes #908. :)

Generates the analysis, potato, and assessment sets first-thing in `tune_grid_loop_iter()`, as well as needed labels and prediction indices, and then no longer needs to reference `split` for the rest of the function body. As such, refers to those sets only by their names and removes references to `split` and `split_orig` in explanatory comments.