### PR TITLE
Load required packages in workers

### DIFF
--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -11,6 +11,7 @@ make_static <- function(
   eval_time,
   split_args,
   control,
+  pkgs = character(0),
   data = list(fit = NULL, pred = NULL, cal = NULL)
 ) {
   # check inputs
@@ -40,6 +41,7 @@ make_static <- function(
     eval_time = eval_time,
     split_args = split_args,
     control = control,
+    pkgs = pkgs,
     data = data
   )
 }
@@ -543,3 +545,22 @@ parsnip_to_engine <- function(wflow, grid) {
   names(nm_lst) <- key$user
   dplyr::rename(grid, dplyr::all_of(nm_lst))
 }
+
+# ------------------------------------------------------------------------------
+
+attach_pkgs <- function(pkgs, load = character(0)) {
+  # Testing to see if they are installed triggers package attachment.
+  is_inst <- purrr::map_lgl(pkgs, rlang::is_installed)
+  if (any(!is_inst)) {
+    nms <- pkgs[!is_inst]
+    cli::cli_abort("Some package installs are needed: {.pkg {nms}}", call = NULL)
+  }
+
+  # There may be some packages that need to be fully loaded to work
+  # appropriately.
+  sshh_load <- purrr::quietly(library)
+  load_res <- purrr::map(load, ~ sshh_load(.x, character.only = TRUE))
+
+  invisible(pkgs)
+}
+

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -4,8 +4,11 @@
 #    `allow_par = FALSE`; that will use `lapply()` so that you can see output.
 
 loop_over_all_stages <- function(resamples, grid, static) {
-  # Initialize some objects
+  # Some packages may use random numbers so attach them prior to initializing
+  # the RNG seed
+  attach_pkgs(static$pkgs)
 
+  # Initialize some objects
   seed_length <- length(resamples$.seeds[[1]])
 
   # If we are using last_fit() (= zero seed length), don't mess with the RNG
@@ -84,7 +87,7 @@ loop_over_all_stages <- function(resamples, grid, static) {
         split_labels = split_labs,
         location = location, notes = notes
       )
-      
+
       if (is_failure(current_wflow)) {
         next
       }
@@ -194,7 +197,7 @@ loop_over_all_stages <- function(resamples, grid, static) {
             if (is_failure(post_fit)) {
               next
             }
-            
+
             post_pred <- .catch_and_log(
               predict(post_fit, current_pred),
               control = static$control,

--- a/R/tune_grid_loop.R
+++ b/R/tune_grid_loop.R
@@ -41,6 +41,16 @@ tune_grid_loop <- function(
   # 2. If you are debugging loop_over_all_stages, use the control option
   #    `allow_par = FALSE`; that will use `lapply()` so that you can see output.
 
+  # ------------------------------------------------------------------------------
+
+  # fmt: skip
+  tm_pkgs <- c("rsample", "workflows", "hardhat", "tune", "parsnip", "tailor",
+               "yardstick")
+  load_pkgs <- c(required_pkgs(workflow), control$pkgs, tm_pkgs)
+  load_pkgs <- unique(load_pkgs)
+
+  par_opt <- list()
+
   # ----------------------------------------------------------------------------
   # Collect "static" data into a single object for a cleaner interface
 
@@ -51,7 +61,8 @@ tune_grid_loop <- function(
     metrics = metrics,
     eval_time = eval_time,
     split_args = split_args,
-    control = control
+    control = control,
+    pkgs = load_pkgs
   )
 
   # fmt: skip

--- a/tests/testthat/test-loop-over-all-stages-helpers-make-static.R
+++ b/tests/testthat/test-loop-over-all-stages-helpers-make-static.R
@@ -32,6 +32,7 @@ test_that("maker static object", {
       "eval_time",
       "split_args",
       "control",
+      "pkgs",
       "data"
     )
   )
@@ -105,6 +106,7 @@ test_that("maker static object", {
       "eval_time",
       "split_args",
       "control",
+      "pkgs",
       "data"
     )
   )


### PR DESCRIPTION
When adding Mirai, we left out the bits where we attach the required packages. This PR does that in the loops and leaves some infrastructure for cases where a package will only function well when fully loaded (maybe earth is an example).