### PR TITLE
Add "Supported By Posit" badge to tune website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,7 +2,7 @@ url: https://tune.tidymodels.org/
 
 navbar:
   components:
-    home: ~
+    home:
     tutorials:
       text: Learn more
       menu:
@@ -21,8 +21,9 @@ template:
     primary: "#CA225E"
 
   includes:
-      in_header: |
-        <script defer data-domain="tune.tidymodels.org,all.tidymodels.org" src="https://plausible.io/js/plausible.js"></script>
+    in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-hide-below="1200" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
+      <script defer data-domain="tune.tidymodels.org,all.tidymodels.org" src="https://plausible.io/js/plausible.js"></script>
 
 development:
   mode: auto
@@ -32,44 +33,44 @@ figures:
   fig.height: 5.75
 
 reference:
-  - title: Fit many models
-    contents:
-    - tune_grid
-    - tune_bayes
-    - expo_decay
-    - conf_bound
-    - starts_with("melodie")
-    - fit_resamples
-    - control_grid
-    - control_bayes
-    - parallelism
-  - title: Fit one model
-    contents:
-    - fit_best
-    - last_fit
-    - starts_with("finalize")
-    - control_last_fit
-  - title: Inspect results
-    contents:
-    - starts_with("collect")
-    - show_notes
-    - show_best
-    - starts_with("select_")
-    - filter_parameters
-    - autoplot.tune_results
-    - coord_obs_pred
-    - conf_mat_resampled
-  - title: Miscellaneous
-    contents:
-    - starts_with("extract_")
-    - starts_with("int_pctl")
-    - starts_with("compute")
-    - augment.tune_results
-    - example_ames_knn
-    - contains("resample_weight")
-  - title: Developer functions
-    contents:
-    - merge.recipe
-    - message_wrap
-    - .use_case_weights_with_yardstick
-    - .stash_last_result
+- title: Fit many models
+  contents:
+  - tune_grid
+  - tune_bayes
+  - expo_decay
+  - conf_bound
+  - starts_with("melodie")
+  - fit_resamples
+  - control_grid
+  - control_bayes
+  - parallelism
+- title: Fit one model
+  contents:
+  - fit_best
+  - last_fit
+  - starts_with("finalize")
+  - control_last_fit
+- title: Inspect results
+  contents:
+  - starts_with("collect")
+  - show_notes
+  - show_best
+  - starts_with("select_")
+  - filter_parameters
+  - autoplot.tune_results
+  - coord_obs_pred
+  - conf_mat_resampled
+- title: Miscellaneous
+  contents:
+  - starts_with("extract_")
+  - starts_with("int_pctl")
+  - starts_with("compute")
+  - augment.tune_results
+  - example_ames_knn
+  - contains("resample_weight")
+- title: Developer functions
+  contents:
+  - merge.recipe
+  - message_wrap
+  - .use_case_weights_with_yardstick
+  - .stash_last_result


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the tune website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of tune website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/tune-1200.png)

At 992px browser width:

![Screenshot of tune website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/tune-992.png)

At 991px browser width:

![Screenshot of tune website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/tune-991.png)

