### PR TITLE
updates for no-suggests checks

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,59 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check-hard.yaml
+
+permissions: read-all
+
+jobs:
+  check-no-suggests:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Imports:
     recipes (>= 1.0.4),
     rlang (>= 1.1.0),
     rsample (>= 1.2.1.9000),
+    tailor,
     tibble (>= 3.1.0),
     tidyr (>= 1.2.0),
     tidyselect (>= 1.1.2),
@@ -52,7 +53,6 @@ Suggests:
     scales,
     spelling,
     splines2,
-    tailor,
     testthat (>= 3.0.0),
     xgboost,
     xml2

--- a/R/conf_mat_resampled.R
+++ b/R/conf_mat_resampled.R
@@ -11,27 +11,27 @@
 #' @param tidy Should the results come back in a tibble (`TRUE`) or a `conf_mat`
 #' object like `yardstick::conf_mat()` (`FALSE`)?
 #' @return A tibble or `conf_mat` with the average cell count across resamples.
-#' @examples
+#' @examplesIf rlang::is_installed("modeldata")
+#' # example code
+#'
 #' library(parsnip)
 #' library(rsample)
 #' library(dplyr)
-#' if (rlang::is_installed("modeldata")) {
 #'
-#'   data(two_class_dat, package = "modeldata")
+#' data(two_class_dat, package = "modeldata")
 #'
-#'   set.seed(2393)
-#'   res <-
-#'     logistic_reg() %>%
-#'     set_engine("glm") %>%
-#'     fit_resamples(
-#'       Class ~ .,
-#'       resamples = vfold_cv(two_class_dat, v = 3),
-#'       control = control_resamples(save_pred = TRUE)
-#'     )
+#' set.seed(2393)
+#' res <-
+#'   logistic_reg() %>%
+#'   set_engine("glm") %>%
+#'   fit_resamples(
+#'     Class ~ .,
+#'     resamples = vfold_cv(two_class_dat, v = 3),
+#'     control = control_resamples(save_pred = TRUE)
+#'   )
 #'
