### PR TITLE
cache duplicated preprocessor fits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # tune (development version)
 
+* Iterative searches now cache preprocessor fits that would be duplicated across
+  iterations, greatly reducing the time to tune computationally intensive
+  preprocessing steps in `tune_bayes()` (and `tune_sim_anneal()`) in 
+  finetune (#955).
+
 * The package will now warn when parallel processing has been enabled with foreach but not with future. See [`?parallelism`](https://tune.tidymodels.org/dev/reference/parallelism.html) to learn more about transitioning your code to future (#878, #866).
 
 * The package will now log a backtrace for errors and warnings that occur during tuning. When a tuning process encounters issues, see the new `trace` column in the `collect_notes(.Last.tune.result)` output to find precisely where the error occurred (#873).

--- a/R/cache.R
+++ b/R/cache.R
@@ -1,0 +1,32 @@
+# For iterative searches, the same preprocessor fits are recomputed
+# for every iteration. Hook into the `tune_env`, an environment that
+# defines a call to a tuning function, to cache repeated fits while tuning.
+has_cached_result <- function(split_id, param_desc) {
+  cache <- cached_results()
+
+  if (!split_id %in% names(cache) || !param_desc %in% names(cache[[split_id]])) {
+    return(FALSE)
+  }
+
+  TRUE
+}
+
+get_cached_result <- function(split_id, param_desc) {
+  cache <- cached_results()
+  cache[[split_id]][[param_desc]]
+}
+
+set_cached_result <- function(split_id, param_desc, workflow) {
+  cache <- cached_results()
+  cache[[split_id]][[param_desc]] <- workflow
+  workflow
+}
+
+cached_results <- function() {
+  env <- tune_env$progress_env
+  if (!"cache" %in% names(env)) {
+    rlang::env_bind(env, cache = rlang::new_environment())
+  }
+
+  env$cache
+}

--- a/R/grid_code_paths.R
+++ b/R/grid_code_paths.R
@@ -436,13 +436,19 @@ tune_grid_loop_iter <- function(split,
       grid_preprocessor = iter_grid_preprocessor
     )
 
-    workflow <- .catch_and_log(
-      .expr = .fit_pre(workflow, analysis),
-      control,
-      split_labels,
-      iter_msg_preprocessor,
-      notes = out_notes
-    )
+    if (!has_cached_result(split_labels$id, iter_msg_preprocessor)) {
+      workflow <- .catch_and_log(
+        .expr = .fit_pre(workflow, analysis),
+        control,
+        split_labels,
+        iter_msg_preprocessor,
+        notes = out_notes
+      )
+
+      set_cached_result(split_labels$id, iter_msg_preprocessor, workflow)
+    } else {
+      workflow <- get_cached_result(split_labels$id, iter_msg_preprocessor)
+    }
 
     if (is_failure(workflow)) {
       next


### PR DESCRIPTION
Closes #955. A proof of concept for cutting out duplicated preprocessor fits for iterative tuning approaches. A bit of a contrived example, but on `main`:

``` r
library(tidymodels)
library(embed)

hotel_rates$arrival_date <- NULL
  
bench::mark(
  tune_bayes = tune_bayes(
    workflow(
      recipe(avg_price_per_room ~ ., hotel_rates) %>% 
        step_lencode_glm(all_nominal_predictors(), outcome = vars(avg_price_per_room)),
      linear_reg(engine = "glmnet", penalty = tune())
    ),
    vfold_cv(hotel_rates)
  )
)
#> ! No improvement for 10 iterations; returning current results.
#> ! No improvement for 10 iterations; returning current results.
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tune_bayes    2.16m    2.16m   0.00773      38GB    0.897
```

<sup>Created on 2024-11-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

After this PR:

``` r
library(tidymodels)
library(embed)

hotel_rates$arrival_date <- NULL
  
bench::mark(
  tune_bayes = tune_bayes(
    workflow(
      recipe(avg_price_per_room ~ ., hotel_rates) %>% 
        step_lencode_glm(all_nominal_predictors(), outcome = vars(avg_price_per_room)),
      linear_reg(engine = "glmnet", penalty = tune())
    ),
    vfold_cv(hotel_rates)
  )
)
#> ! No improvement for 10 iterations; returning current results.
#> ! No improvement for 10 iterations; returning current results.
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tune_bayes      20s      20s    0.0500    5.16GB     2.05
```

<sup>Created on 2024-11-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

* I'm not fully convinced it's actually this simple. 1) Is the `split_id` and `iter_msg_preprocessor` enough to uniquely identify a unique preprocessor fit when tuning iteratively? 2) What are the implications with different types of parallelism? We haven't used the `progress_env` so far for parallelized computations, yet, but also the fact that `has_cached_result()` would only return `TRUE` for iterative searches might mean that the needed information is always available in the parent process.
* This same machinery could be used to e.g. cache model fits if only tuning the postprocessor.