### PR TITLE
send `?tune` to hardhat's docs

### DIFF
--- a/R/reexports.R
+++ b/R/reexports.R
@@ -11,6 +11,7 @@ ggplot2::autoplot
 #' @export
 generics::required_pkgs
 
+#' @noRd
 #' @importFrom hardhat tune
 #' @export
 hardhat::tune

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -7,7 +7,6 @@
 \alias{parameters}
 \alias{autoplot}
 \alias{required_pkgs}
-\alias{tune}
 \alias{tunable}
 \alias{tune_args}
 \alias{min_grid}
@@ -37,7 +36,7 @@ below to see their documentation.
 
   \item{ggplot2}{\code{\link[ggplot2]{autoplot}}}
 
-  \item{hardhat}{\code{\link[hardhat:hardhat-extract]{extract_fit_engine}}, \code{\link[hardhat:hardhat-extract]{extract_fit_parsnip}}, \code{\link[hardhat:hardhat-extract]{extract_mold}}, \code{\link[hardhat:hardhat-extract]{extract_parameter_set_dials}}, \code{\link[hardhat:hardhat-extract]{extract_preprocessor}}, \code{\link[hardhat:hardhat-extract]{extract_recipe}}, \code{\link[hardhat:hardhat-extract]{extract_spec_parsnip}}, \code{\link[hardhat:hardhat-extract]{extract_workflow}}, \code{\link[hardhat]{tune}}}
+  \item{hardhat}{\code{\link[hardhat:hardhat-extract]{extract_fit_engine}}, \code{\link[hardhat:hardhat-extract]{extract_fit_parsnip}}, \code{\link[hardhat:hardhat-extract]{extract_mold}}, \code{\link[hardhat:hardhat-extract]{extract_parameter_set_dials}}, \code{\link[hardhat:hardhat-extract]{extract_preprocessor}}, \code{\link[hardhat:hardhat-extract]{extract_recipe}}, \code{\link[hardhat:hardhat-extract]{extract_spec_parsnip}}, \code{\link[hardhat:hardhat-extract]{extract_workflow}}}
 
   \item{rsample}{\code{\link[rsample:get_fingerprint]{.get_fingerprint}}, \code{\link[rsample]{int_pctl}}}
 }}


### PR DESCRIPTION
PR 1/2 with the goal of `library(tidymodels); ?tune` actually sending users to the docs for `?tune`.

Before these PRs:

https://github.com/user-attachments/assets/29dd9889-d931-4e52-83b3-c3882e591ade

After these PRs. Note that, even without hardhat explicitly loaded, `?tune` can head to the page from hardhat:

https://github.com/user-attachments/assets/0897c5fc-dd97-4cd4-9311-9328412141d7

This doesn't address the "`?tune`'s docs need work" criticism nor apply the same fix to other places that could benefit from this change.