### PR TITLE
transition from `add_tailor(prop)` and `method`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Suggests:
 Remotes:
     tidymodels/rsample,
     tidymodels/tailor, 
-    tidymodels/workflows
+    tidymodels/workflows#262
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Suggests:
 Remotes:
     tidymodels/rsample,
     tidymodels/tailor, 
-    tidymodels/workflows#262
+    tidymodels/workflows
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate
 Config/testthat/edition: 3

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -384,7 +384,7 @@ tune_grid_loop_iter <- function(split,
   assessment_rows <- as.integer(split, data = "assessment")
   assessment <- vctrs::vec_slice(split$data, assessment_rows)
 
-  if (workflows::.should_inner_split(workflow)) {
+  if (workflows::.workflow_includes_calibration(workflow)) {
     # if the workflow has a postprocessor that needs training (i.e. calibration),
     # further split the analysis data into an "inner" analysis and
     # assessment set.
@@ -397,11 +397,6 @@ tune_grid_loop_iter <- function(split,
     #   calibration set
     # * the model (including the post-processor) generates predictions on the
     #   assessment set and those predictions are assessed with performance metrics
-    # todo: check if workflow's `method` is incompatible with `class(split)`?
-    # todo: workflow's `method` is currently ignored in favor of the one
-    # automatically dispatched to from `split`. consider this is combination
-    # with above todo.
-    split_args <- c(split_args, list(prop = workflow$post$actions$tailor$prop))
     split <- rsample::inner_split(split, split_args = split_args)
     analysis <- rsample::analysis(split)
 


### PR DESCRIPTION
Updates related to https://github.com/tidymodels/workflows/pull/262  --  transitions away from the `prop` and `method` arguments to `add_tailor()` to a separate argument for the calibration set and uses the renamed helpers from workflows.