### PR TITLE
Fix logging issues related to parallel computing

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -373,12 +373,12 @@ catalog_log <- function(x) {
   }
 
   rlang::env_bind(tune_env, progress_catalog = catalog)
-  rlang::env_bind(
-    tune_env$progress_env,
-    catalog_summary = summarize_catalog(catalog)
-  )
-
   if (uses_catalog()) {
+    rlang::env_bind(
+      tune_env$progress_env,
+      catalog_summary = summarize_catalog(catalog)
+    )
+
     if (!tune_env$progress_started) {
 
       rlang::with_options(

--- a/tests/testthat/_snaps/logging.md
+++ b/tests/testthat/_snaps/logging.md
@@ -157,7 +157,7 @@
         extract = function(x) {
           raise_warning()
           raise_error()
-        }))
+        }, allow_par = FALSE))
     Message
       > A | warning: ope! yikes.
       > B | error:   AHHhH
@@ -177,7 +177,7 @@
         extract = function(x) {
           raise_warning_rl()
           raise_error_rl()
-        }))
+        }, allow_par = FALSE))
     Message
       > A | warning: ope! yikes. (but rlang)
       > B | error:   AHHhH (but rlang)
@@ -194,7 +194,7 @@
     Code
       res_fit <- fit_resamples(parsnip::nearest_neighbor("regression", "kknn"),
       Sale_Price ~ ., rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5), control = control_resamples(
-        extract = raise_multiline_conditions))
+        extract = raise_multiline_conditions, allow_par = FALSE))
     Message
       > A | warning: hmmm what's happening
       > B | error:   aHHHksdjvndiuf
@@ -211,7 +211,7 @@
     Code
       res_fit <- fit_resamples(parsnip::nearest_neighbor("regression", "kknn"),
       Sale_Price ~ ., rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5), control = control_resamples(
-        extract = later))
+        extract = later, allow_par = FALSE))
     Message
       > A | error:   this errors now! ha!
 
@@ -230,7 +230,7 @@
       control = control_resamples(extract = function(x) {
         once()
         later()
-      }))
+      }, allow_par = FALSE))
     Message
       > A | error:   oh no
       > B | error:   this errors now! ha!
@@ -247,7 +247,7 @@
     Code
       res_fit <- fit_resamples(parsnip::nearest_neighbor("regression", "kknn"),
       Sale_Price ~ ., rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5), control = control_resamples(
-        extract = numbered))
+        extract = numbered, allow_par = FALSE))
     Message
       > A | error:   error number 1
       > B | error:   error number 2
@@ -267,7 +267,8 @@
     Code
       res_fit <- tune_grid(parsnip::nearest_neighbor("regression", "kknn",
         dist_power = tune()), Sale_Price ~ ., rsample::vfold_cv(modeldata::ames[, c(
-        72, 40:45)], 5), grid = 5, control = control_grid(extract = raise_error))
+        72, 40:45)], 5), grid = 5, control = control_grid(extract = raise_error,
+        allow_par = FALSE))
     Message
       > A | error:   AHHhH
 
@@ -283,13 +284,9 @@
     Code
       res_grid <- tune_bayes(parsnip::nearest_neighbor("regression", "kknn",
         dist_power = tune()), Sale_Price ~ ., rsample::vfold_cv(modeldata::ames[, c(
-        72, 40:45)], 5), initial = 5, iter = 5, control = control_bayes(extract = raise_error))
+        72, 40:45)], 5), initial = 5, iter = 5, control = control_bayes(extract = raise_error,
+        allow_par = FALSE))
     Message
-      > A | error:   AHHhH
-      > A | error:   AHHhH
-      > A | error:   AHHhH
-      > A | error:   AHHhH
-      > A | error:   AHHhH
       > A | error:   AHHhH
 
 ---
@@ -297,5 +294,5 @@
     Code
       catalog_summary_test
     Output
