### PR TITLE
replace some tidyverse code with base R  or vctrs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tune
 Title: Tidy Tuning Tools
-Version: 2.0.1.9002
+Version: 2.0.1.9003
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/checks.R
+++ b/R/checks.R
@@ -550,7 +550,7 @@ check_initial <- function(
     }
   }
   if (!any(names(x) == ".iter")) {
-    x <- x |> dplyr::mutate(.iter = 0L)
+    x$.iter <- 0L
   }
   x
 }

--- a/R/filter_parameters.R
+++ b/R/filter_parameters.R
@@ -91,7 +91,7 @@ filter_by_join <- function(x, parameters = NULL, nm = "") {
   }
 
   # run a test to make sure that there are no issues in filtering
-  tst_orig <- bind_rows(x$.metrics)
+  tst_orig <- vctrs::vec_rbind(!!!x$.metrics)
   tst_filtered <- filter_join_iter(tst_orig, parameters)
   if (nrow(tst_filtered) == 0) {
     cli::cli_abort("No parameter combinations were selected using your subset.")

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -44,7 +44,10 @@ finalize_model <- function(x, parameters) {
 
   parameters <- parameters[names(parameters) %in% pset$id]
 
-  discordant <- dplyr::filter(pset, id != name & id %in% names(parameters))
+  discordant <- vctrs::vec_slice(
+    pset,
+    pset$id != pset$name & pset$id %in% names(parameters)
+  )
   if (nrow(discordant) > 0) {
     for (i in 1:nrow(discordant)) {
       names(parameters)[names(parameters) == discordant$id[i]] <-
@@ -61,9 +64,11 @@ finalize_recipe <- function(x, parameters) {
     cli::cli_abort("{.arg x} should be a recipe, not {.obj_type_friendly {x}}.")
   }
   check_final_param(parameters)
-  pset <-
-    hardhat::extract_parameter_set_dials(x) |>
-    dplyr::filter(id %in% names(parameters) & source == "recipe")
+  pset <- hardhat::extract_parameter_set_dials(x)
+  pset <- vctrs::vec_slice(
+    pset,
+    pset$id %in% names(parameters) & pset$source == "recipe"
+  )
 
   if (tibble::is_tibble(parameters)) {
     parameters <- as.list(parameters)
@@ -116,10 +121,12 @@ finalize_tailor <- function(x, parameters) {
     cli::cli_abort("{.arg x} should be a tailor, not {.obj_type_friendly {x}}.")
   }
   check_final_param(parameters)
-  pset <-
-    hardhat::extract_parameter_set_dials(x) |>
-    dplyr::filter(id %in% names(parameters) & source == "tailor") |>
-    dplyr::as_tibble()
+  pset <- hardhat::extract_parameter_set_dials(x)
+  pset <- vctrs::vec_slice(
+    pset,
+    pset$id %in% names(parameters) & pset$source == "tailor"
+  )
+  pset <- tibble::as_tibble(pset)
 
   if (tibble::is_tibble(parameters)) {
     parameters <- as.list(parameters)

--- a/R/logging.R
+++ b/R/logging.R
@@ -200,22 +200,22 @@ summarize_catalog <- function(catalog, sep = "   ") {
     return("")
   }
 
-  res <- dplyr::arrange(catalog, id)
-  res <- dplyr::mutate(
-    res,
-    color = dplyr::if_else(
-      type == "warning",
-      list(cli::col_yellow),
-      list(cli::col_red)
-    )
+  res <- catalog[order(catalog$id), ]
+  res$color <- ifelse(
+    res$type == "warning",
+    list(cli::col_yellow),
+    list(cli::col_red)
   )
-  res <- dplyr::rowwise(res)
-  res <- dplyr::mutate(
-    res,
-    msg = glue::glue("{color(cli::style_bold(lbls[id]))}: x{n}")
+  res$msg <- vapply(
+    seq_len(nrow(res)),
+    function(i) {
+      glue::glue(
+        "{res$color[[i]](cli::style_bold(lbls[res$id[i]]))}: x{res$n[i]}"
+      )
+    },
+    character(1)
   )
-  res <- dplyr::ungroup(res)
-  res <- dplyr::pull(res, msg)
+  res <- res[["msg"]]
   res <- glue::glue_collapse(res, sep = sep)
 
   res
@@ -487,9 +487,9 @@ log_progress <- function(
     return(invisible(NULL))
   }
 
-  x <- dplyr::filter(x, .metric == objective)
+  x <- vctrs::vec_slice(x, x$.metric == objective)
   if (!is.null(eval_time)) {
-    x <- dplyr::filter(x, .eval_time == eval_time)
+    x <- vctrs::vec_slice(x, x$.eval_time == eval_time)
   }
 
   if (maximize) {

--- a/R/tune_grid_loop.R
+++ b/R/tune_grid_loop.R
@@ -122,12 +122,12 @@ tune_grid_loop <- function(
   # ----------------------------------------------------------------------------
   # Separate results into different components
 
-  res <- dplyr::bind_rows(res)
+  res <- vctrs::vec_rbind(!!!res)
 
   outcome_names <- unique(unlist(res$outcome_names))
   res$outcome_names <- NULL
 
-  resamples <- dplyr::bind_rows(resamples)
+  resamples <- vctrs::vec_rbind(!!!resamples)
   id_cols <- grep("^id", names(resamples), value = TRUE)
 
   if (control$parallel_over == "resamples") {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -49,6 +49,7 @@ parallelization
 postprocessing
 postprocessor
 pre
+pred
 preprocessor
 preprocessors
 reprex


### PR DESCRIPTION
Based on Simon's previous [blog posts](https://tidyverse.org/blog/2023/04/performant-packages/), I used a Claude skill to do the conversion.

The code is less readable, and there is no real speedup. I did a few benchmarks: 

- Resample measurements of an `lm()` model using `mtcars` via 10 bootstraps. Speedup: 1.04-fold (i.e., a 4% improvement) 
- Collect the resampled predictions for the `lm()` model ☝️ and average them. Speedup: 0.897 (a.k.a. a 1.11-fold _slowdown_). 
- Resample measurements of an `lm()` model using `mtcars` via 5,000 bootstraps. Speedup: 1.11-fold
- Tuned a CART model using Bayesian optimization for a total of 23 model configurations via 10-fold CV. Speedup: 1.09-fold

Fast training models were chosen so that long model training time didn't saturate the overall elapsed times. 

I'm unlikely to merge this since the changes are meager and, for almost any practical data set, will get washed away due to longer trianing times. 

