### PR TITLE
fix `inner_join()` complaints

### DIFF
--- a/R/collect.R
+++ b/R/collect.R
@@ -424,13 +424,13 @@ average_predictions <- function(x, grid = NULL) {
     }
     if (length(param_names) == 0) {
       x$.predictions <-
-        purrr::map(x$.predictions, dplyr::cross_join, parameters)
+        purrr::map(x$.predictions, dplyr::cross_join, grid)
     } else {
       x$.predictions <-
         purrr::map(
           x$.predictions,
           dplyr::inner_join,
-          parameters,
+          grid,
           by = param_names
         )
     }


### PR DESCRIPTION
`inner_join()` doesn't like it when you set `by = character()` which happens sometimes inside {tune}.

I fixed this by adding a `if () else`

Secondly i fixed a typo in `average_predictions()` in which the code was copied from `filter_predictions()` inproperly