-#'   conf_mat_resampled(res)
-#'   conf_mat_resampled(res, tidy = FALSE)
-#' }
+#' conf_mat_resampled(res)
+#' conf_mat_resampled(res, tidy = FALSE)
 #' @export
 conf_mat_resampled <- function(x, ..., parameters = NULL, tidy = TRUE) {
   rlang::check_dots_empty()

--- a/R/conf_mat_resampled.R
+++ b/R/conf_mat_resampled.R
@@ -15,21 +15,23 @@
 #' library(parsnip)
 #' library(rsample)
 #' library(dplyr)
+#' if (rlang::is_installed("modeldata")) {
 #'
-#' data(two_class_dat, package = "modeldata")
+#'   data(two_class_dat, package = "modeldata")
 #'
-#' set.seed(2393)
-#' res <-
-#'   logistic_reg() %>%
-#'   set_engine("glm") %>%
-#'   fit_resamples(
-#'     Class ~ .,
-#'     resamples = vfold_cv(two_class_dat, v = 3),
-#'     control = control_resamples(save_pred = TRUE)
-#'   )
+#'   set.seed(2393)
+#'   res <-
+#'     logistic_reg() %>%
+#'     set_engine("glm") %>%
+#'     fit_resamples(
+#'       Class ~ .,
+#'       resamples = vfold_cv(two_class_dat, v = 3),
+#'       control = control_resamples(save_pred = TRUE)
+#'     )
 #'
-#' conf_mat_resampled(res)
-#' conf_mat_resampled(res, tidy = FALSE)
+#'   conf_mat_resampled(res)
+#'   conf_mat_resampled(res, tidy = FALSE)
+#' }
 #' @export
 conf_mat_resampled <- function(x, ..., parameters = NULL, tidy = TRUE) {
   rlang::check_dots_empty()

--- a/R/coord_obs_pred.R
+++ b/R/coord_obs_pred.R
@@ -36,21 +36,20 @@ CoordObsPred <-
 #' may show up in places such as the axes, the legend, the plot title, or the
 #' plot margins.
 #' @return A `ggproto` object.
-#' @examples
-#' if (rlang::is_installed("modeldata")) {
-#'   data(solubility_test, package = "modeldata")
+#' @examplesIf rlang::is_installed("modeldata")
+#' # example code
+#' data(solubility_test, package = "modeldata")
 #'
-#'   library(ggplot2)
-#'   p <- ggplot(solubility_test, aes(x = solubility, y = prediction)) +
-#'     geom_abline(lty = 2) +
-#'     geom_point(alpha = 0.5)
+#' library(ggplot2)
+#' p <- ggplot(solubility_test, aes(x = solubility, y = prediction)) +
+#'   geom_abline(lty = 2) +
+#'   geom_point(alpha = 0.5)
 #'
-#'   p
+#' p
 #'
-#'   p + coord_fixed()
+#' p + coord_fixed()
 #'
-#'   p + coord_obs_pred()
-#' }
+#' p + coord_obs_pred()
 #' @export
 coord_obs_pred <-
   function(ratio = 1,

--- a/R/coord_obs_pred.R
+++ b/R/coord_obs_pred.R
@@ -37,18 +37,20 @@ CoordObsPred <-
 #' plot margins.
 #' @return A `ggproto` object.
 #' @examples
-#' data(solubility_test, package = "modeldata")
+#' if (rlang::is_installed("modeldata")) {
+#'   data(solubility_test, package = "modeldata")
 #'
-#' library(ggplot2)
-#' p <- ggplot(solubility_test, aes(x = solubility, y = prediction)) +
-#'   geom_abline(lty = 2) +
-#'   geom_point(alpha = 0.5)
+#'   library(ggplot2)
+#'   p <- ggplot(solubility_test, aes(x = solubility, y = prediction)) +
+#'     geom_abline(lty = 2) +
+#'     geom_point(alpha = 0.5)
 #'
-#' p
+#'   p
 #'
-#' p + coord_fixed()
+#'   p + coord_fixed()
 #'
-#' p + coord_obs_pred()
+#'   p + coord_obs_pred()
+#' }
 #' @export
 coord_obs_pred <-
   function(ratio = 1,

--- a/R/extract.R
+++ b/R/extract.R
@@ -46,42 +46,44 @@
 #'
 #' @name extract-tune
 #' @examples
-#' library(recipes)
-#' library(rsample)
-#' library(parsnip)
+#' if (rlang::is_installed("splines2")) {
+#'   library(recipes)
+#'   library(rsample)
+#'   library(parsnip)
 #'
-#' set.seed(6735)
-#' tr_te_split <- initial_split(mtcars)
+#'   set.seed(6735)
+#'   tr_te_split <- initial_split(mtcars)
 #'
-#' spline_rec <- recipe(mpg ~ ., data = mtcars) %>%
-#'   step_spline_natural(disp)
+#'   spline_rec <- recipe(mpg ~ ., data = mtcars) %>%
+#'     step_spline_natural(disp)
 #'
-#' lin_mod <- linear_reg() %>%
-#'   set_engine("lm")
+#'   lin_mod <- linear_reg() %>%
+#'     set_engine("lm")
 #'
-#' spline_res <- last_fit(lin_mod, spline_rec, split = tr_te_split)
+#'   spline_res <- last_fit(lin_mod, spline_rec, split = tr_te_split)
 #'
-#' extract_preprocessor(spline_res)
+#'   extract_preprocessor(spline_res)
 #'
-#' # The `spec` is the parsnip spec before it has been fit.
-#' # The `fit` is the fitted parsnip model.
-#' extract_spec_parsnip(spline_res)
-#' extract_fit_parsnip(spline_res)
-#' extract_fit_engine(spline_res)
+#'   # The `spec` is the parsnip spec before it has been fit.
+#'   # The `fit` is the fitted parsnip model.
+#'   extract_spec_parsnip(spline_res)
+#'   extract_fit_parsnip(spline_res)
+#'   extract_fit_engine(spline_res)
 #'
-#' # The mold is returned from `hardhat::mold()`, and contains the
-#' # predictors, outcomes, and information about the preprocessing
-#' # for use on new data at `predict()` time.
-#' extract_mold(spline_res)
+#'   # The mold is returned from `hardhat::mold()`, and contains the
+#'   # predictors, outcomes, and information about the preprocessing
+#'   # for use on new data at `predict()` time.
+#'   extract_mold(spline_res)
 #'
-#' # A useful shortcut is to extract the fitted recipe from the workflow
-#' extract_recipe(spline_res)
-#'
-#' # That is identical to
-#' identical(
-#'   extract_mold(spline_res)$blueprint$recipe,
+#'   # A useful shortcut is to extract the fitted recipe from the workflow
 #'   extract_recipe(spline_res)
-#' )
+#'
+#'   # That is identical to
+#'   identical(
+#'     extract_mold(spline_res)$blueprint$recipe,
+#'     extract_recipe(spline_res)
+#'  )
+#' }
 NULL
 
 #' @export

--- a/R/extract.R
+++ b/R/extract.R
@@ -45,45 +45,45 @@
 #' description section.
 #'
 #' @name extract-tune
-#' @examples
-#' if (rlang::is_installed("splines2")) {
-#'   library(recipes)
-#'   library(rsample)
-#'   library(parsnip)
+#' @examplesIf rlang::is_installed("splines2")
+#' # example code
 #'
-#'   set.seed(6735)
-#'   tr_te_split <- initial_split(mtcars)
+#' library(recipes)
+#' library(rsample)
+#' library(parsnip)
 #'
-#'   spline_rec <- recipe(mpg ~ ., data = mtcars) %>%
-#'     step_spline_natural(disp)
+#' set.seed(6735)
+#' tr_te_split <- initial_split(mtcars)
 #'
-#'   lin_mod <- linear_reg() %>%
-#'     set_engine("lm")
+#' spline_rec <- recipe(mpg ~ ., data = mtcars) %>%
+#'   step_spline_natural(disp)
 #'
-#'   spline_res <- last_fit(lin_mod, spline_rec, split = tr_te_split)
+#' lin_mod <- linear_reg() %>%
+#'   set_engine("lm")
 #'
-#'   extract_preprocessor(spline_res)
+#' spline_res <- last_fit(lin_mod, spline_rec, split = tr_te_split)
 #'
-#'   # The `spec` is the parsnip spec before it has been fit.
-#'   # The `fit` is the fitted parsnip model.
-#'   extract_spec_parsnip(spline_res)
-#'   extract_fit_parsnip(spline_res)
-#'   extract_fit_engine(spline_res)
+#' extract_preprocessor(spline_res)
 #'
-#'   # The mold is returned from `hardhat::mold()`, and contains the
-#'   # predictors, outcomes, and information about the preprocessing
-#'   # for use on new data at `predict()` time.
-#'   extract_mold(spline_res)
+#' # The `spec` is the parsnip spec before it has been fit.
+#' # The `fit` is the fitted parsnip model.
+#' extract_spec_parsnip(spline_res)
+#' extract_fit_parsnip(spline_res)
+#' extract_fit_engine(spline_res)
 #'
-#'   # A useful shortcut is to extract the fitted recipe from the workflow
+#' # The mold is returned from `hardhat::mold()`, and contains the
+#' # predictors, outcomes, and information about the preprocessing
+#' # for use on new data at `predict()` time.
+#' extract_mold(spline_res)
+#'
+#' # A useful shortcut is to extract the fitted recipe from the workflow
+#' extract_recipe(spline_res)
+#'
+#' # That is identical to
+#' identical(
+#'   extract_mold(spline_res)$blueprint$recipe,
 #'   extract_recipe(spline_res)
-#'
-#'   # That is identical to
-#'   identical(
-#'     extract_mold(spline_res)$blueprint$recipe,
-#'     extract_recipe(spline_res)
-#'  )
-#' }
+#' )
 NULL
 
 #' @export

--- a/R/fit_best.R
+++ b/R/fit_best.R
@@ -37,40 +37,38 @@
 #'
 #' @inheritSection last_fit See also
 #'
-#' @examplesIf tune:::should_run_examples()
+#' @examplesIf tune:::should_run_examples() & rlang::is_installed("modeldata")
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)
 #' library(dplyr)
 #'
-#' if (rlang::is_installed("modeldata")) {
-#'   data(meats, package = "modeldata")
-#'   meats <- meats %>% select(-water, -fat)
+#' data(meats, package = "modeldata")
+#' meats <- meats %>% select(-water, -fat)
 #'
-#'   set.seed(1)
-#'   meat_split <- initial_split(meats)
-#'   meat_train <- training(meat_split)
-#'   meat_test  <- testing(meat_split)
+#' set.seed(1)
+#' meat_split <- initial_split(meats)
+#' meat_train <- training(meat_split)
+#' meat_test  <- testing(meat_split)
 #'
-#'   set.seed(2)
-#'   meat_rs <- vfold_cv(meat_train, v = 10)
+#' set.seed(2)
+#' meat_rs <- vfold_cv(meat_train, v = 10)
 #'
-#'   pca_rec <-
-#'     recipe(protein ~ ., data = meat_train) %>%
-#'     step_normalize(all_numeric_predictors()) %>%
-#'     step_pca(all_numeric_predictors(), num_comp = tune())
+#' pca_rec <-
+#'   recipe(protein ~ ., data = meat_train) %>%
+#'   step_normalize(all_numeric_predictors()) %>%
+#'   step_pca(all_numeric_predictors(), num_comp = tune())
 #'
-#'   knn_mod <- nearest_neighbor(neighbors = tune()) %>% set_mode("regression")
+#' knn_mod <- nearest_neighbor(neighbors = tune()) %>% set_mode("regression")
 #'
-#'   ctrl <- control_grid(save_workflow = TRUE)
+#' ctrl <- control_grid(save_workflow = TRUE)
 #'
-#'   set.seed(128)
-#'   knn_pca_res <-
-#'     tune_grid(knn_mod, pca_rec, resamples = meat_rs, grid = 10, control = ctrl)
+#' set.seed(128)
+#' knn_pca_res <-
+#'   tune_grid(knn_mod, pca_rec, resamples = meat_rs, grid = 10, control = ctrl)
 #'
-#'   knn_fit <- fit_best(knn_pca_res, verbose = TRUE)
-#'   predict(knn_fit, meat_test)
-#' }
+#' knn_fit <- fit_best(knn_pca_res, verbose = TRUE)
+#' predict(knn_fit, meat_test)
 #' @return A fitted workflow.
 #' @export
 fit_best <- function(x, ...) {

--- a/R/fit_best.R
+++ b/R/fit_best.R
@@ -13,8 +13,8 @@
 #' a column for each tuning parameter. This tibble should have columns for each
 #' tuning parameter identifier (e.g. `"my_param"` if `tune("my_param")` was used).
 #' If `NULL`, this argument will be set to
-#' [`select_best(metric, eval_time)`][tune::select_best.tune_results]. 
-#' If not `NULL`, `parameters` overwrites the specification via `metric`, and 
+#' [`select_best(metric, eval_time)`][tune::select_best.tune_results].
+#' If not `NULL`, `parameters` overwrites the specification via `metric`, and
 #' `eval_time`.
 #' @param verbose A logical for printing logging.
 #' @param add_validation_set When the resamples embedded in `x` are a split into
@@ -43,32 +43,34 @@
 #' library(parsnip)
 #' library(dplyr)
 #'
-#' data(meats, package = "modeldata")
-#' meats <- meats %>% select(-water, -fat)
+#' if (rlang::is_installed("modeldata")) {
+#'   data(meats, package = "modeldata")
+#'   meats <- meats %>% select(-water, -fat)
 #'
-#' set.seed(1)
-#' meat_split <- initial_split(meats)
-#' meat_train <- training(meat_split)
-#' meat_test  <- testing(meat_split)
+#'   set.seed(1)
+#'   meat_split <- initial_split(meats)
+#'   meat_train <- training(meat_split)
+#'   meat_test  <- testing(meat_split)
 #'
-#' set.seed(2)
-#' meat_rs <- vfold_cv(meat_train, v = 10)
+#'   set.seed(2)
+#'   meat_rs <- vfold_cv(meat_train, v = 10)
 #'
-#' pca_rec <-
-#'   recipe(protein ~ ., data = meat_train) %>%
-#'   step_normalize(all_numeric_predictors()) %>%
-#'   step_pca(all_numeric_predictors(), num_comp = tune())
+#'   pca_rec <-
+#'     recipe(protein ~ ., data = meat_train) %>%
+#'     step_normalize(all_numeric_predictors()) %>%
+#'     step_pca(all_numeric_predictors(), num_comp = tune())
 #'
-#' knn_mod <- nearest_neighbor(neighbors = tune()) %>% set_mode("regression")
+#'   knn_mod <- nearest_neighbor(neighbors = tune()) %>% set_mode("regression")
 #'
-#' ctrl <- control_grid(save_workflow = TRUE)
+#'   ctrl <- control_grid(save_workflow = TRUE)
 #'
-#' set.seed(128)
-#' knn_pca_res <-
-#'   tune_grid(knn_mod, pca_rec, resamples = meat_rs, grid = 10, control = ctrl)
+#'   set.seed(128)
+#'   knn_pca_res <-
+#'     tune_grid(knn_mod, pca_rec, resamples = meat_rs, grid = 10, control = ctrl)
 #'
-#' knn_fit <- fit_best(knn_pca_res, verbose = TRUE)
-#' predict(knn_fit, meat_test)
+#'   knn_fit <- fit_best(knn_pca_res, verbose = TRUE)
+#'   predict(knn_fit, meat_test)
+#' }
 #' @return A fitted workflow.
 #' @export
 fit_best <- function(x, ...) {

--- a/R/int_pctl.R
+++ b/R/int_pctl.R
@@ -46,24 +46,26 @@
 #' @references Davison, A., & Hinkley, D. (1997). _Bootstrap Methods and their
 #'  Application_. Cambridge: Cambridge University Press.
 #'  doi:10.1017/CBO9780511802843
-#' @examplesIf !tune:::is_cran_check() & tune:::should_run_examples("modeldata")
-#' data(Sacramento, package = "modeldata")
-#' library(rsample)
-#' library(parsnip)
+#' @examplesIf !tune:::is_cran_check()
+#' if (rlang::is_installed("modeldata")) {
+#'   data(Sacramento, package = "modeldata")
+#'   library(rsample)
+#'   library(parsnip)
 #'
-#' set.seed(13)
-#' sac_rs <- vfold_cv(Sacramento)
+#'   set.seed(13)
+#'   sac_rs <- vfold_cv(Sacramento)
 #'
-#' lm_res <-
-#'   linear_reg() %>%
-#'   fit_resamples(
-#'     log10(price) ~ beds + baths + sqft + type + latitude + longitude,
-#'     resamples = sac_rs,
-#'     control = control_resamples(save_pred = TRUE)
-#'   )
+#'   lm_res <-
+#'     linear_reg() %>%
+#'     fit_resamples(
+#'       log10(price) ~ beds + baths + sqft + type + latitude + longitude,
+#'       resamples = sac_rs,
+#'       control = control_resamples(save_pred = TRUE)
+#'     )
 #'
-#' set.seed(31)
-#' int_pctl(lm_res)
+#'   set.seed(31)
+#'   int_pctl(lm_res)
+#' }
 #' @export
 int_pctl.tune_results <- function(.data, metrics = NULL, eval_time = NULL,
                                   times = 1001, parameters = NULL,

--- a/R/last_fit.R
+++ b/R/last_fit.R
@@ -59,7 +59,7 @@
 #' model (and recipe, if any) that used the training set. Helper functions
 #' for formatting tuning results like [collect_metrics()] and
 #' [collect_predictions()] can be used with `last_fit()` output.
-#' @examplesIf tune:::should_run_examples()
+#' @examplesIf tune:::should_run_examples() & rlang::is_installed("splines2")
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)

--- a/R/merge.R
+++ b/R/merge.R
@@ -13,7 +13,7 @@
 #'
 #' @return A tibble with a column `x` that has as many rows as were in `y`.
 #' @keywords internal
-#' @examplesIf tune:::should_run_examples(suggests = c("xgboost", "modeldata"))
+#' @examplesIf tune:::should_run_examples(suggests = c("xgboost", "modeldata", "splines2"))
 #' library(tibble)
 #' library(recipes)
 #' library(parsnip)

--- a/R/resample.R
+++ b/R/resample.R
@@ -20,7 +20,7 @@
 #' @template case-weights
 #' @template censored-regression
 #' @seealso [control_resamples()], [collect_predictions()], [collect_metrics()]
-#' @examplesIf tune:::should_run_examples()
+#' @examplesIf tune:::should_run_examples() & rlang::is_installed("splines2")
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -163,7 +163,7 @@
 #' @template case-weights
 #' @template censored-regression
 #'
-#' @examplesIf tune:::should_run_examples(suggests = "kernlab")
+#' @examplesIf tune:::should_run_examples(suggests = "kernlab") & rlang::is_installed("splines2")
 #' library(recipes)
 #' library(rsample)
 #' library(parsnip)

--- a/man/conf_mat_resampled.Rd
+++ b/man/conf_mat_resampled.Rd
@@ -29,19 +29,21 @@ confusion matrix for each resample then averages the cell counts.
 library(parsnip)
 library(rsample)
 library(dplyr)
+if (rlang::is_installed("modeldata")) {
 
-data(two_class_dat, package = "modeldata")
+  data(two_class_dat, package = "modeldata")
 
-set.seed(2393)
-res <-
-  logistic_reg() \%>\%
-  set_engine("glm") \%>\%
-  fit_resamples(
-    Class ~ .,
-    resamples = vfold_cv(two_class_dat, v = 3),
-    control = control_resamples(save_pred = TRUE)
-  )
+  set.seed(2393)
+  res <-
+    logistic_reg() \%>\%
+    set_engine("glm") \%>\%
+    fit_resamples(
+      Class ~ .,
+      resamples = vfold_cv(two_class_dat, v = 3),
+      control = control_resamples(save_pred = TRUE)
+    )
 
-conf_mat_resampled(res)
-conf_mat_resampled(res, tidy = FALSE)
+  conf_mat_resampled(res)
+  conf_mat_resampled(res, tidy = FALSE)
+}
 }

--- a/man/conf_mat_resampled.Rd
+++ b/man/conf_mat_resampled.Rd
@@ -26,24 +26,26 @@ For classification problems, \code{conf_mat_resampled()} computes a separate
 confusion matrix for each resample then averages the cell counts.
 }
 \examples{
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# example code
+
 library(parsnip)
 library(rsample)
 library(dplyr)
-if (rlang::is_installed("modeldata")) {
 
-  data(two_class_dat, package = "modeldata")
+data(two_class_dat, package = "modeldata")
 
-  set.seed(2393)
-  res <-
-    logistic_reg() \%>\%
-    set_engine("glm") \%>\%
-    fit_resamples(
-      Class ~ .,
-      resamples = vfold_cv(two_class_dat, v = 3),
-      control = control_resamples(save_pred = TRUE)
-    )
+set.seed(2393)
+res <-
+  logistic_reg() \%>\%
+  set_engine("glm") \%>\%
+  fit_resamples(
+    Class ~ .,
+    resamples = vfold_cv(two_class_dat, v = 3),
+    control = control_resamples(save_pred = TRUE)
+  )
 
-  conf_mat_resampled(res)
-  conf_mat_resampled(res, tidy = FALSE)
-}
+conf_mat_resampled(res)
+conf_mat_resampled(res, tidy = FALSE)
+\dontshow{\}) # examplesIf}
 }

--- a/man/coord_obs_pred.Rd
+++ b/man/coord_obs_pred.Rd
@@ -30,18 +30,19 @@ For regression models, \code{coord_obs_pred()} can be used in a ggplot to make t
 x- and y-axes have the same exact scale along with an aspect ratio of one.
 }
 \examples{
-if (rlang::is_installed("modeldata")) {
-  data(solubility_test, package = "modeldata")
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# example code
+data(solubility_test, package = "modeldata")
 
-  library(ggplot2)
-  p <- ggplot(solubility_test, aes(x = solubility, y = prediction)) +
-    geom_abline(lty = 2) +
-    geom_point(alpha = 0.5)
+library(ggplot2)
+p <- ggplot(solubility_test, aes(x = solubility, y = prediction)) +
+  geom_abline(lty = 2) +
+  geom_point(alpha = 0.5)
 
-  p
+p
 
-  p + coord_fixed()
+p + coord_fixed()
 
-  p + coord_obs_pred()
-}
+p + coord_obs_pred()
+\dontshow{\}) # examplesIf}
 }

