### PR TITLE
temporarily add our working branch to use all tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,9 +6,9 @@
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'melodie-switch']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'melodie-switch']
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'melodie-switch']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'melodie-switch']
 
 name: test-coverage.yaml
 


### PR DESCRIPTION
Most of our triggers for testing were `branches: [main, master]` (except the no-suggests tests). 

I'm trying to add `melodie-switch` here until we merge into main. 