### PR TITLE
add early exit to `engine_to_parsnip()`

### DIFF
--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -519,6 +519,9 @@ reorder_pred_cols <- function(x, y_name) {
 }
 
 engine_to_parsnip <- function(wflow, grid) {
+  if (is.null(grid)) {
+    return(grid)
+  }
   grid_nm <- names(grid)
   key <- parsnip::.model_param_name_key(wflow) |>
     dplyr::filter(user != parsnip & user %in% grid_nm) |>


### PR DESCRIPTION
Found this little speed improvement when benchmarking the following

```r
library(tidymodels)
ames <- ames |>
  select(where(is.numeric))

svm_spec <- null_model(mode = "regression")

set.seed(1)
cv1 <- rsample::bootstraps(ames)

set.seed(1)

for (i in 1:100) {
  fit_1 <- fit_resamples(
    svm_spec,
    Sale_Price ~ .,
    cv1, metrics = metric_set(yardstick::rmse),
    control = control_grid(save_pred = TRUE)
  )
}
```

It gives around 10-13% speed increase in that specific example. and Is very likely not to give any downsides

<details>
<summary>Before</summary>

``` r
library(tidymodels)
ames <- ames |>
  select(where(is.numeric))

svm_spec <- null_model(mode = "regression")

set.seed(1)
cv1 <- rsample::bootstraps(ames)

set.seed(1)

bench::mark(
  run = fit_resamples(
    svm_spec,
    Sale_Price ~ .,
    cv1, metrics = metric_set(yardstick::rmse),
    control = control_grid(save_pred = TRUE)
  ), iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 run           526ms    540ms      1.79     162MB     10.9
```

<sup>Created on 2025-08-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

</details>

<details>
<summary>After</summary>

``` r
library(tidymodels)
ames <- ames |>
  select(where(is.numeric))

svm_spec <- null_model(mode = "regression")

set.seed(1)
cv1 <- rsample::bootstraps(ames)

set.seed(1)

bench::mark(
  run = fit_resamples(
    svm_spec,
    Sale_Price ~ .,
    cv1, metrics = metric_set(yardstick::rmse),
    control = control_grid(save_pred = TRUE)
  ), iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 run           446ms    468ms      2.02     163MB     10.3
```

<sup>Created on 2025-08-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

</details>