--- a/man/coord_obs_pred.Rd
+++ b/man/coord_obs_pred.Rd
@@ -30,16 +30,18 @@ For regression models, \code{coord_obs_pred()} can be used in a ggplot to make t
 x- and y-axes have the same exact scale along with an aspect ratio of one.
 }
 \examples{
-data(solubility_test, package = "modeldata")
+if (rlang::is_installed("modeldata")) {
+  data(solubility_test, package = "modeldata")
 
-library(ggplot2)
-p <- ggplot(solubility_test, aes(x = solubility, y = prediction)) +
-  geom_abline(lty = 2) +
-  geom_point(alpha = 0.5)
+  library(ggplot2)
+  p <- ggplot(solubility_test, aes(x = solubility, y = prediction)) +
+    geom_abline(lty = 2) +
+    geom_point(alpha = 0.5)
 
-p
+  p
 
-p + coord_fixed()
+  p + coord_fixed()
 
-p + coord_obs_pred()
+  p + coord_obs_pred()
+}
 }

--- a/man/extract-tune.Rd
+++ b/man/extract-tune.Rd
@@ -73,42 +73,44 @@ estimated for objects produced by \code{\link[=last_fit]{last_fit()}}.
 These functions supersede \code{extract_model()}.
 }
 \examples{
-if (rlang::is_installed("splines2")) {
-  library(recipes)
-  library(rsample)
-  library(parsnip)
+\dontshow{if (rlang::is_installed("splines2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# example code
 
-  set.seed(6735)
-  tr_te_split <- initial_split(mtcars)
+library(recipes)
+library(rsample)
+library(parsnip)
 
-  spline_rec <- recipe(mpg ~ ., data = mtcars) \%>\%
-    step_spline_natural(disp)
+set.seed(6735)
+tr_te_split <- initial_split(mtcars)
 
-  lin_mod <- linear_reg() \%>\%
-    set_engine("lm")
+spline_rec <- recipe(mpg ~ ., data = mtcars) \%>\%
+  step_spline_natural(disp)
 
-  spline_res <- last_fit(lin_mod, spline_rec, split = tr_te_split)
+lin_mod <- linear_reg() \%>\%
+  set_engine("lm")
 
-  extract_preprocessor(spline_res)
+spline_res <- last_fit(lin_mod, spline_rec, split = tr_te_split)
 
-  # The `spec` is the parsnip spec before it has been fit.
-  # The `fit` is the fitted parsnip model.
-  extract_spec_parsnip(spline_res)
-  extract_fit_parsnip(spline_res)
-  extract_fit_engine(spline_res)
+extract_preprocessor(spline_res)
 
-  # The mold is returned from `hardhat::mold()`, and contains the
-  # predictors, outcomes, and information about the preprocessing
-  # for use on new data at `predict()` time.
-  extract_mold(spline_res)
+# The `spec` is the parsnip spec before it has been fit.
+# The `fit` is the fitted parsnip model.
+extract_spec_parsnip(spline_res)
+extract_fit_parsnip(spline_res)
+extract_fit_engine(spline_res)
 
-  # A useful shortcut is to extract the fitted recipe from the workflow
+# The mold is returned from `hardhat::mold()`, and contains the
+# predictors, outcomes, and information about the preprocessing
+# for use on new data at `predict()` time.
+extract_mold(spline_res)
+
+# A useful shortcut is to extract the fitted recipe from the workflow
+extract_recipe(spline_res)
+
+# That is identical to
+identical(
+  extract_mold(spline_res)$blueprint$recipe,
   extract_recipe(spline_res)
-
-  # That is identical to
-  identical(
-    extract_mold(spline_res)$blueprint$recipe,
-    extract_recipe(spline_res)
- )
-}
+)
+\dontshow{\}) # examplesIf}
 }

--- a/man/extract-tune.Rd
+++ b/man/extract-tune.Rd
@@ -73,40 +73,42 @@ estimated for objects produced by \code{\link[=last_fit]{last_fit()}}.
 These functions supersede \code{extract_model()}.
 }
 \examples{
-library(recipes)
-library(rsample)
-library(parsnip)
+if (rlang::is_installed("splines2")) {
+  library(recipes)
+  library(rsample)
+  library(parsnip)
 
-set.seed(6735)
-tr_te_split <- initial_split(mtcars)
+  set.seed(6735)
+  tr_te_split <- initial_split(mtcars)
 
-spline_rec <- recipe(mpg ~ ., data = mtcars) \%>\%
-  step_spline_natural(disp)
+  spline_rec <- recipe(mpg ~ ., data = mtcars) \%>\%
+    step_spline_natural(disp)
 
-lin_mod <- linear_reg() \%>\%
-  set_engine("lm")
+  lin_mod <- linear_reg() \%>\%
+    set_engine("lm")
 
-spline_res <- last_fit(lin_mod, spline_rec, split = tr_te_split)
+  spline_res <- last_fit(lin_mod, spline_rec, split = tr_te_split)
 
-extract_preprocessor(spline_res)
+  extract_preprocessor(spline_res)
 
-# The `spec` is the parsnip spec before it has been fit.
-# The `fit` is the fitted parsnip model.
-extract_spec_parsnip(spline_res)
-extract_fit_parsnip(spline_res)
-extract_fit_engine(spline_res)
+  # The `spec` is the parsnip spec before it has been fit.
+  # The `fit` is the fitted parsnip model.
+  extract_spec_parsnip(spline_res)
+  extract_fit_parsnip(spline_res)
+  extract_fit_engine(spline_res)
 
-# The mold is returned from `hardhat::mold()`, and contains the
-# predictors, outcomes, and information about the preprocessing
-# for use on new data at `predict()` time.
-extract_mold(spline_res)
+  # The mold is returned from `hardhat::mold()`, and contains the
+  # predictors, outcomes, and information about the preprocessing
+  # for use on new data at `predict()` time.
+  extract_mold(spline_res)
 
-# A useful shortcut is to extract the fitted recipe from the workflow
-extract_recipe(spline_res)
-
-# That is identical to
-identical(
-  extract_mold(spline_res)$blueprint$recipe,
+  # A useful shortcut is to extract the fitted recipe from the workflow
   extract_recipe(spline_res)
-)
+
+  # That is identical to
+  identical(
+    extract_mold(spline_res)$blueprint$recipe,
+    extract_recipe(spline_res)
+ )
+}
 }

--- a/man/fit_best.Rd
+++ b/man/fit_best.Rd
@@ -109,39 +109,37 @@ via \link[=extract_workflow.tune_results]{extract_workflow()}.
 }
 
 \examples{
-\dontshow{if (tune:::should_run_examples()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples() & rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)
 library(dplyr)
 
-if (rlang::is_installed("modeldata")) {
-  data(meats, package = "modeldata")
-  meats <- meats \%>\% select(-water, -fat)
+data(meats, package = "modeldata")
+meats <- meats \%>\% select(-water, -fat)
 
-  set.seed(1)
-  meat_split <- initial_split(meats)
-  meat_train <- training(meat_split)
-  meat_test  <- testing(meat_split)
+set.seed(1)
+meat_split <- initial_split(meats)
+meat_train <- training(meat_split)
+meat_test  <- testing(meat_split)
 
-  set.seed(2)
-  meat_rs <- vfold_cv(meat_train, v = 10)
+set.seed(2)
+meat_rs <- vfold_cv(meat_train, v = 10)
 
-  pca_rec <-
-    recipe(protein ~ ., data = meat_train) \%>\%
-    step_normalize(all_numeric_predictors()) \%>\%
-    step_pca(all_numeric_predictors(), num_comp = tune())
+pca_rec <-
+  recipe(protein ~ ., data = meat_train) \%>\%
+  step_normalize(all_numeric_predictors()) \%>\%
+  step_pca(all_numeric_predictors(), num_comp = tune())
 
-  knn_mod <- nearest_neighbor(neighbors = tune()) \%>\% set_mode("regression")
+knn_mod <- nearest_neighbor(neighbors = tune()) \%>\% set_mode("regression")
 
-  ctrl <- control_grid(save_workflow = TRUE)
+ctrl <- control_grid(save_workflow = TRUE)
 
-  set.seed(128)
-  knn_pca_res <-
-    tune_grid(knn_mod, pca_rec, resamples = meat_rs, grid = 10, control = ctrl)
+set.seed(128)
+knn_pca_res <-
+  tune_grid(knn_mod, pca_rec, resamples = meat_rs, grid = 10, control = ctrl)
 
-  knn_fit <- fit_best(knn_pca_res, verbose = TRUE)
-  predict(knn_fit, meat_test)
-}
+knn_fit <- fit_best(knn_pca_res, verbose = TRUE)
+predict(knn_fit, meat_test)
 \dontshow{\}) # examplesIf}
 }

