### PR TITLE
Smooth out fitting the post stage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     tidyselect (>= 1.1.2),
     vctrs (>= 0.6.1),
     withr,
-    workflows (>= 1.2.0.9000),
+    workflows (>= 1.2.0.9001),
     yardstick (>= 1.3.0)
 Suggests: 
     C50,
@@ -64,7 +64,7 @@ Suggests:
 Remotes:
     tidymodels/rsample,
     tidymodels/tailor,
-    tidymodels/workflows
+    tidymodels/workflows#298
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Suggests:
 Remotes:
     tidymodels/rsample,
     tidymodels/tailor,
-    tidymodels/workflows#298
+    tidymodels/workflows
 Config/Needs/website: pkgdown, tidymodels, kknn, doParallel, doFuture,
     tidyverse/tidytemplate
 Config/testthat/edition: 3

--- a/tests/testthat/test-loop-over-all-stages-helpers-train-post.R
+++ b/tests/testthat/test-loop-over-all-stages-helpers-train-post.R
@@ -10,8 +10,8 @@ test_that("tailor trains calibrator", {
   wflow_fit <- .fit_pre(wflow_cal, cls$data) |>
     .fit_model(control = control_workflow())
 
-  predictions <- augment(wflow_fit$fit$fit, cls$data)
-  res <- tune:::finalize_fit_post(wflow_fit, predictions, grid = tibble())
+  wflow_fit <- finalize_fit_post(wflow_fit, cls$data, grid = tibble())
+  res <- extract_postprocessor(wflow_fit, estimated = TRUE)
   expect_s3_class(res, "tailor")
   expect_true(res$adjustments[[1]]$trained)
   expect_equal(
@@ -37,13 +37,15 @@ test_that("tailor updated with grid and fit", {
   wflow_fit <- .fit_pre(wflow_cal, cls$data) |>
     .fit_model(control = control_workflow())
 
-  predictions <- augment(wflow_fit$fit$fit, cls$data)
-  res <- tune:::finalize_fit_post(
+  wflow_fit <- finalize_fit_post(
     wflow_fit,
-    predictions,
+    cls$data,
     grid = tibble(cut = 0)
   )
-  re_predicted <- predict(res, predictions)
+  wflow_fit <- .fit_finalize(wflow_fit)
+
+  re_predicted <- predict(wflow_fit, cls$data)
+  res <- extract_postprocessor(wflow_fit, estimated = TRUE)
 
   expect_s3_class(res, "tailor")
   expect_true(res$adjustments[[1]]$trained)


### PR DESCRIPTION
Draft stage: need to finalize and merge https://github.com/tidymodels/workflows/pull/298 first (and change the remote from that PR to workflows `main` branch)

tune fits the workflow in stages, so that we can, e.g., do expensive preprocessing only as often as necessary.  For the `pre` and `model` stages, we have `finalize_fit_pre()` and `finalize_fit_model()`, which both extract the relevant component, finalize it, write it back into the workflow, and then use the corresponding `.fit_*()` function from workflows to fit the stage (within the workflow). 

This PR applies the same pattern to the `post` stage, making use of `workflows::.fit_post()`. This means that, for calibration, we do not have to generate predictions on the calibration set manually, `.fit_post()` is taking care of that.

As part of this, this PR also fixes where the unfitted and the fitted versions of the tailor object are stored within the workflow: the unfitted version in the `action`, the fitted version in the `fit` slot.

We could also use `predict.workflow()`. It generates the predictions from the (primary) model and then adjusts them based on the (fitted) tailor. Since we already generated the model predictions earlier in the loop, we extract the fitted tailor and adjust those instead of re-generating them as part of `predict.workflow()`. 