### PR TITLE
load some packages that users interact with directly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,6 @@ Suggests:
     xgboost,
     xml2
 Remotes:
-    tidymodels/rsample,
     tidymodels/tailor,
     tidymodels/workflows
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -4,16 +4,16 @@
 # Note: in loop(), we add more elements for the outcome name(s), and the
 # data partitions
 make_static <- function(
-    workflow,
-    param_info,
-    grid,
-    metrics,
-    eval_time,
-    split_args,
-    control,
-    pkgs = character(0),
-    strategy = character(0),
-    data = list(fit = NULL, pred = NULL, cal = NULL)
+  workflow,
+  param_info,
+  grid,
+  metrics,
+  eval_time,
+  split_args,
+  control,
+  pkgs = character(0),
+  strategy = character(0),
+  data = list(fit = NULL, pred = NULL, cal = NULL)
 ) {
   # check inputs
   if (!inherits(workflow, "workflow")) {

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -561,6 +561,13 @@ attach_pkgs <- function(pkgs, load = character(0)) {
 
   # There may be some packages that need to be fully loaded to work
   # appropriately.
+
+  # These are packages that users might directly interact with so we should
+  # fully load them
+  load_user_pkgs <- c("parsnip", "recipes", "workflows", "tailor", "tune")
+  load_user_pkgs <- intersect(load_user_pkgs, pkgs)
+  load <- unique(c(load, load_user_pkgs))
+
   sshh_load <- purrr::quietly(library)
   load_res <- purrr::map(load, sshh_load, character.only = TRUE)
 

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -550,14 +550,8 @@ parsnip_to_engine <- function(wflow, grid) {
 
 # ------------------------------------------------------------------------------
 
-attach_pkgs <- function(pkgs, strategy = "sequential", load = character(0)) {
+attach_pkgs <- function(pkgs, strategy = "sequential") {
   sshh_load <- purrr::quietly(library)
-
-  if (length(load) > 0) {
-    # There may be some packages that need to be fully loaded to work
-    # appropriately.
-    load_res <- purrr::map(load, ~ sshh_load(.x, character.only = TRUE))
-  }
 
   if (length(pkgs) > 0 & strategy != "sequential") {
     # In parallel, load it all

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -11,8 +11,8 @@ make_static <- function(
   eval_time,
   split_args,
   control,
-  pkgs = character(0),
-  strategy = character(0),
+  pkgs = "tune",
+  strategy = "sequential",
   data = list(fit = NULL, pred = NULL, cal = NULL)
 ) {
   # check inputs
@@ -550,14 +550,17 @@ parsnip_to_engine <- function(wflow, grid) {
 
 # ------------------------------------------------------------------------------
 
-attach_pkgs <- function(pkgs, strategy, load = character(0)) {
-  # There may be some packages that need to be fully loaded to work
-  # appropriately.
+attach_pkgs <- function(pkgs, strategy = "sequential", load = character(0)) {
   sshh_load <- purrr::quietly(library)
-  load_res <- purrr::map(load, ~ sshh_load(.x, character.only = TRUE))
 
-  # In parallel, load it all
-  if (strategy != "sequential") {
+  if (length(load) > 0) {
+    # There may be some packages that need to be fully loaded to work
+    # appropriately.
+    load_res <- purrr::map(load, ~ sshh_load(.x, character.only = TRUE))
+  }
+
+  if (length(pkgs) > 0 & strategy != "sequential") {
+    # In parallel, load it all
     pkgs_res <- purrr::map(pkgs, ~ sshh_load(.x, character.only = TRUE))
   }
 

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -6,7 +6,7 @@
 loop_over_all_stages <- function(resamples, grid, static) {
   # Some packages may use random numbers so attach them prior to initializing
   # the RNG seed
-  attach_pkgs(static$pkgs)
+  attach_pkgs(static$pkgs, strategy = static$strategy)
 
   # Initialize some objects
   seed_length <- length(resamples$.seeds[[1]])

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -300,11 +300,12 @@ get_parallel_seeds <- function(workers) {
 #' \pkg{tune} knows what packages are required to fit a workflow object.
 #'
 #' When computations are run sequentially, an initial check is made to see if
-#' they are installed. This triggers the packages to be attached (but not fully
-#' loaded).
+#' they are installed. This triggers the packages to be loaded but not visible
+#' in the search path.
 #'
-#'  In parallel, the required packages are fully loaded, as they were previously
-#'  with \pkg{foreach}, in the worker processes (but not the main R session).
+#' In parallel, the required packages are fully loaded (i.e., loaded and seen
+#' in the search path), as they were previously with \pkg{foreach}, in the
+#' worker processes (but not the main R session).
 #'
 #' @references
 #' \url{https://www.tmwr.org/grid-search#parallel-processing}

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -295,6 +295,17 @@ get_parallel_seeds <- function(workers) {
 #'   platforms due to the packages' use of different numerical tolerance
 #'   constants across operating systems.
 #'
+#' ## Handling package dependencies
+#'
+#' \pkg{tune} knows what packages are required to fit a workflow object.
+#'
+#' When computations are run sequentially, an initial check is made to see if
+#' they are installed. This triggers the packages to be attached (but not fully
+#' loaded).
+#'
+#'  In parallel, the required packages are fully loaded, as they were previously
+#'  with \pkg{foreach}, in the worker processes (but not the main R session).
+#'
 #' @references
 #' \url{https://www.tmwr.org/grid-search#parallel-processing}
 #'

--- a/R/tune_grid_loop.R
+++ b/R/tune_grid_loop.R
@@ -55,7 +55,10 @@ tune_grid_loop <- function(
   is_inst <- purrr::map_lgl(load_pkgs, rlang::is_installed)
   if (any(!is_inst)) {
     nms <- load_pkgs[!is_inst]
-    cli::cli_abort("Some package installs are needed: {.pkg {nms}}", call = NULL)
+    cli::cli_abort(
+      "Some package installs are needed: {.pkg {nms}}",
+      call = NULL
+    )
   }
 
   par_opt <- list()

--- a/man/parallelism.Rd
+++ b/man/parallelism.Rd
@@ -121,6 +121,18 @@ platforms due to the packages' use of different numerical tolerance
 constants across operating systems.
 }
 }
+
+\subsection{Handling package dependencies}{
+
+\pkg{tune} knows what packages are required to fit a workflow object.
+
+When computations are run sequentially, an initial check is made to see if
+they are installed. This triggers the packages to be attached (but not fully
+loaded).
+
+In parallel, the required packages are fully loaded, as they were previously
+with \pkg{foreach}, in the worker processes (but not the main R session).
+}
 }
 \references{
 \url{https://www.tmwr.org/grid-search#parallel-processing}

--- a/man/parallelism.Rd
+++ b/man/parallelism.Rd
@@ -127,11 +127,12 @@ constants across operating systems.
 \pkg{tune} knows what packages are required to fit a workflow object.
 
 When computations are run sequentially, an initial check is made to see if
-they are installed. This triggers the packages to be attached (but not fully
-loaded).
+they are installed. This triggers the packages to be loaded but not visible
+in the search path.
 
-In parallel, the required packages are fully loaded, as they were previously
-with \pkg{foreach}, in the worker processes (but not the main R session).
+In parallel, the required packages are fully loaded (i.e., loaded and seen
+in the search path), as they were previously with \pkg{foreach}, in the
+worker processes (but not the main R session).
 }
 }
 \references{

--- a/tests/testthat/test-loop-over-all-stages-helpers-make-static.R
+++ b/tests/testthat/test-loop-over-all-stages-helpers-make-static.R
@@ -33,6 +33,7 @@ test_that("maker static object", {
       "split_args",
       "control",
       "pkgs",
+      "strategy",
       "data"
     )
   )
@@ -107,6 +108,7 @@ test_that("maker static object", {
       "split_args",
       "control",
       "pkgs",
+      "strategy",
       "data"
     )
   )


### PR DESCRIPTION
Since we are attaching packages in the workers, some functions are not available since the packages are not fully loaded: 

``` r
library(tidymodels)
library(mirai)
daemons(10)
#> [1] 10

data(ames)

ames <- mutate(ames, Sale_Price = log10(Sale_Price))

set.seed(502)
ames_split <- initial_split(ames, prop = 0.80, strata = Sale_Price)
ames_train <- training(ames_split)
ames_test  <-  testing(ames_split)

set.seed(1001)
ames_folds <- vfold_cv(ames_train, v = 10)

reg_mtr <- metric_set(rmse, ccc)

ames_rec <-
  recipe(
    Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type +
      Latitude + Longitude,
    data = ames_train
  ) %>%
  step_other(Neighborhood, threshold = 0.01) %>%
  step_dummy(all_nominal_predictors()) %>%
  step_interact(~ Gr_Liv_Area:starts_with("Bldg_Type_")) %>%
  step_ns(Latitude, Longitude, deg_free = 20)

lm_wflow <-
  workflow() %>%
  add_recipe(ames_rec) %>%
  add_model(linear_reg() %>% set_engine("lm"))

lm_fit <- lm_wflow %>% fit(data = ames_train)

get_model <- function(x) {
  library(broom)
  extract_fit_parsnip(x) %>% tidy()
}

ctrl <- control_resamples(extract = get_model)

lm_res <-
  lm_wflow %>%
  fit_resamples(resamples = ames_folds, control = ctrl, metrics = reg_mtr)
#> Warning: All models failed. Run `show_notes(.Last.tune.result)` for more
#> information.
show_notes(.Last.tune.result)
#> unique notes:
#> ──────────────────────────────────────────────────
#> Error in `step_dummy()`:
#> Caused by error in `prep()`:
#> Caused by error in `all_nominal_predictors()`:
#> ! could not find function "all_nominal_predictors"
```

<sup>Created on 2025-08-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

This PR fully loads the packages that people are most likely to specify. 