--- a/man/fit_best.Rd
+++ b/man/fit_best.Rd
@@ -115,31 +115,33 @@ library(rsample)
 library(parsnip)
 library(dplyr)
 
-data(meats, package = "modeldata")
-meats <- meats \%>\% select(-water, -fat)
+if (rlang::is_installed("modeldata")) {
+  data(meats, package = "modeldata")
+  meats <- meats \%>\% select(-water, -fat)
 
-set.seed(1)
-meat_split <- initial_split(meats)
-meat_train <- training(meat_split)
-meat_test  <- testing(meat_split)
+  set.seed(1)
+  meat_split <- initial_split(meats)
+  meat_train <- training(meat_split)
+  meat_test  <- testing(meat_split)
 
-set.seed(2)
-meat_rs <- vfold_cv(meat_train, v = 10)
+  set.seed(2)
+  meat_rs <- vfold_cv(meat_train, v = 10)
 
-pca_rec <-
-  recipe(protein ~ ., data = meat_train) \%>\%
-  step_normalize(all_numeric_predictors()) \%>\%
-  step_pca(all_numeric_predictors(), num_comp = tune())
+  pca_rec <-
+    recipe(protein ~ ., data = meat_train) \%>\%
+    step_normalize(all_numeric_predictors()) \%>\%
+    step_pca(all_numeric_predictors(), num_comp = tune())
 
-knn_mod <- nearest_neighbor(neighbors = tune()) \%>\% set_mode("regression")
+  knn_mod <- nearest_neighbor(neighbors = tune()) \%>\% set_mode("regression")
 
-ctrl <- control_grid(save_workflow = TRUE)
+  ctrl <- control_grid(save_workflow = TRUE)
 
-set.seed(128)
-knn_pca_res <-
-  tune_grid(knn_mod, pca_rec, resamples = meat_rs, grid = 10, control = ctrl)
+  set.seed(128)
+  knn_pca_res <-
+    tune_grid(knn_mod, pca_rec, resamples = meat_rs, grid = 10, control = ctrl)
 
-knn_fit <- fit_best(knn_pca_res, verbose = TRUE)
-predict(knn_fit, meat_test)
+  knn_fit <- fit_best(knn_pca_res, verbose = TRUE)
+  predict(knn_fit, meat_test)
+}
 \dontshow{\}) # examplesIf}
 }