-      A: x5
+      A: x100
 

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -169,7 +169,9 @@ test_that("interactive logger works (fit_resamples, warning + error)", {
         Sale_Price ~ .,
         rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5),
         control = control_resamples(
-          extract = function(x) {raise_warning(); raise_error()})
+          extract = function(x) {raise_warning(); raise_error()}, 
+          allow_par = FALSE
+        )
     )},
     transform = catalog_lines
   )
@@ -199,7 +201,8 @@ test_that("interactive logger works (fit_resamples, rlang warning + error)", {
         Sale_Price ~ .,
         rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5),
         control = control_resamples(
-          extract = function(x) {raise_warning_rl(); raise_error_rl()}
+          extract = function(x) {raise_warning_rl(); raise_error_rl()}, 
+          allow_par = FALSE
         )
     )},
     transform = catalog_lines
@@ -234,7 +237,10 @@ test_that("interactive logger works (fit_resamples, multiline)", {
         parsnip::nearest_neighbor("regression", "kknn"),
         Sale_Price ~ .,
         rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5),
-        control = control_resamples(extract = raise_multiline_conditions)
+        control = control_resamples(
+          extract = raise_multiline_conditions,
+          allow_par = FALSE
+        )
     )},
     transform = catalog_lines
   )
@@ -273,7 +279,7 @@ test_that("interactive logger works (fit_resamples, occasional error)", {
         parsnip::nearest_neighbor("regression", "kknn"),
         Sale_Price ~ .,
         rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5),
-        control = control_resamples(extract = later)
+        control = control_resamples(extract = later, allow_par = FALSE)
     )},
     transform = catalog_lines
   )
@@ -327,7 +333,10 @@ test_that("interactive logger works (fit_resamples, occasional errors)", {
         parsnip::nearest_neighbor("regression", "kknn"),
         Sale_Price ~ .,
         rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 10),
-        control = control_resamples(extract = function(x) {once(); later()})
+        control = control_resamples(
+          extract = function(x) {once(); later()},
+          allow_par = FALSE
+        )
     )},
     transform = catalog_lines
   )
@@ -368,7 +377,7 @@ test_that("interactive logger works (fit_resamples, many distinct errors)", {
         parsnip::nearest_neighbor("regression", "kknn"),
         Sale_Price ~ .,
         rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5),
-        control = control_resamples(extract = numbered)
+        control = control_resamples(extract = numbered, allow_par = FALSE)
     )},
     transform = catalog_lines
   )
@@ -398,7 +407,7 @@ test_that("interactive logger works (tune grid, error)", {
         Sale_Price ~ .,
         rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5),
         grid = 5,
-        control = control_grid(extract = raise_error)
+        control = control_grid(extract = raise_error, allow_par = FALSE)
     )},
     transform = catalog_lines
   )
@@ -430,7 +439,7 @@ test_that("interactive logger works (bayesian, error)", {
         rsample::vfold_cv(modeldata::ames[, c(72, 40:45)], 5),
         initial = 5,
         iter = 5,
-        control = control_bayes(extract = raise_error)
+        control = control_bayes(extract = raise_error, allow_par = FALSE)
     )},
     transform = catalog_lines
   )


### PR DESCRIPTION
To close https://github.com/tidymodels/tune/issues/1064

## Mirai example

