### PR TITLE
work with null results when model fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * The warning threshold when check the size of a workflow is now a parameter to the control functions and has a new default of 100MB. (#914)
 
+* A bug was fixed where `NULL` results generated during simulated annealing would cause errors when logging. 
+
 ## Breaking Changes
 
 * The Gaussian process model package was changed from \pkg{GPfit} to \pkg{GauPro} because the former is no longer actively maintained. There are some differences: 

--- a/R/tune_bayes.R
+++ b/R/tune_bayes.R
@@ -516,25 +516,24 @@ tune_bayes_workflow <- function(
       check_time(start_time, control$time_limit)
 
       all_bad <- is_cataclysmic(tmp_res)
-
       if (!inherits(tmp_res, "try-error") & !all_bad) {
         tmp_res[[".metrics"]] <- purrr::map(
           tmp_res[[".metrics"]],
-          dplyr::mutate,
-          .config = iter_chr[i]
+          set_config,
+          config = iter_chr[i]
         )
         if (control$save_pred) {
           tmp_res[[".predictions"]] <- purrr::map(
             tmp_res[[".predictions"]],
-            dplyr::mutate,
-            .config = iter_chr[i]
+            set_config,
+            config = iter_chr[i]
           )
         }
         if (".extracts" %in% names(tmp_res)) {
           tmp_res[[".extracts"]] <- purrr::map(
             tmp_res[[".extracts"]],
-            dplyr::mutate,
-            .config = iter_chr[i]
+            set_config,
+            config = iter_chr[i]
           )
         }
         unsummarized <- dplyr::bind_rows(
@@ -618,6 +617,17 @@ check_iter <- function(iter, call) {
   }
 
   iter
+}
+
+set_config <- function(x, config = NULL, prefix = NULL) {
+  if (!is.null(x)) {
+    if (!is.null(prefix)) {
+      x <- dplyr::mutate(x, .config = paste0(prefix, "_", .config))
+    } else {
+      x <- dplyr::mutate(x, .config = config)
+    }
+  }
+  x
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-tune_bayes.R
+++ b/tests/testthat/test-tune_bayes.R
@@ -653,3 +653,26 @@ test_that("tune_bayes() output for `iter` edge cases (#721)", {
     tune_bayes(wf, boots, iter = NULL)
   )
 })
+
+# ------------------------------------------------------------------------------
+
+test_that("tune_bayes loggining doesn't error with failed model", {
+  # no failed results:
+  res_1 <- purrr::map_dfr(
+    ames_iter_search$.metrics,
+    tune:::set_config,
+    config = "beratna"
+  )
+  expect_true(all(res_1$.config == "beratna"))
+
+  has_failure <- tune:::vec_list_rowwise(ames_iter_search$.metrics[[1]])[1:3]
+  has_failure[2] <- list(NULL)
+  res_2 <- purrr::map(
+    has_failure,
+    tune:::set_config,
+    config = "sasa ke?"
+  )
+  expect_null(res_2[[2]])
+  expect_equal(res_2[[1]]$.config, "sasa ke?")
+  expect_equal(res_2[[3]]$.config, "sasa ke?")
+})


### PR DESCRIPTION
In some cases, the model may fail during an iteration of BO. This causes an error when we try to update the .config values of NULL.