### PR TITLE
No extra rng seed alterations for last_fit()

### DIFF
--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -9,7 +9,7 @@ loop_over_all_stages <- function(resamples, grid, static) {
   seed_length <- length(resamples$.seeds[[1]])
 
   # If we are using last_fit() (= zero seed length), don't mess with the RNG
-  # stream; otherwise set everything up
+  # stream; otherwise set everything up.
   if (seed_length > 0) {
     orig_seed <- .Random.seed
     # Set seed within the worker process

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -6,11 +6,18 @@
 loop_over_all_stages <- function(resamples, grid, static) {
   # Initialize some objects
 
-  orig_seed <- .Random.seed
-  # Set seed within the worker process
-  assign(".Random.seed", resamples$.seeds[[1]], envir = .GlobalEnv)
-  resamples$.seeds <- NULL
-  withr::defer(assign(".Random.seed", orig_seed, envir = .GlobalEnv))
+  seed_length <- length(resamples$.seeds[[1]])
+
+  # If we are using last_fit() (= zero seed length), don't mess with the RNG
+  # stream; otherwise set everything up
+  if (seed_length > 0) {
+    orig_seed <- .Random.seed
+    # Set seed within the worker process
+    assign(".Random.seed", resamples$.seeds[[1]], envir = .GlobalEnv)
+    resamples$.seeds <- NULL
+    withr::defer(assign(".Random.seed", orig_seed, envir = .GlobalEnv))
+  }
+
   split <- resamples$splits[[1]]
   split_labs <- resamples |>
     dplyr::select(dplyr::starts_with("id"))

--- a/R/parallel_new.R
+++ b/R/parallel_new.R
@@ -268,7 +268,7 @@ get_parallel_seeds <- function(workers) {
 #'
 #' Also, we want the results for [last_fit()] to be the same as what one would
 #' get by executing those steps manually (i.e., training the workflow,
-#' predicting the test set, etc.). If [last_fit()] is used, we don’t affect the
+#' predicting the test set, etc.). If [last_fit()] is used, we don’t alter the
 #' random number stream.
 #'
 #' @references

--- a/R/parallel_new.R
+++ b/R/parallel_new.R
@@ -183,7 +183,7 @@ get_parallel_seeds <- function(workers) {
 #'
 #' @description
 #'
-#' \pkg{tune} can enable the simultaneous parallel computations. Tierney (2008)
+#' \pkg{tune} can enable simultaneous parallel computations. Tierney (2008)
 #'  defined different classes of parallel processing techniques:
 #'
 #'  - _Implicit_ is when a function uses low-level tools to perform a
@@ -245,34 +245,58 @@ get_parallel_seeds <- function(workers) {
 #'
 #' ## Using mirai
 #'
-#' To set the specific for parallel processing with \pkg{mirai}, the
-#' [mirai::daemons()] functions. The first argument, `n`, determines the number
+#' To set the specific for parallel processing with \pkg{mirai}, use the
+#' [mirai::daemons()] function. The first argument, `n`, determines the number
 #' of parallel workers. Using `daemons(0)` reverts to sequential processing.
 #'
 #' The arguments `url` and `remote` are used to set up and launch parallel
 #' processes over the network for distributed computing. See [mirai::daemons()]
 #' documentation for more details.
 #'
-#' ## Exceptions
+#' ## Reverting to sequential processing
 #'
 #' There are a few times when you might specify that you wish to use parallel
-#' processing, but it will revert to sequential execution.
-#' - Many of the control functions (e.g. [control_grid()]) have an argument
-#' called `allow_par`. If this is set to `FALSE`, parallel backends will always
-#' be ignored.
-#' - Some packages, such as \pkg{rJava} and \pkg{keras} are not compatible with
-#' explicit parallelization. If any of these packages are used, sequential
-#' processing occurs.
-#' - If you specify fewer than two workers, or if there is only a single task,
-#'  the computations will occur sequentially.
+#' processing, but it will revert to sequential execution:
 #'
-#' Also, we want the results for [last_fit()] to be the same as what one would
-#' get by executing those steps manually (i.e., training the workflow,
-#' predicting the test set, etc.). If [last_fit()] is used, we don’t alter the
-#' random number stream.
+#' - Many of the control functions (e.g. [control_grid()]) have an argument
+#'   called `allow_par`. If this is set to `FALSE`, parallel backends will
+#'   always be ignored.
+#' - Some packages, such as \pkg{rJava} and \pkg{keras} are not compatible with
+#'   explicit parallelization. If any of these packages are used, sequential
+#'   processing occurs.
+#' - If you specify fewer than two workers, or if there is only a single task,
+#'   the computations will occur sequentially.
+#'
+#' ## Expectations for reproducibility
+#'
+#' We advise that you _always_ run [set.seed()] with a seed value just prior to
+#' using a function that uses (or might use) random numbers. Given this:
+#'
+#' - You should expect to get the same results if you run that section of code
+#'   repeatedly, conditional on using version 1.4.0 of tune.
+#' - You should expect differences in results between version 1.4.0 of tune and
+#'   previous versions.
+#' - When using [last_fit()], you should be able to get the same results as
+#'   manually using [fit()] and [predict()] to do the same work.
+#' - When running with or without parallel processing (using any backend
+#'   package), you should be able to achieve the same results from
+#'   [fit_resamples()] and the various tuning functions.
+#'
+#' Specific exceptions:
+#'
+#' - For SVM classification models using the \pkg{kernlab} package, the random
+#'   number generator is independent of R, and there is no argument to control
+#'   it. Unfortunately, it is likely to give you different results from
+#'   run-to-run.
+#' - For some deep learning packages (e.g., \pkg{tensorflow}, \pkg{keras}, and
+#'   \pkg{torch}), it is very difficult to achieve reproducible results. This
+#'   is especially true when using GPUs for computations. Additionally, we have
+#'   seen differences in computations (stochastic or non-random) between
+#'   platforms due to the packages' use of different numerical tolerance
+#'   constants across operating systems.
 #'
 #' @references
-#' https://www.tmwr.org/grid-search#parallel-processing
+#' \url{https://www.tmwr.org/grid-search#parallel-processing}
 #'
 #' Tierney, Luke. "Implicit and explicit parallel computing in R." COMPSTAT
 #' 2008: Proceedings in Computational Statistics. Physica-Verlag HD, 2008.

--- a/R/parallel_new.R
+++ b/R/parallel_new.R
@@ -266,6 +266,11 @@ get_parallel_seeds <- function(workers) {
 #' - If you specify fewer than two workers, or if there is only a single task,
 #'  the computations will occur sequentially.
 #'
+#' Also, we want the results for [last_fit()] to be the same as what one would
+#' get by executing those steps manually (i.e., training the workflow,
+#' predicting the test set, etc.). If [last_fit()] is used, we don’t affect the
+#' random number stream.
+#'
 #' @references
 #' https://www.tmwr.org/grid-search#parallel-processing
 #'

--- a/R/tune_grid_loop_new.R
+++ b/R/tune_grid_loop_new.R
@@ -15,8 +15,15 @@ tune_grid_loop_new <- function(
 
   control <- update_parallel_over(control, resamples, grid)
 
-  # Make and set the worker/process seeds if workers get resamples
-  resamples$.seeds <- get_parallel_seeds(nrow(resamples))
+  # For last_fit, we want to keep the RNG stream as-is to maintain reproducibility
+  # with manual execution. Otherwise, generate parallel seeds even if work is
+  # being executed sequentially. `resamples$id` is set in `last_fit_workflow`.
+  if (all(resamples$id == "train/test split")) {
+    resamples$.seeds <- purrr::map(resamples$id, ~ integer(0))
+  } else {
+    # Make and set the worker/process seeds if workers get resamples
+    resamples$.seeds <- get_parallel_seeds(nrow(resamples))
+  }
 
   # We'll significantly alter the rsample object but will need it intact later;
   # Make a copy and save some information before proceeding

--- a/man/parallelism.Rd
+++ b/man/parallelism.Rd
@@ -4,7 +4,7 @@
 \alias{parallelism}
 \title{Support for parallel processing in tune}
 \description{
-\pkg{tune} can enable the simultaneous parallel computations. Tierney (2008)
+\pkg{tune} can enable simultaneous parallel computations. Tierney (2008)
 defined different classes of parallel processing techniques:
 \itemize{
 \item \emph{Implicit} is when a function uses low-level tools to perform a
@@ -66,8 +66,8 @@ install and load the \pkg{future.mirai} package.
 
 \subsection{Using mirai}{
 
-To set the specific for parallel processing with \pkg{mirai}, the
-\code{\link[mirai:daemons]{mirai::daemons()}} functions. The first argument, \code{n}, determines the number
+To set the specific for parallel processing with \pkg{mirai}, use the
+\code{\link[mirai:daemons]{mirai::daemons()}} function. The first argument, \code{n}, determines the number
 of parallel workers. Using \code{daemons(0)} reverts to sequential processing.
 
 The arguments \code{url} and \code{remote} are used to set up and launch parallel
@@ -75,29 +75,55 @@ processes over the network for distributed computing. See \code{\link[mirai:daem
 documentation for more details.
 }
 
-\subsection{Exceptions}{
+\subsection{Reverting to sequential processing}{
 
 There are a few times when you might specify that you wish to use parallel
-processing, but it will revert to sequential execution.
+processing, but it will revert to sequential execution:
 \itemize{
 \item Many of the control functions (e.g. \code{\link[=control_grid]{control_grid()}}) have an argument
-called \code{allow_par}. If this is set to \code{FALSE}, parallel backends will always
-be ignored.
+called \code{allow_par}. If this is set to \code{FALSE}, parallel backends will
+always be ignored.
 \item Some packages, such as \pkg{rJava} and \pkg{keras} are not compatible with
 explicit parallelization. If any of these packages are used, sequential
 processing occurs.
 \item If you specify fewer than two workers, or if there is only a single task,
 the computations will occur sequentially.
 }
+}
 
-Also, we want the results for \code{\link[=last_fit]{last_fit()}} to be the same as what one would
-get by executing those steps manually (i.e., training the workflow,
-predicting the test set, etc.). If \code{\link[=last_fit]{last_fit()}} is used, we don’t affect the
-random number stream.
+\subsection{Expectations for reproducibility}{
+
+We advise that you \emph{always} run \code{\link[=set.seed]{set.seed()}} with a seed value just prior to
+using a function that uses (or might use) random numbers. Given this:
+\itemize{
+\item You should expect to get the same results if you run that section of code
+repeatedly, conditional on using version 1.4.0 of tune.
+\item You should expect differences in results between version 1.4.0 of tune and
+previous versions.
+\item When using \code{\link[=last_fit]{last_fit()}}, you should be able to get the same results as
+manually using \code{\link[=fit]{fit()}} and \code{\link[=predict]{predict()}} to do the same work.
+\item When running with or without parallel processing (using any backend
+package), you should be able to achieve the same results from
+\code{\link[=fit_resamples]{fit_resamples()}} and the various tuning functions.
+}
+
+Specific exceptions:
+\itemize{
+\item For SVM classification models using the \pkg{kernlab} package, the random
+number generator is independent of R, and there is no argument to control
+it. Unfortunately, it is likely to give you different results from
+run-to-run.
+\item For some deep learning packages (e.g., \pkg{tensorflow}, \pkg{keras}, and
+\pkg{torch}), it is very difficult to achieve reproducible results. This
+is especially true when using GPUs for computations. Additionally, we have
+seen differences in computations (stochastic or non-random) between
+platforms due to the packages' use of different numerical tolerance
+constants across operating systems.
+}
 }
 }
 \references{
-https://www.tmwr.org/grid-search#parallel-processing
+\url{https://www.tmwr.org/grid-search#parallel-processing}
 
 Tierney, Luke. "Implicit and explicit parallel computing in R." COMPSTAT
 2008: Proceedings in Computational Statistics. Physica-Verlag HD, 2008.

--- a/man/parallelism.Rd
+++ b/man/parallelism.Rd
@@ -89,6 +89,11 @@ processing occurs.
 \item If you specify fewer than two workers, or if there is only a single task,
 the computations will occur sequentially.
 }
+
+Also, we want the results for \code{\link[=last_fit]{last_fit()}} to be the same as what one would
+get by executing those steps manually (i.e., training the workflow,
+predicting the test set, etc.). If \code{\link[=last_fit]{last_fit()}} is used, we don’t affect the
+random number stream.
 }
 }
 \references{


### PR DESCRIPTION
As mentioned in #1038, we want to ensure that users can reproduce the results of `last_fit()` exactly. 

This PR does not generate (or set) the rng seeds when `last_fit()` is the parent function. Consequently, the random numbers used manually should be the same as those used by last fit **unless there is a stochastic inner split**. 

Additional tests will be in extratests since we don't suggest any modeling packages in tune that we could test with. 