### PR TITLE
two future option updates

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -378,7 +378,8 @@ loop_call <-
       future_opts <- list(
         future.label = "tune-grid-%d",
         future.stdout = TRUE,
-        future.seed = NULL
+        future.seed = TRUE,
+        future.globals = names(base_args)
       )
       base_args <- c(base_args, future_opts)
     }
@@ -402,7 +403,8 @@ pctl_call <- function(framework, args = list()) {
     future_opts <- list(
       future.label = "int-pctl-%d",
       future.stdout = TRUE,
-      future.seed = NULL
+      future.seed = TRUE,
+      future.globals = names(args)
     )
     args <- c(args, future_opts)
   }

--- a/tests/testthat/_snaps/parallel.md
+++ b/tests/testthat/_snaps/parallel.md
@@ -178,7 +178,8 @@
     Output
       future.apply::future_lapply(resamples, loop_over_all_stages, 
           grid = grid, static = static, future.label = "tune-grid-%d", 
-          future.stdout = TRUE, future.seed = NULL)
+          future.stdout = TRUE, future.seed = TRUE, future.globals = c("grid", 
+          "static"))
 
 ---
 
@@ -187,7 +188,8 @@
     Output
       future.apply::future_lapply(resamples, loop_over_all_stages, 
           grid = grid, static = static, a = a, future.label = "tune-grid-%d", 
-          future.stdout = TRUE, future.seed = NULL)
+          future.stdout = TRUE, future.seed = TRUE, future.globals = c("grid", 
+          "static", "a"))
 
 ---
 
@@ -196,7 +198,8 @@
     Output
       future.apply::future_lapply(inds, loop_over_all_stages2, resamples = resamples, 
           grid = candidates, static = static, future.label = "tune-grid-%d", 
-          future.stdout = TRUE, future.seed = NULL)
+          future.stdout = TRUE, future.seed = TRUE, future.globals = c("resamples", 
+          "grid", "static"))
 
 ---
 
@@ -205,7 +208,8 @@
     Output
       future.apply::future_lapply(inds, loop_over_all_stages2, resamples = resamples, 
           grid = candidates, static = static, a = a, future.label = "tune-grid-%d", 
-          future.stdout = TRUE, future.seed = NULL)
+          future.stdout = TRUE, future.seed = TRUE, future.globals = c("resamples", 
+          "grid", "static", "a"))
 
 ---
 


### PR DESCRIPTION
Closes #1087

Try to set global variables to avoid warnings. Also, tell future to use its own seeds even though we use our own. 