### PR TITLE
fix `int_pctl()` and `future.globals = NULL` bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # tune (development version)
 
-* Fixed a bug where `int_pctl()` wouldn't work on `last_fit()` outcomes when future parallelism was enabled. (1099) 
+* Fixed a bug where `int_pctl()` wouldn't work on `last_fit()` outcomes when future parallelism was enabled. (#1099) 
 
 # tune 2.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* Fixed a bug where `int_pctl()` wouldn't work on `last_fit()` outcomes when future parallelism was enabled. (1099) 
+
 # tune 2.0.0
 
 ## Changes to `tune_grid()`. 

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -449,9 +449,11 @@ pctl_call <- function(framework, args = list()) {
     future_opts <- list(
       future.label = "int-pctl-%d",
       future.stdout = TRUE,
-      future.seed = TRUE,
-      future.globals = names(args)
+      future.seed = TRUE
     )
+    if (!is.null(names(args))) {
+      future_opts$future.globals <- names(args)
+    }
     args <- c(args, future_opts)
   }
 


### PR DESCRIPTION
To close #1099

future doesn't like it when `future.globals = NULL` so this PR simply doesn't set it if it is `NULL`