--- a/man/fit_resamples.Rd
+++ b/man/fit_resamples.Rd
@@ -206,7 +206,7 @@ grid has a separate R object associated with it.
 }
 
 \examples{
-\dontshow{if (tune:::should_run_examples()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples() & rlang::is_installed("splines2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)

--- a/man/int_pctl.tune_results.Rd
+++ b/man/int_pctl.tune_results.Rd
@@ -77,24 +77,26 @@ computations can take a long time unless the times are filtered with the
 \code{eval_time} argument.
 }
 \examples{
-\dontshow{if (!tune:::is_cran_check() & tune:::should_run_examples("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-data(Sacramento, package = "modeldata")
-library(rsample)
-library(parsnip)
+\dontshow{if (!tune:::is_cran_check()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+if (rlang::is_installed("modeldata")) {
+  data(Sacramento, package = "modeldata")
+  library(rsample)
+  library(parsnip)
 
-set.seed(13)
-sac_rs <- vfold_cv(Sacramento)
+  set.seed(13)
+  sac_rs <- vfold_cv(Sacramento)
 
-lm_res <-
-  linear_reg() \%>\%
-  fit_resamples(
-    log10(price) ~ beds + baths + sqft + type + latitude + longitude,
-    resamples = sac_rs,
-    control = control_resamples(save_pred = TRUE)
-  )
+  lm_res <-
+    linear_reg() \%>\%
+    fit_resamples(
+      log10(price) ~ beds + baths + sqft + type + latitude + longitude,
+      resamples = sac_rs,
+      control = control_resamples(save_pred = TRUE)
+    )
 
-set.seed(31)
-int_pctl(lm_res)
+  set.seed(31)
+  int_pctl(lm_res)
+}
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/last_fit.Rd
+++ b/man/last_fit.Rd
@@ -152,7 +152,7 @@ via \link[=extract_workflow.tune_results]{extract_workflow()}.
 }
 
 \examples{
-\dontshow{if (tune:::should_run_examples()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples() & rlang::is_installed("splines2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)

--- a/man/merge.recipe.Rd
+++ b/man/merge.recipe.Rd
@@ -26,7 +26,7 @@ A tibble with a column \code{x} that has as many rows as were in \code{y}.
 \pkg{parsnip} model or recipe.
 }
 \examples{
-\dontshow{if (tune:::should_run_examples(suggests = c("xgboost", "modeldata"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples(suggests = c("xgboost", "modeldata", "splines2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(tibble)
 library(recipes)
 library(parsnip)

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -275,7 +275,7 @@ the largest time corresponding to an event are constant (or \code{NA}).
 }
 
 \examples{
-\dontshow{if (tune:::should_run_examples(suggests = "kernlab")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (tune:::should_run_examples(suggests = "kernlab") & rlang::is_installed("splines2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(recipes)
 library(rsample)
 library(parsnip)

--- a/tests/testthat/_snaps/bayes.md
+++ b/tests/testthat/_snaps/bayes.md
@@ -392,13 +392,13 @@
       cars_res <- tune_bayes(svm_mod, preprocessor = rec, resamples = data_folds)
     Message
       x Fold1: preprocessor 1/1:
-        Error in `step_bs()`:
-        Caused by error in `if (...) NULL`:
-        ! missing value where TRUE/FALSE needed
+        Error in `step_spline_b()`:
+        Caused by error in `glue()`:
+        ! Expecting '}'
       x Fold2: preprocessor 1/1:
-        Error in `step_bs()`:
-        Caused by error in `if (...) NULL`:
-        ! missing value where TRUE/FALSE needed
+        Error in `step_spline_b()`:
+        Caused by error in `glue()`:
+        ! Expecting '}'
     Condition
       Warning:
       All models failed. Run `show_notes(.Last.tune.result)` for more information.

--- a/tests/testthat/_snaps/checks.md
+++ b/tests/testthat/_snaps/checks.md
@@ -92,6 +92,22 @@
       Error in `tune:::check_workflow()`:
       ! A parsnip model is required.
 
+# errors informatively when needed package isn't installed
+
+    Code
+      check_workflow(stan_wflow)
+    Condition
+      Error:
+      ! Package install is required for rstanarm.
+
+---
+
+    Code
+      fit_resamples(stan_wflow, rsample::bootstraps(mtcars))
+    Condition
+      Error in `fit_resamples()`:
+      ! Package install is required for rstanarm.
+
 # workflow objects (will not tune, tidymodels/tune#548)
 
     Code

--- a/tests/testthat/_snaps/grid.md
+++ b/tests/testthat/_snaps/grid.md
@@ -7,13 +7,13 @@
       }, save_pred = TRUE))
     Message
       x Fold1: preprocessor 1/1:
-        Error in `step_bs()`:
-        Caused by error in `if (...) NULL`:
-        ! missing value where TRUE/FALSE needed
+        Error in `step_spline_b()`:
+        Caused by error in `glue()`:
+        ! Expecting '}'
       x Fold2: preprocessor 1/1:
-        Error in `step_bs()`:
-        Caused by error in `if (...) NULL`:
-        ! missing value where TRUE/FALSE needed
+        Error in `step_spline_b()`:
+        Caused by error in `glue()`:
+        ! Expecting '}'
     Condition
       Warning:
       All models failed. Run `show_notes(.Last.tune.result)` for more information.

--- a/tests/testthat/_snaps/resample.md
+++ b/tests/testthat/_snaps/resample.md
@@ -4,13 +4,13 @@
       result <- fit_resamples(lin_mod, rec, folds, control = control)
     Message
       x Fold1: preprocessor 1/1:
-        Error in `step_ns()`:
-        Caused by error in `if (...) NULL`:
-        ! missing value where TRUE/FALSE needed
+        Error in `step_spline_natural()`:
+        Caused by error in `glue()`:
+        ! Expecting '}'
       x Fold2: preprocessor 1/1:
-        Error in `step_ns()`:
-        Caused by error in `if (...) NULL`:
-        ! missing value where TRUE/FALSE needed
+        Error in `step_spline_natural()`:
+        Caused by error in `glue()`:
+        ! Expecting '}'
     Condition
       Warning:
       All models failed. Run `show_notes(.Last.tune.result)` for more information.

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -1,8 +1,10 @@
-data(two_class_dat, package = "modeldata")
-
-# ------------------------------------------------------------------------------
 
 test_that("augment fit_resamples", {
+  skip_if_not_installed("modeldata")
+  data(two_class_dat, package = "modeldata")
+
+  # ------------------------------------------------------------------------------
+
   lr_spec <- parsnip::logistic_reg() %>% parsnip::set_engine("glm")
 
   set.seed(1)
@@ -40,6 +42,11 @@ test_that("augment fit_resamples", {
 
 
 test_that("augment fit_resamples", {
+  skip_if_not_installed("modeldata")
+  data(two_class_dat, package = "modeldata")
+
+  # ------------------------------------------------------------------------------
+
   skip_if(new_rng_snapshots)
   lr_spec <- parsnip::logistic_reg() %>% parsnip::set_engine("glm")
 
@@ -152,6 +159,11 @@ test_that("augment tune_grid", {
 # ------------------------------------------------------------------------------
 
 test_that("augment last_fit", {
+  skip_if_not_installed("modeldata")
+  data(two_class_dat, package = "modeldata")
+
+  # ------------------------------------------------------------------------------
+
   lr_spec <- parsnip::logistic_reg() %>% parsnip::set_engine("glm")
   set.seed(1)
   split <- rsample::initial_split(two_class_dat)

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -222,6 +222,8 @@ test_that("coord_obs_pred", {
 })
 
 test_that("1D regular grid x labels", {
+  skip_if_not_installed("kernlab")
+
   set.seed(1)
   res <-
     parsnip::svm_rbf(cost = tune()) %>%
@@ -334,6 +336,7 @@ test_that("plot_perf_vs_iter with fairness metrics (#773)", {
 
 test_that("regular grid plot", {
   skip_if_not_installed("ggplot2", minimum_version = "3.5.0")
+  skip_if_not_installed("kernlab")
 
   svm_spec <-
     parsnip::svm_rbf(cost = tune()) %>%
@@ -357,6 +360,7 @@ test_that("regular grid plot", {
 })
 
 test_that("evaluation time warning for non-survival model", {
+  skip_if_not_installed("kernlab")
 
   set.seed(1)
   res <-

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -193,6 +193,8 @@ test_that("regular grid plot", {
 
 
 test_that("coord_obs_pred", {
+  skip_if_not_installed("modeldata")
+
   data(solubility_test, package = "modeldata")
 
   p <-

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -234,6 +234,7 @@ test_that("1D regular grid x labels", {
 test_that("plot_regular_grid with fairness metrics (#773)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+  skip_if_not_installed("kknn")
 
   knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
   mtcars_fair <- mtcars
@@ -266,6 +267,7 @@ test_that("plot_regular_grid with fairness metrics (#773)", {
 test_that("plot_marginals with fairness metrics (#773)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+  skip_if_not_installed("kknn")
 
   knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune(), weight_func = tune())
   mtcars_fair <- mtcars
@@ -298,6 +300,7 @@ test_that("plot_marginals with fairness metrics (#773)", {
 test_that("plot_perf_vs_iter with fairness metrics (#773)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+  skip_if_not_installed("kknn")
 
   knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
   mtcars_fair <- mtcars

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -547,6 +547,8 @@ test_that("missing performance values", {
 
 # ------------------------------------------------------------------------------
 test_that("tune_bayes() output for `iter` edge cases (#721)", {
+  skip_if_not_installed("kknn")
+
   # for `iter = 0`, ought to match `tune_grid()`
   boots <- rsample::bootstraps(mtcars)
   wf <-

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -113,6 +113,8 @@ test_that("tune recipe only", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model only (with recipe)", {
+  skip_if_not_installed("kernlab")
+
   set.seed(4400)
   wflow <- workflow() %>%
     add_recipe(rec_no_tune_1) %>%
@@ -142,6 +144,8 @@ test_that("tune model only (with recipe)", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model only (with variables)", {
+  skip_if_not_installed("kernlab")
+
   set.seed(4400)
 
   wflow <- workflow() %>%
@@ -176,6 +180,8 @@ test_that("tune model only (with variables)", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model only (with recipe, multi-predict)", {
+  skip_if_not_installed("kernlab")
+
   skip_on_cran()
 
   set.seed(4400)
@@ -210,6 +216,8 @@ test_that("tune model only (with recipe, multi-predict)", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model and recipe", {
+  skip_if_not_installed("kernlab")
+
   set.seed(4400)
   wflow <- workflow() %>%
     add_recipe(rec_tune_1) %>%
@@ -242,6 +250,7 @@ test_that("tune model and recipe", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model and recipe (multi-predict)", {
+  skip_if_not_installed("kernlab")
   skip_on_cran()
 
   set.seed(4400)
@@ -325,6 +334,7 @@ test_that("tune recipe only - failure in recipe is caught elegantly", {
 
 test_that("tune model only - failure in recipe is caught elegantly", {
   skip_if_not_installed("splines2")
+  skip_if_not_installed("kernlab")
 
   set.seed(7898)
   data_folds <- rsample::vfold_cv(mtcars, v = 2)
@@ -345,6 +355,8 @@ test_that("tune model only - failure in recipe is caught elegantly", {
 })
 
 test_that("tune model only - failure in formula is caught elegantly", {
+  skip_if_not_installed("kernlab")
+
   set.seed(7898)
   data_folds <- rsample::vfold_cv(mtcars, v = 2)
 
@@ -367,6 +379,7 @@ test_that("tune model only - failure in formula is caught elegantly", {
 test_that("tune model and recipe - failure in recipe is caught elegantly", {
   skip("test is not implemented for tune_bayes()")
   skip_if_not_installed("splines2")
+  skip_if_not_installed("kernlab")
 
   # With tune_grid() this tests for NA values in the grid.
   # This is not applicable for tune_bayes().
@@ -423,6 +436,8 @@ test_that("argument order gives an error for recipes", {
 })
 
 test_that("argument order gives an error for formula", {
+  skip_if_not_installed("kernlab")
+
   expect_snapshot(error = TRUE, {
     tune_bayes(
       mpg ~ .,

--- a/tests/testthat/test-bayes.R
+++ b/tests/testthat/test-bayes.R
@@ -274,6 +274,7 @@ test_that("tune model and recipe (multi-predict)", {
 
 test_that("tune recipe only - failure in recipe is caught elegantly", {
   skip("test is not implemented for tune_bayes()")
+  skip_if_not_installed("splines2")
 
   # With tune_grid() this tests for NA values in the grid.
   # This is not applicable for tune_bayes().
@@ -282,7 +283,7 @@ test_that("tune recipe only - failure in recipe is caught elegantly", {
   data_folds <- rsample::vfold_cv(mtcars, v = 2)
 
   rec <- recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_bs(disp, deg_free = tune())
+    recipes::step_spline_b(disp, deg_free = tune())
 
   model <- parsnip::linear_reg(mode = "regression") %>%
     parsnip::set_engine("lm")
@@ -323,12 +324,14 @@ test_that("tune recipe only - failure in recipe is caught elegantly", {
 })
 
 test_that("tune model only - failure in recipe is caught elegantly", {
+  skip_if_not_installed("splines2")
+
   set.seed(7898)
   data_folds <- rsample::vfold_cv(mtcars, v = 2)
 
   # NA values not allowed in recipe
   rec <- recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_bs(disp, deg_free = NA_real_)
+    recipes::step_spline_b(disp, deg_free = NA_real_)
 
   expect_snapshot({
     cars_res <- tune_bayes(
@@ -363,6 +366,7 @@ test_that("tune model only - failure in formula is caught elegantly", {
 
 test_that("tune model and recipe - failure in recipe is caught elegantly", {
   skip("test is not implemented for tune_bayes()")
+  skip_if_not_installed("splines2")
 
   # With tune_grid() this tests for NA values in the grid.
   # This is not applicable for tune_bayes().
@@ -371,7 +375,7 @@ test_that("tune model and recipe - failure in recipe is caught elegantly", {
   data_folds <- rsample::vfold_cv(mtcars, v = 2)
 
   rec <- recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_bs(disp, deg_free = tune())
+    recipes::step_spline_b(disp, deg_free = tune())
 
 
   # NA values not allowed in recipe
@@ -501,6 +505,7 @@ test_that("too few starting values", {
 test_that("missing performance values", {
   skip_if(new_rng_snapshots)
   skip_if(packageVersion("dplyr") < "1.1.1")
+  skip_if_not_installed("modeldata")
 
   data(ames, package = "modeldata")
 

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -15,6 +15,7 @@ test_that("grid objects", {
   data("Chicago", package = "modeldata")
   skip_if_not_installed("modeldata")
   skip_if_not_installed("splines2")
+  skip_if_not_installed("kernlab")
 
   spline_rec <-
     recipes::recipe(ridership ~ ., data = head(Chicago)) %>%
@@ -371,6 +372,8 @@ test_that("Bayes control objects", {
 # ------------------------------------------------------------------------------
 
 test_that("initial values", {
+  skip_if_not_installed("kernlab")
+
   svm_mod <-
     parsnip::svm_rbf(cost = tune()) %>%
     parsnip::set_engine("kernlab") %>%

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -12,11 +12,11 @@ test_that("rsample objects", {
 # ------------------------------------------------------------------------------
 
 test_that("grid objects", {
-  data("Chicago", package = "modeldata")
   skip_if_not_installed("modeldata")
   skip_if_not_installed("splines2")
   skip_if_not_installed("kernlab")
-
+  data("Chicago", package = "modeldata")
+  data("Chicago", package = "modeldata")
   spline_rec <-
     recipes::recipe(ridership ~ ., data = head(Chicago)) %>%
     recipes::step_date(date) %>%

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -25,7 +25,7 @@ test_that("grid objects", {
     recipes::step_other(recipes::all_nominal(), threshold = tune()) %>%
     recipes::step_dummy(recipes::all_nominal()) %>%
     recipes::step_normalize(recipes::all_numeric_predictors()) %>%
-    recipes::step_splines_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
+    recipes::step_spline_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
 
   glmn <- parsnip::linear_reg(penalty = tune(), mixture = tune()) %>%
     parsnip::set_engine("glmnet")

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -13,6 +13,8 @@ test_that("rsample objects", {
 
 test_that("grid objects", {
   data("Chicago", package = "modeldata")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("splines2")
 
   spline_rec <-
     recipes::recipe(ridership ~ ., data = head(Chicago)) %>%
@@ -23,7 +25,7 @@ test_that("grid objects", {
     recipes::step_other(recipes::all_nominal(), threshold = tune()) %>%
     recipes::step_dummy(recipes::all_nominal()) %>%
     recipes::step_normalize(recipes::all_numeric_predictors()) %>%
-    recipes::step_bs(recipes::all_predictors(), deg_free = tune(), degree = tune())
+    recipes::step_splines_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
 
   glmn <- parsnip::linear_reg(penalty = tune(), mixture = tune()) %>%
     parsnip::set_engine("glmnet")
@@ -88,10 +90,12 @@ test_that("grid objects", {
 })
 
 test_that("Unknown `grid` columns are caught", {
+  skip_if_not_installed("splines2")
+
   data <- data.frame(x = 1:2, y = 1:2)
 
   rec <- recipes::recipe(y ~ x, data = data)
-  rec <- recipes::step_bs(rec, x, deg_free = tune())
+  rec <- recipes::step_spline_b(rec, x, deg_free = tune())
   rec <- recipes::step_pca(rec, x, num_comp = tune())
 
   model <- parsnip::linear_reg()
@@ -109,10 +113,12 @@ test_that("Unknown `grid` columns are caught", {
 })
 
 test_that("Missing required `grid` columns are caught", {
+  skip_if_not_installed("splines2")
+
   data <- data.frame(x = 1:2, y = 1:2)
 
   rec <- recipes::recipe(y ~ x, data = data)
-  rec <- recipes::step_bs(rec, x, deg_free = tune())
+  rec <- recipes::step_spline_b(rec, x, deg_free = tune())
   rec <- recipes::step_pca(rec, x, num_comp = tune())
 
   model <- parsnip::linear_reg()
@@ -200,10 +206,11 @@ test_that("errors informatively when needed package isn't installed", {
 
 test_that("workflow objects (will not tune, tidymodels/tune#548)", {
   skip_if_not_installed("glmnet")
+  skip_if_not_installed("splines2")
 
   # one recipe without tuning, one with:
   rec_bare <- recipes::recipe(ridership ~ ., data = head(Chicago, 30))
-  rec_tune <- rec_bare %>% recipes::step_ns(temp_max, deg_free = tune())
+  rec_tune <- rec_bare %>% recipes::step_spline_natural(temp_max, deg_free = tune())
 
   # well-defined:
   lr_lm_0 <- parsnip::linear_reg()
@@ -261,6 +268,8 @@ test_that("workflow objects (will not tune, tidymodels/tune#548)", {
 # ------------------------------------------------------------------------------
 
 test_that("yardstick objects", {
+  skip_if_not_installed("splines2")
+
   spline_rec <-
     recipes::recipe(ridership ~ ., data = head(Chicago)) %>%
     recipes::step_date(date) %>%
@@ -270,7 +279,7 @@ test_that("yardstick objects", {
     recipes::step_other(recipes::all_nominal(), threshold = tune()) %>%
     recipes::step_dummy(recipes::all_nominal()) %>%
     recipes::step_normalize(recipes::all_numeric_predictors()) %>%
-    recipes::step_bs(recipes::all_predictors(), deg_free = tune(), degree = tune())
+    recipes::step_spline_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
 
   glmn <- parsnip::linear_reg(penalty = tune(), mixture = tune()) %>%
     parsnip::set_engine("glmnet")
@@ -429,9 +438,11 @@ test_that("validation helpers", {
 # ------------------------------------------------------------------------------
 
 test_that("check parameter finalization", {
+  skip_if_not_installed("splines2")
+
   rec <-
     recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_ns(disp, deg_free = 3)
+    recipes::step_spline_natural(disp, deg_free = 3)
   rec_tune <- rec %>% recipes::step_pca(recipes::all_predictors(), num_comp = tune())
   f <- mpg ~ .
   rf1 <-

--- a/tests/testthat/test-collect.R
+++ b/tests/testthat/test-collect.R
@@ -333,6 +333,8 @@ test_that("`pivot_metrics()`, iterative search, typical metrics, summarized", {
 })
 
 test_that("`pivot_metrics()`, resampled fits, fairness metrics, summarized", {
+  skip_if_not_installed("kknn")
+
   mtcars_fair <- mtcars
   mtcars_fair$vs <- as.factor(mtcars_fair$vs)
   mtcars_fair$cyl <- as.factor(mtcars_fair$cyl)

--- a/tests/testthat/test-collect.R
+++ b/tests/testthat/test-collect.R
@@ -98,6 +98,9 @@ test_that("`collect_predictions()`, un-averaged", {
 # ------------------------------------------------------------------------------
 
 test_that("bad filter grid", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kernlab")
+
   expect_snapshot(
     error = TRUE,
     collect_predictions(svm_tune, parameters = tibble(wrong = "value"))
@@ -150,6 +153,9 @@ test_that("classification class predictions, averaged", {
 # ------------------------------------------------------------------------------
 
 test_that("classification class and prob predictions, averaged", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kernlab")
+
   all_res <- collect_predictions(svm_tune)
   res <- collect_predictions(svm_tune, summarize = TRUE)
   expect_equal(nrow(res), nrow(two_class_dat) * nrow(svm_grd))

--- a/tests/testthat/test-collect.R
+++ b/tests/testthat/test-collect.R
@@ -130,6 +130,9 @@ test_that("regression predictions, averaged", {
 # ------------------------------------------------------------------------------
 
 test_that("classification class predictions, averaged", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kernlab")
+
   all_res <- collect_predictions(svm_tune_class)
   res <- collect_predictions(svm_tune_class, summarize = TRUE)
   expect_equal(nrow(res), nrow(two_class_dat) * nrow(svm_grd))

--- a/tests/testthat/test-collect.R
+++ b/tests/testthat/test-collect.R
@@ -1,4 +1,4 @@
-if (rlang::is_installed(c("modeldata", "splines2"))) {
+if (rlang::is_installed(c("modeldata", "splines2", "kernlab"))) {
 
   data(two_class_dat, package = "modeldata")
 

--- a/tests/testthat/test-compute_metrics.R
+++ b/tests/testthat/test-compute_metrics.R
@@ -118,6 +118,7 @@ test_that("`metrics` argument works (numeric metrics)", {
 test_that("`metrics` argument works (compatible class metric types)", {
   skip_on_cran()
   skip_if_not_installed("kknn")
+  skip_if_not_installed("modeldata")
 
   library(parsnip)
   library(rsample)
@@ -186,6 +187,7 @@ test_that("`metrics` argument works (compatible class metric types)", {
 test_that("`metrics` argument works (differing class metric types)", {
   skip_on_cran()
   skip_if_not_installed("kknn")
+  skip_if_not_installed("modeldata")
 
   library(parsnip)
   library(rsample)

--- a/tests/testthat/test-eval-time-args.R
+++ b/tests/testthat/test-eval-time-args.R
@@ -61,6 +61,8 @@ test_that("eval time are checked for classification models", {
   library(workflows)
   library(yardstick)
   library(rsample)
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
 
   data(two_class_dat, package = "modeldata")
   wflow <- workflow(Class ~ A + B, logistic_reg())

--- a/tests/testthat/test-eval-time-args.R
+++ b/tests/testthat/test-eval-time-args.R
@@ -1,4 +1,6 @@
 test_that("eval time inputs are checked for regression models", {
+  skip_if_not_installed("kknn")
+
   library(parsnip)
   library(workflows)
   library(yardstick)

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -1,5 +1,7 @@
 
 test_that("tune recipe only", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
   set.seed(363)
   mt_folds <- rsample::vfold_cv(mtcars, v = 5)
@@ -29,6 +31,8 @@ test_that("tune recipe only", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model only", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
   set.seed(363)
   mt_folds <- rsample::vfold_cv(mtcars, v = 5)
@@ -154,6 +158,8 @@ test_that("mis-specified extract function", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model and recipe", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
   set.seed(363)
   mt_folds <- rsample::vfold_cv(mtcars, v = 5)

--- a/tests/testthat/test-finalization.R
+++ b/tests/testthat/test-finalization.R
@@ -1,5 +1,6 @@
 test_that("cannot finalize with recipe parameters", {
   skip_if_not_installed("randomForest")
+  skip_if_not_installed("splines2")
 
   set.seed(21983)
   rs <- rsample::vfold_cv(mtcars)
@@ -11,11 +12,11 @@ test_that("cannot finalize with recipe parameters", {
 
   rec_1 <-
     recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_ns(disp, deg_free = tune())
+    recipes::step_spline_natural(disp, deg_free = tune())
 
   rec_2 <-
     recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_ns(disp, deg_free = 3)
+    recipes::step_spline_natural(disp, deg_free = 3)
 
   expect_snapshot(error = TRUE, {
     mod_1 %>% tune_grid(rec_1, resamples = rs, grid = 3)
@@ -31,6 +32,8 @@ test_that("cannot finalize with recipe parameters", {
 
 test_that("skip error if grid is supplied", {
   skip_if_not_installed("randomForest")
+  skip_if_not_installed("splines2")
+
 
   set.seed(21983)
   rs <- rsample::vfold_cv(mtcars)
@@ -42,7 +45,7 @@ test_that("skip error if grid is supplied", {
 
   rec_1 <-
     recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_ns(disp, deg_free = tune())
+    recipes::step_spline_natural(disp, deg_free = tune())
 
   grid <- tibble::tibble(mtry = 1:3, deg_free = c(3, 3, 4), min_n = c(5, 4, 6))
 
@@ -55,13 +58,16 @@ test_that("skip error if grid is supplied", {
 
 
 test_that("finalize recipe step with multiple tune parameters", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("splines2")
+
   data(biomass, package = "modeldata")
 
   model_spec <- parsnip::linear_reg() %>%
     parsnip::set_engine("lm")
 
   rec <- recipes::recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur, data = biomass) %>%
-    recipes::step_bs(carbon, hydrogen, deg_free = tune(), degree = tune())
+    recipes::step_spline_b(carbon, hydrogen, deg_free = tune(), degree = tune())
 
   best <- tibble(deg_free = 2, degree = 1, .config = "Preprocessor1_Model1")
 

--- a/tests/testthat/test-fit_best.R
+++ b/tests/testthat/test-fit_best.R
@@ -1,5 +1,6 @@
 test_that("fit_best", {
   skip_if_not_installed("kknn")
+  skip_if_not_installed("modeldata")
 
   library(recipes)
   library(rsample)

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -427,13 +427,15 @@ test_that('tune model and recipe (parallel_over = "everything")', {
 # ------------------------------------------------------------------------------
 
 test_that("tune recipe only - failure in recipe is caught elegantly", {
+  skip_if_not_installed("splines2")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(7898)
   data_folds <- rsample::vfold_cv(mtcars, v = 2)
 
   rec <- recipe(mpg ~ ., data = mtcars) %>%
-    step_bs(disp, deg_free = tune())
+    step_spline_b(disp, deg_free = tune())
 
   model <- linear_reg(mode = "regression") %>%
     set_engine("lm")
@@ -475,6 +477,8 @@ test_that("tune recipe only - failure in recipe is caught elegantly", {
 })
 
 test_that("tune model only - failure in recipe is caught elegantly", {
+  skip_if_not_installed("splines2")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(7898)
@@ -482,7 +486,7 @@ test_that("tune model only - failure in recipe is caught elegantly", {
 
   # NA values not allowed in recipe
   rec <- recipe(mpg ~ ., data = mtcars) %>%
-    step_bs(disp, deg_free = NA_real_)
+    step_spline_b(disp, deg_free = NA_real_)
 
   cars_grid <- tibble(cost = c(0.01, 0.02))
 
@@ -542,13 +546,15 @@ test_that("tune model only - failure in formula is caught elegantly", {
 })
 
 test_that("tune model and recipe - failure in recipe is caught elegantly", {
+  skip_if_not_installed("splines2")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(7898)
   data_folds <- rsample::vfold_cv(mtcars, v = 2)
 
   rec <- recipe(mpg ~ ., data = mtcars) %>%
-    step_bs(disp, deg_free = tune())
+    step_spline_b(disp, deg_free = tune())
 
 
   # NA values not allowed in recipe

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -99,6 +99,8 @@ test_that("tune model only (with variables)", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model only (with recipe, multi-predict)", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(4400)

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -135,6 +135,7 @@ test_that("tune model only (without recipe, multi-predict. #695)", {
 test_that("tune model only (fairness - include `by` variable as predictor)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+  skip_if_not_installed("kknn")
 
   knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
   mtcars_fair <- mtcars
@@ -175,6 +176,7 @@ test_that("tune model only (fairness - include `by` variable as predictor)", {
 test_that("tune model only (fairness - don't include `by` variable as predictor)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+  skip_if_not_installed("kknn")
 
   knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
   mtcars_fair <- mtcars
@@ -215,6 +217,7 @@ test_that("tune model only (fairness - don't include `by` variable as predictor)
 test_that("tune model only (fairness metrics - evaluate across multiple `by`)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+  skip_if_not_installed("kknn")
 
   knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
   mtcars_fair <- mtcars
@@ -256,6 +259,7 @@ test_that("tune model only (fairness metrics - evaluate across multiple `by`)", 
 test_that("tune model only (fairness - evaluate across multiple `by`, same metric)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+  skip_if_not_installed("kknn")
 
   knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
   mtcars_fair <- mtcars
@@ -298,6 +302,7 @@ test_that("tune model only (fairness - evaluate across multiple `by`, same metri
 test_that("tune model only (fairness - evaluate only fairness metrics)", {
   skip_on_cran()
   skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
+  skip_if_not_installed("kknn")
 
   knn <- parsnip::nearest_neighbor("classification", "kknn", neighbors = tune())
   mtcars_fair <- mtcars

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -1,4 +1,6 @@
 test_that("tune recipe only", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(4400)
@@ -34,6 +36,8 @@ test_that("tune recipe only", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model only (with recipe)", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(4400)
@@ -65,6 +69,8 @@ test_that("tune model only (with recipe)", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model only (with variables)", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(4400)
@@ -341,6 +347,8 @@ test_that("tune model only (fairness - evaluate only fairness metrics)", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model and recipe", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(4400)
@@ -381,6 +389,8 @@ test_that("tune model and recipe", {
 # ------------------------------------------------------------------------------
 
 test_that("tune model and recipe (multi-predict)", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(4400)
@@ -403,6 +413,8 @@ test_that("tune model and recipe (multi-predict)", {
 # ------------------------------------------------------------------------------
 
 test_that('tune model and recipe (parallel_over = "everything")', {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(4400)
@@ -433,6 +445,7 @@ test_that('tune model and recipe (parallel_over = "everything")', {
 
 test_that("tune recipe only - failure in recipe is caught elegantly", {
   skip_if_not_installed("splines2")
+  skip_if_not_installed("kernlab")
 
   helper_objects <- helper_objects_tune()
 
@@ -483,6 +496,7 @@ test_that("tune recipe only - failure in recipe is caught elegantly", {
 
 test_that("tune model only - failure in recipe is caught elegantly", {
   skip_if_not_installed("splines2")
+  skip_if_not_installed("kernlab")
 
   helper_objects <- helper_objects_tune()
 
@@ -519,6 +533,8 @@ test_that("tune model only - failure in recipe is caught elegantly", {
 })
 
 test_that("tune model only - failure in formula is caught elegantly", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(7898)
@@ -552,6 +568,7 @@ test_that("tune model only - failure in formula is caught elegantly", {
 
 test_that("tune model and recipe - failure in recipe is caught elegantly", {
   skip_if_not_installed("splines2")
+  skip_if_not_installed("kernlab")
 
   helper_objects <- helper_objects_tune()
 
@@ -595,6 +612,8 @@ test_that("tune model and recipe - failure in recipe is caught elegantly", {
 })
 
 test_that("argument order gives errors for recipes", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   expect_snapshot(error = TRUE, {
@@ -607,6 +626,8 @@ test_that("argument order gives errors for recipes", {
 })
 
 test_that("argument order gives errors for formula", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   expect_snapshot(error = TRUE, {
@@ -615,6 +636,8 @@ test_that("argument order gives errors for formula", {
 })
 
 test_that("ellipses with tune_grid", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   wflow <- workflow() %>%
@@ -640,6 +663,8 @@ test_that("determining the grid type", {
 
 
 test_that("retain extra attributes", {
+  skip_if_not_installed("kernlab")
+
   helper_objects <- helper_objects_tune()
 
   set.seed(4400)

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -233,6 +233,7 @@ test_that("last_fit() can include validation set for initial_validation_split ob
 
 test_that("can use `last_fit()` with a workflow - postprocessor (requires training)", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("mgcv")
 
   y <- seq(0, 7, .001)
   dat <- data.frame(y = y, x = y + (y-3)^2)

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -149,9 +149,11 @@ test_that("same results of last_fit() and fit() (#300)", {
 
 
 test_that("`last_fit()` when objects need tuning", {
+  skip_if_not_installed("splines2")
+
   options(width = 200, pillar.advice = FALSE, pillar.min_title_chars = Inf)
 
-  rec <- recipe(mpg ~ ., data = mtcars) %>% step_ns(disp, deg_free = tune())
+  rec <- recipe(mpg ~ ., data = mtcars) %>% step_spline_natural(disp, deg_free = tune())
   spec_1 <- linear_reg(penalty = tune()) %>% set_engine("glmnet")
   spec_2 <- linear_reg()
   wflow_1 <- workflow(rec, spec_1)

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -249,6 +249,9 @@ test_that("message_wrap", {
 
 test_that("interactive logger works (fit_resamples, warning + error)", {
   skip_if(allow_parallelism(FALSE), "Will not catalog: parallelism is enabled")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   local_mocked_bindings(
     is_testing = function() {FALSE},
     initialize_catalog = redefer_initialize_catalog(rlang::current_env())
@@ -275,6 +278,9 @@ test_that("interactive logger works (fit_resamples, warning + error)", {
 })
 
 test_that("interactive logger works (fit_resamples, rlang warning + error)", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   skip_if(allow_parallelism(FALSE), "Will not catalog: parallelism is enabled")
   local_mocked_bindings(
     is_testing = function() {FALSE},
@@ -305,6 +311,9 @@ test_that("interactive logger works (fit_resamples, rlang warning + error)", {
 
 test_that("interactive logger works (fit_resamples, multiline)", {
   skip_if(allow_parallelism(FALSE), "Will not catalog: parallelism is enabled")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   local_mocked_bindings(
     is_testing = function() {FALSE},
     initialize_catalog = redefer_initialize_catalog(rlang::current_env())
@@ -335,6 +344,9 @@ test_that("interactive logger works (fit_resamples, multiline)", {
 
 test_that("interactive logger works (fit_resamples, occasional error)", {
   skip_if(allow_parallelism(FALSE), "Will not catalog: parallelism is enabled")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   local_mocked_bindings(
     is_testing = function() {FALSE},
     initialize_catalog = redefer_initialize_catalog(rlang::current_env())
@@ -371,6 +383,9 @@ test_that("interactive logger works (fit_resamples, occasional error)", {
 
 test_that("interactive logger works (fit_resamples, occasional errors)", {
   skip_if(allow_parallelism(FALSE), "Will not catalog: parallelism is enabled")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   local_mocked_bindings(
     is_testing = function() {FALSE},
     initialize_catalog = redefer_initialize_catalog(rlang::current_env())
@@ -423,6 +438,9 @@ test_that("interactive logger works (fit_resamples, occasional errors)", {
 
 test_that("interactive logger works (fit_resamples, many distinct errors)", {
   skip_if(allow_parallelism(FALSE), "Will not catalog: parallelism is enabled")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   local_mocked_bindings(
     is_testing = function() {FALSE},
     initialize_catalog = redefer_initialize_catalog(rlang::current_env())
@@ -460,6 +478,9 @@ test_that("interactive logger works (fit_resamples, many distinct errors)", {
 
 test_that("interactive logger works (tune grid, error)", {
   skip_if(allow_parallelism(FALSE), "Will not catalog: parallelism is enabled")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   local_mocked_bindings(
     is_testing = function() {FALSE},
     initialize_catalog = redefer_initialize_catalog(rlang::current_env())
@@ -487,6 +508,9 @@ test_that("interactive logger works (tune grid, error)", {
 
 test_that("interactive logger works (bayesian, error)", {
   skip_if(allow_parallelism(FALSE), "Will not catalog: parallelism is enabled")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   local_mocked_bindings(
     is_testing = function() {FALSE},
     initialize_catalog = redefer_initialize_catalog(rlang::current_env())

--- a/tests/testthat/test-merge.R
+++ b/tests/testthat/test-merge.R
@@ -143,6 +143,7 @@ test_that("umerged recipe merge", {
 
 
 test_that("model spec merges", {
+  library(parsnip)
   bst_model <-
     parsnip::boost_tree(mode = "classification", trees = tune("funky name \n")) %>%
     parsnip::set_engine("C5.0", rules = tune(), noGlobalPruning = TRUE)

--- a/tests/testthat/test-merge.R
+++ b/tests/testthat/test-merge.R
@@ -1,4 +1,7 @@
 test_that("recipe merges", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("splines2")
+
   data("Chicago", package = "modeldata")
   spline_rec <-
     recipes::recipe(ridership ~ ., data = head(Chicago)) %>%
@@ -9,7 +12,7 @@ test_that("recipe merges", {
     recipes::step_other(recipes::all_nominal(), threshold = tune()) %>%
     recipes::step_dummy(recipes::all_nominal()) %>%
     recipes::step_normalize(recipes::all_numeric_predictors()) %>%
-    recipes::step_bs(recipes::all_predictors(), deg_free = tune(), degree = tune())
+    recipes::step_spline_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
   spline_grid <-
     tibble::tribble(
       ~imputation, ~threshold, ~deg_free, ~degree,
@@ -47,6 +50,9 @@ test_that("recipe merges", {
 })
 
 test_that("partially recipe merge", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("splines2")
+
   data("Chicago", package = "modeldata")
   spline_rec <-
     recipes::recipe(ridership ~ ., data = head(Chicago)) %>%
@@ -57,7 +63,7 @@ test_that("partially recipe merge", {
     recipes::step_other(recipes::all_nominal(), threshold = tune()) %>%
     recipes::step_dummy(recipes::all_nominal()) %>%
     recipes::step_normalize(recipes::all_numeric_predictors()) %>%
-    recipes::step_bs(recipes::all_predictors(), deg_free = tune(), degree = tune())
+    recipes::step_spline_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
   spline_grid <-
     tibble::tribble(
       ~imputation, ~threshold, ~deg_free, ~degree,
@@ -95,6 +101,9 @@ test_that("partially recipe merge", {
 })
 
 test_that("umerged recipe merge", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("splines2")
+
   data("Chicago", package = "modeldata")
   spline_rec <-
     recipes::recipe(ridership ~ ., data = head(Chicago)) %>%
@@ -105,7 +114,7 @@ test_that("umerged recipe merge", {
     recipes::step_other(recipes::all_nominal(), threshold = tune()) %>%
     recipes::step_dummy(recipes::all_nominal()) %>%
     recipes::step_normalize(recipes::all_numeric_predictors()) %>%
-    recipes::step_bs(recipes::all_predictors(), deg_free = tune(), degree = tune())
+    recipes::step_spline_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
   bst_grid <- tibble::tibble("funky name \n" = 1:4, rules = rep(c(TRUE, FALSE), each = 2))
 
   expect_error(

--- a/tests/testthat/test-metric-args.R
+++ b/tests/testthat/test-metric-args.R
@@ -55,6 +55,9 @@ test_that("metric inputs are checked for regression models", {
 })
 
 test_that("metric inputs are checked for classification models", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("kknn")
+
   library(parsnip)
   library(workflows)
   library(yardstick)

--- a/tests/testthat/test-metric-args.R
+++ b/tests/testthat/test-metric-args.R
@@ -1,4 +1,7 @@
 test_that("metric inputs are checked for regression models", {
+  skip_if_not_installed("kknn")
+
+
   library(parsnip)
   library(workflows)
   library(yardstick)

--- a/tests/testthat/test-min-grid.R
+++ b/tests/testthat/test-min-grid.R
@@ -553,6 +553,7 @@ test_that("multinomial regression grid reduction - glmnet", {
 
 
 test_that("nearest neighbors grid reduction - kknn", {
+
   mod <- parsnip::nearest_neighbor() %>% parsnip::set_engine("kknn")
 
   # A typical grid

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -1,5 +1,7 @@
 test_that("determine foreach operator", {
   skip_if(foreach::getDoParWorkers() > 1 || future::nbrOfWorkers() > 1)
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("splines2")
 
   data("Chicago", package = "modeldata")
   spline_rec <-
@@ -11,7 +13,7 @@ test_that("determine foreach operator", {
     recipes::step_other(recipes::all_nominal(), threshold = tune()) %>%
     recipes::step_dummy(recipes::all_nominal()) %>%
     recipes::step_normalize(recipes::all_numeric_predictors()) %>%
-    recipes::step_bs(recipes::all_predictors(), deg_free = tune(), degree = tune())
+    recipes::step_spline_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
   glmn <- parsnip::linear_reg(penalty = tune(), mixture = tune()) %>%
     parsnip::set_engine("glmnet")
   chi_wflow <-

--- a/tests/testthat/test-param_set.R
+++ b/tests/testthat/test-param_set.R
@@ -17,6 +17,9 @@ check_param_set_tibble <- function(x) {
 # ------------------------------------------------------------------------------
 
 test_that("parameters.recipe() still works after deprecation", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("splines2")
+
   withr::local_options(lifecycle_verbosity = "quiet")
 
   data("Chicago", package = "modeldata")
@@ -24,7 +27,7 @@ test_that("parameters.recipe() still works after deprecation", {
     recipes::recipe(ridership ~ ., data = head(Chicago)) %>%
     recipes::step_impute_knn(recipes::all_predictors(), neighbors = tune("imputation")) %>%
     recipes::step_other(recipes::all_nominal(), threshold = tune()) %>%
-    recipes::step_bs(recipes::all_predictors(), deg_free = tune(), degree = tune())
+    recipes::step_spline_b(recipes::all_predictors(), deg_free = tune(), degree = tune())
 
   spline_info <- dials::parameters(spline_rec)
   check_param_set_tibble(spline_info)

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -35,12 +35,14 @@ test_that("can use `fit_resamples()` with a formula", {
 })
 
 test_that("can use `fit_resamples()` with a recipe", {
+  skip_if_not_installed("splines2")
+
   set.seed(6735)
   folds <- rsample::vfold_cv(mtcars, v = 2)
 
   rec <- recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_ns(disp) %>%
-    recipes::step_ns(wt)
+    recipes::step_spline_natural(disp) %>%
+    recipes::step_spline_natural(wt)
 
   lin_mod <- linear_reg() %>%
     set_engine("lm")
@@ -59,12 +61,14 @@ test_that("can use `fit_resamples()` with a recipe", {
 })
 
 test_that("can use `fit_resamples()` with a workflow - recipe", {
+  skip_if_not_installed("splines2")
+
   set.seed(6735)
   folds <- rsample::vfold_cv(mtcars, v = 2)
 
   rec <- recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_ns(disp) %>%
-    recipes::step_ns(wt)
+    recipes::step_spline_natural(disp) %>%
+    recipes::step_spline_natural(wt)
 
   lin_mod <- parsnip::linear_reg() %>%
     parsnip::set_engine("lm")
@@ -248,11 +252,13 @@ test_that("can use `fit_resamples()` with a workflow - postprocessor (no trainin
 # Error capture ----------------------------------------------------------------
 
 test_that("failure in recipe is caught elegantly", {
+  skip_if_not_installed("splines2")
+
   set.seed(6735)
   folds <- rsample::vfold_cv(mtcars, v = 2)
 
   rec <- recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_ns(disp, deg_free = NA_real_)
+    recipes::step_spline_natural(disp, deg_free = NA_real_)
 
   lin_mod <- parsnip::linear_reg() %>%
     parsnip::set_engine("lm")
@@ -426,12 +432,14 @@ test_that("ellipses with fit_resamples", {
 })
 
 test_that("argument order gives errors for recipe/formula", {
+  skip_if_not_installed("splines2")
+
   set.seed(6735)
   folds <- rsample::vfold_cv(mtcars, v = 2)
 
   rec <- recipes::recipe(mpg ~ ., data = mtcars) %>%
-    recipes::step_ns(disp) %>%
-    recipes::step_ns(wt)
+    recipes::step_spline_natural(disp) %>%
+    recipes::step_spline_natural(wt)
 
   lin_mod <- parsnip::linear_reg() %>%
     parsnip::set_engine("lm")
@@ -447,6 +455,8 @@ test_that("argument order gives errors for recipe/formula", {
 
 
 test_that("retain extra attributes", {
+  skip_if_not_installed("splines2")
+
   set.seed(6735)
   folds <- rsample::vfold_cv(mtcars, v = 2)
 
@@ -488,7 +498,7 @@ test_that("retain extra attributes", {
 
 
 test_that("`fit_resamples()` when objects need tuning", {
-  rec <- recipe(mpg ~ ., data = mtcars) %>% step_ns(disp, deg_free = tune())
+  rec <- recipe(mpg ~ ., data = mtcars) %>% step_spline_natural(disp, deg_free = tune())
   spec_1 <- linear_reg(penalty = tune()) %>% set_engine("glmnet")
   spec_2 <- linear_reg()
   wflow_1 <- workflow(rec, spec_1)

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -278,7 +278,7 @@ test_that("failure in recipe is caught elegantly", {
   expect_length(notes, 2L)
 
   # Known failure in the recipe
-  expect_true(any(grepl("missing value where", note)))
+  expect_true(any(grepl("Expecting", note)))
 
   expect_equal(extract, list(NULL, NULL))
   expect_equal(predictions, list(NULL, NULL))

--- a/tests/testthat/test-select_best.R
+++ b/tests/testthat/test-select_best.R
@@ -193,6 +193,7 @@ test_that("percent loss", {
 
 test_that("select_by_* can handle metrics with direction == 'zero'", {
   skip_on_cran()
+  skip_if_not_installed("kknn")
 
   set.seed(1)
   resamples <- rsample::bootstraps(mtcars, times = 5)

--- a/vignettes/tune.Rmd
+++ b/vignettes/tune.Rmd
@@ -11,7 +11,15 @@ vignette: >
 ---
 
 ```{r setup, include=FALSE}
+if (rlang::is_installed(c("tidymodels", "kknn", "modeldata", "splines2"))) {
+  run <- TRUE
+} else {
+  cv_splits <- NULL
+  run <- FALSE
+}
+
 knitr::opts_chunk$set(
+  eval = run,
   digits = 3,
   collapse = TRUE,
   comment = "#>"


### PR DESCRIPTION
Add a GH workflow that only directly installs "hard" dependencies, i.e. Depends, Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never installed, with the exception of testthat, knitr, and rmarkdown. The cache is never used to avoid accidentally restoring a cache containing a suggested dependency.