### PR TITLE
Use new `data_calibration` arg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     tidyselect (>= 1.1.2),
     vctrs (>= 0.6.1),
     withr,
-    workflows (>= 1.2.0.9001),
+    workflows (>= 1.2.0.9002),
     yardstick (>= 1.3.0)
 Suggests: 
     C50,

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -186,7 +186,7 @@ has_tailor_estimated <- function(x) {
 # ------------------------------------------------------------------------------
 # Prediction and postprocessing
 
-finalize_fit_post <- function(wflow_current, calibration, grid = NULL) {
+finalize_fit_post <- function(wflow_current, data_calibration, grid = NULL) {
   if (is.null(grid)) {
     grid <- dplyr::tibble()
   }
@@ -195,7 +195,7 @@ finalize_fit_post <- function(wflow_current, calibration, grid = NULL) {
     finalize_tailor(grid)
   wflow_current <- set_workflow_tailor(wflow_current, post_obj)
 
-  workflows::.fit_post(wflow_current, calibration)
+  workflows::.fit_post(wflow_current, data_calibration)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -188,7 +188,7 @@ loop_over_all_stages <- function(resamples, grid, static) {
             current_wflow <- .catch_and_log(
               finalize_fit_post(
                 current_wflow,
-                calibration = tailor_train_data,
+                data_calibration = tailor_train_data,
                 grid = post_grid
               ),
               control = static$control,

--- a/tests/testthat/test-last-fit.R
+++ b/tests/testthat/test-last-fit.R
@@ -308,7 +308,7 @@ test_that("can use `last_fit()` with a workflow - postprocessor (requires traini
     generics::fit(
       wflow,
       rsample::analysis(internal_calibration_split),
-      calibration = rsample::calibration(internal_calibration_split)
+      data_calibration = rsample::calibration(internal_calibration_split)
     )
 
   wflow_cal <-

--- a/tests/testthat/test-loop-over-all-stages-helpers-predict-all-types.R
+++ b/tests/testthat/test-loop-over-all-stages-helpers-predict-all-types.R
@@ -158,7 +158,7 @@ test_that("predict classification - no submodels - with calibration", {
   cal_pst <- tailor() |> adjust_probability_calibration()
 
   wflow <- workflow(pca_rec, logistic_reg(), cal_pst)
-  wflow_fit <- fit(wflow, cls$data, calibration = cls$data)
+  wflow_fit <- fit(wflow, cls$data, data_calibration = cls$data)
   grd <- tibble()
 
   class_only <- metric_set(accuracy)
@@ -522,7 +522,7 @@ test_that("predict classification - with submodels - with calibration", {
   cal_pst <- tailor() |> adjust_probability_calibration()
 
   wflow <- workflow(pca_rec, knn_cls_spec, cal_pst)
-  wflow_fit <- fit(wflow, cls$data, calibration = cls$data)
+  wflow_fit <- fit(wflow, cls$data, data_calibration = cls$data)
   grd <- tibble()
 
   class_only <- metric_set(accuracy)
@@ -770,7 +770,7 @@ test_that("predict regression - no submodels - with calibration", {
   reg_pst <- tailor() |> adjust_numeric_calibration()
 
   wflow <- workflow(pca_rec, linear_reg(), reg_pst)
-  wflow_fit <- fit(wflow, reg$data, calibration = reg$data)
+  wflow_fit <- fit(wflow, reg$data, data_calibration = reg$data)
   grd <- tibble()
 
   reg_mtr <- metric_set(rmse)
@@ -892,7 +892,7 @@ test_that("predict regression - with submodels - with calibration", {
   reg_pst <- tailor() |> adjust_numeric_calibration()
 
   wflow <- workflow(pca_rec, knn_reg_spec, reg_pst)
-  wflow_fit <- fit(wflow, reg$data, calibration = reg$data)
+  wflow_fit <- fit(wflow, reg$data, data_calibration = reg$data)
 
   reg_mtr <- metric_set(rmse)
 


### PR DESCRIPTION
instead of `calibration`, following on fromhttps://github.com/tidymodels/workflows/pull/302

This PR also renames the argument for the calibration set in `finalize_fit_post()` to `data_calibration` so that we use the same name for the same thing in both workflows and tune.