``` r
library(tidymodels)

use_future <- FALSE

library(mirai)
daemons(10)
#> [1] 10

set.seed(1)
dat <- sim_regression(1000)
rs <- vfold_cv(dat)

rec <- 
  recipe(outcome ~ ., data = dat) |> 
  step_pca(all_numeric_predictors(), num_comp = tune())

wflow <- workflow(rec, linear_reg())


res <- 
  wflow |> 
  tune_grid(
    resamples = rs,
    grid = tibble(num_comp = 1:10)
  )
#> Warning: All models failed. Run `show_notes(.Last.tune.result)` for more
#> information.

res
#> # Tuning results
#> # 10-fold cross-validation 
#> # A tibble: 10 × 4
#>    splits            id     .metrics .notes           
#>    <list>            <chr>  <list>   <list>           
#>  1 <split [900/100]> Fold01 <NULL>   <tibble [10 × 4]>
#>  2 <split [900/100]> Fold02 <NULL>   <tibble [10 × 4]>
#>  3 <split [900/100]> Fold03 <NULL>   <tibble [10 × 4]>
#>  4 <split [900/100]> Fold04 <NULL>   <tibble [10 × 4]>
#>  5 <split [900/100]> Fold05 <NULL>   <tibble [10 × 4]>
#>  6 <split [900/100]> Fold06 <NULL>   <tibble [10 × 4]>
#>  7 <split [900/100]> Fold07 <NULL>   <tibble [10 × 4]>
#>  8 <split [900/100]> Fold08 <NULL>   <tibble [10 × 4]>
#>  9 <split [900/100]> Fold09 <NULL>   <tibble [10 × 4]>
#> 10 <split [900/100]> Fold10 <NULL>   <tibble [10 × 4]>
#> 
#> There were issues with some computations:
#> 
#>   - Error(s) x100: Error in `step_pca()`: Caused by error in `prep()`: Caused by err...
#> 
#> Run `show_notes(.Last.tune.result)` for more information.
```

<sup>Created on 2025-07-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

## Future example

``` r
library(tidymodels)
library(desirability2)
library(future)
library(tailor)

tidymodels_prefer()
theme_set(theme_bw())
options(pillar.advice = FALSE, pillar.min_title_chars = Inf)
plan("multisession")

set.seed(1)
dat <- sim_classification(num_samples = 1000, intercept = -10)
split <- initial_split(dat, strata = class)
tr_dat <- training(split)
rs <- vfold_cv(tr_dat)

# fmt: skip
cls_mtr <- metric_set(kap, brier_class, roc_auc, pr_auc, sensitivity, specificity,
                      mn_log_loss, mcc)

mlp_spec <-
  mlp(
    hidden_units = tune(),
    penalty = tune(),
    learn_rate = tune(),
    epochs = 500,
    activation = tune()
  ) |>
  set_engine(
    "brulee",
    stop_iter = tune(),
    class_weights = tune(),
    grad_value_clip = 1 / 100,
    grad_norm_clip = 1 / 100
  ) |>
  set_mode("classification")

rec <- recipe(class ~ ., data = tr_dat) |>
  step_normalize(all_numeric_predictors())

tlr <- tailor() |> adjust_probability_threshold(threshold = tune())

mlp_wflow <- workflow(rec, mlp_spec, tlr)

mlp_param <-
  mlp_wflow |>
  extract_parameter_set_dials() |>
  update(
    learn_rate = learn_rate(c(-4, -1/2)),
    threshold = threshold(c(.5, 1)),
    class_weights = class_weights(c(1, 20))
  )

set.seed(2)
imbalance_example <-
  mlp_wflow |>
  tune_grid(
    resamples = rs,
    grid = 5,
    metrics = cls_mtr,
    param_info = mlp_param,
    control = control_grid(allow_par = TRUE)
  )
#> Loading required package: dplyr
#> 
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#>     filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#>     intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 8. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 6. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 6. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 6. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 6. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 5. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 5. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 5. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 7. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> Loading required package: dplyr
#> Attaching package: ‘dplyr’
#> The following objects are masked from ‘package:stats’:
#> 
#> filter, lag
#> The following objects are masked from ‘package:base’:
#> 
#> intersect, setdiff, setequal, union
#> New names:
#> New names:
#> → A | warning: Loss is NaN at epoch 5. Training is stopped.
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> New names:
#> → B | error: Must group by variables found in `.data`. Column `stop_iter` is
#> not found. Column `class_weights` is not found.
#> • `stop_iter` -> `stop_iter...5`
#> • `class_weights` -> `class_weights...6`
#> • `stop_iter` -> `stop_iter...7`
#> • `class_weights` -> `class_weights...8`
#> Warning: All models failed. Run `show_notes(.Last.tune.result)` for more
#> information.
```

<sup>Created on 2025-07-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>