### PR TITLE
apply postprocessors even if they don't need training

### DIFF
--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -504,7 +504,7 @@ tune_grid_loop_iter <- function(split,
         iter_grid_model
       )
 
-      if (!workflows::.should_inner_split(workflow)) {
+      if (!has_postprocessor(workflow)) {
         elt_extract <- .catch_and_log(
           extract_details(workflow, control$extract),
           control,
@@ -535,7 +535,7 @@ tune_grid_loop_iter <- function(split,
         next
       }
 
-      if (workflows::.should_inner_split(workflow)) {
+      if (has_postprocessor(workflow)) {
         # note that, since we're training a postprocessor, `iter_predictions`
         # are the predictions from the potato set rather than the
         # assessment set
@@ -543,7 +543,11 @@ tune_grid_loop_iter <- function(split,
         # train the post-processor on the predictions generated from the model
         # on the potato set
         # todo: needs a `.catch_and_log`
-        workflow_with_post <- .fit_post(workflow, potato)
+        #
+        # if the postprocessor does not require training, then `potato` will
+        # be NULL and nothing other than the column names is learned from
+        # `assessment`.
+        workflow_with_post <- .fit_post(workflow, potato %||% assessment)
 
         workflow_with_post <- .fit_finalize(workflow_with_post)
 

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -187,6 +187,54 @@ test_that("can use `fit_resamples()` with a workflow - postprocessor (requires t
   expect_equal(tune_wflow, wflow_res)
 })
 
+test_that("can use `fit_resamples()` with a workflow - postprocessor (no training)", {
+  skip_if_not_installed("tailor")
+
+  y <- seq(0, 7, .001)
+  dat <- data.frame(y = y, x = y + (y-3)^2)
+
+  folds <- rsample::vfold_cv(dat, v = 2)
+
+  wflow <-
+    workflows::workflow(
+      y ~ x,
+      parsnip::linear_reg()
+    ) %>%
+    workflows::add_tailor(
+      tailor::tailor("regression") %>% tailor::adjust_numeric_range(lower_limit = 1)
+    )
+
+  set.seed(1)
+  tune_res <-
+    fit_resamples(
+      wflow,
+      folds,
+      control = control_resamples(save_pred = TRUE, extract = identity)
+    )
+
+  tune_preds <-
+    collect_predictions(tune_res) %>%
+    dplyr::filter(id == "Fold1")
+
+  tune_wflow <-
+    collect_extracts(tune_res) %>%
+    pull(.extracts) %>%
+    `[[`(1)
+
+  # mock `tune::tune_grid_loop_iter`'s RNG scheme
+  set.seed(1)
+  seed <- generate_seeds(TRUE, 1)[[1]]
+  old_kind <- RNGkind()[[1]]
+  assign(".Random.seed", seed, envir = globalenv())
+
+  wflow_res <- generics::fit(wflow, rsample::analysis(folds$splits[[1]]))
+  wflow_preds <- predict(wflow_res, rsample::assessment(folds$splits[[1]]))
+
+  tune_wflow$fit$fit$elapsed$elapsed <- wflow_res$fit$fit$elapsed$elapsed
+  expect_equal(tune_preds$.pred, wflow_preds$.pred)
+  expect_equal(tune_wflow, wflow_res)
+})
+
 # Error capture ----------------------------------------------------------------
 
 test_that("failure in recipe is caught elegantly", {


### PR DESCRIPTION
Closes #939.

``` r
library(tidymodels)
library(tailor)

set.seed(121)
ad_split <- initial_split(ad_data, strata = Class)
ad_tr <- training(ad_split)
ad_te <- testing(ad_split)
ad_rs <- vfold_cv(ad_tr, repeats = 10, strata = Class)

rf_spec <- rand_forest() %>% set_mode("classification")

rf_bl_wflow <- 
  workflow(Class ~ ., rf_spec)

post_high <- tailor() %>% adjust_probability_threshold(0.99)
post_low  <- tailor() %>% adjust_probability_threshold(0.01)

high_wflow <- 
  rf_bl_wflow %>% 
  add_tailor(post_high)

low_wflow <- 
  rf_bl_wflow %>% 
  add_tailor(post_low)

cls_mtr <- metric_set(roc_auc, brier_class, sensitivity, specificity, j_index, mcc)

set.seed(1)
rf_bl_res <- rf_bl_wflow %>% fit_resamples(ad_rs, metrics = cls_mtr)

set.seed(1)
high_res <- high_wflow %>% fit_resamples(ad_rs, metrics = cls_mtr)

set.seed(1)
low_res <- low_wflow %>% fit_resamples(ad_rs, metrics = cls_mtr)

identical(collect_metrics(rf_bl_res), collect_metrics(low_res))
#> [1] FALSE
identical(collect_metrics(high_res), collect_metrics(low_res))
#> [1] FALSE
```

<sup>Created on 2024-09-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>