### PR TITLE
Loop(y): Predict for all submodels at once

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@
 
 * Fixed a bug for cases where we tune a grid without a model parameter but with a postprocessing parameter (#1119)
 
+* Tuning of models with submodel parameters now predicts all submodels at once (again) to speed up the tuning process (#1140).
+
 ## Breaking Changes
 
 * The Gaussian process model package was changed from \pkg{GPfit} to \pkg{GauPro} because the former is no longer actively maintained. There are some differences: 

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -132,8 +132,31 @@
       )
 
       # --------------------------------------------------------------------------
-      # Iterate over prediction submodels; no multipredict, just one at a time
-      # without retraining the model
+      # Predict all submodels at once (if applicable), then iterate over them
+      # for postprocessing
+
+      if (has_submodel) {
+        # Collect all submodel values and predict once
+        all_sub_sched <- current_sched_model$predict_stage[[1]]
+        sub_nm <- get_sub_param(all_sub_sched)
+        all_sub_grid <- all_sub_sched[, sub_nm, drop = FALSE]
+
+        location <- glue::glue(
+          "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model} (predictions)"
+        )
+        all_submodel_pred <- .catch_and_log(
+          predict_all_types(current_wflow, pred_data, static, all_sub_grid),
+          control = static$control,
+          split_labels = split_labs,
+          location = location,
+          notes = notes
+        )
+
+        if (is_failure(all_submodel_pred)) {
+          next
+        }
+        all_submodel_pred <- remove_log_notes(all_submodel_pred)
+      }
 
       for (iter_pred in seq_len(num_iterations_pred)) {
         current_sched_pred <- current_sched_model$predict_stage[[1]][
@@ -142,27 +165,18 @@
 
         if (has_submodel) {
           sub_nm <- get_sub_param(current_sched_pred)
-          sub_grid <- current_sched_pred[, sub_nm]
+          sub_val <- current_sched_pred[[sub_nm]]
 
           # The assigned submodel parameter (from min_grid()) is in the
           # current grid. Remove that and add the one that we are predicting on
-
           current_grid <- current_grid |>
             dplyr::select(-dplyr::all_of(sub_nm)) |>
             rebind_grid(current_sched_pred)
 
-          # Remove the submodel column since it is in the currrent grid.
-          location <- glue::glue(
-            "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model} (predictions)"
-          )
-          current_pred <- .catch_and_log(
-            predict_all_types(current_wflow, pred_data, static, sub_grid) |>
-              dplyr::select(-dplyr::all_of(sub_nm)),
-            control = static$control,
-            split_labels = split_labs,
-            location = location,
-            notes = notes
-          )
+          # Filter to this submodel's predictions (already computed above)
+          current_pred <- all_submodel_pred |>
+            dplyr::filter(.data[[sub_nm]] == sub_val) |>
+            dplyr::select(-dplyr::all_of(sub_nm))
         } else {
           location <- glue::glue(
             "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model} (predictions)"
@@ -174,12 +188,12 @@
             location = location,
             notes = notes
           )
-        }
 
-        if (is_failure(current_pred)) {
-          next
+          if (is_failure(current_pred)) {
+            next
+          }
+          current_pred <- remove_log_notes(current_pred)
         }
-        current_pred <- remove_log_notes(current_pred)
 
         has_post <- has_tailor(current_wflow)
         num_iterations_post <- max(nrow(current_sched_pred$post_stage[[1]]), 1)


### PR DESCRIPTION
closes #1135

We first filtered down to a single submodel parameter before calculating the predictions:
https://github.com/tidymodels/tune/blob/c46909125cc4e9531886cc6d1bb3827bfa680787/R/loop_over_all_stages.R#L139-L141

Therefore `predict_all_types()` -> `predict_wrapper()` never called `mulit_predict()` but rather `predict()` repeatedly.

With `multi_predict()` things are considerably faster. In the example from the issue:

Small grid:  3.281 sec to 0.882 sec on my machine
Large grid: 52.706 sec to 7.213 sec on my machine

```
library(tidyverse)
library(tidymodels)
library(tictoc)

d <- ames |>
  select(where(is.numeric)) |>
  drop_na()

rec <- recipe(Sale_Price ~ ., data = d) |>
  step_normalize(all_predictors())

# 5-fold CV
splits <- d |>
  vfold_cv(v = 5)

# ------------------------------------------------------------------------------

alpha <- seq(0, 1, length.out = 3)
lambda_small <- seq(0, 1, length.out = 10)

# grid with 30 values
grid_small <- expand_grid(
  penalty = lambda_small,
  mixture = alpha
)

tic()
fits_baseline <- linear_reg(penalty = tune(), mixture = tune()) |>
  set_engine("glmnet") |>
  tune_grid(
    preprocessor = rec,
    resamples = splits,
    grid = grid_small,
    metrics = metric_set(rmse),
    control = control_grid(verbose = TRUE)
  )
toc()
#> main: 3.281 sec elapsed
#> dev: 0.882 sec elapsed

metrics_baseline <- collect_metrics(fits_baseline)
nrow(metrics_baseline)

# ------------------------------------------------------------------------------

lambda_large <- seq(0, 1, length.out = 200)

# grid with 600 values
grid_large <- expand_grid(penalty = lambda_large, mixture = alpha)

tic()
fits_1 <- linear_reg(penalty = tune(), mixture = tune()) |>
  set_engine("glmnet") |>
  tune_grid(
    preprocessor = rec,
    resamples = splits,
    grid = grid_large,
    metrics = metric_set(rmse)
  )
toc()
#> main: 52.706 sec elapsed
#> dev: 7.213 sec elapsed

metrics_1 <- collect_metrics(fits_1)
nrow(metrics_1)
```