### PR TITLE
Fit resampled calbration model on correct submodel predictions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,5 @@
 # tune (development version)
 
-
 * Model tuning has been enabled for quantile regression models. (#1125)
 
 * In `tune_grid()`, a bug was fixed that caused inefficiency where preprocessing steps were applied to data being predicted several times (redundantly). We now execute that operation once. (#1101)
@@ -22,6 +21,8 @@
 * Fixed a bug for cases where we tune a grid without a model parameter but with a postprocessing parameter (#1119)
 
 * Tuning of models with submodel parameters now predicts all submodels at once (again) to speed up the tuning process (#1140).
+
+* Fixed a bug where models with submodel parameters would train all calibration models on predictions from a single submodel value instead of the correct value for each submodel (#1144).
 
 ## Breaking Changes
 

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -233,12 +233,14 @@ fit_post_from_predictions <- function(wflow, cal_predictions) {
 
 predict_all_types <- function(
   wflow_fit,
-  processed_data_pred,
+  processed_data,
   static,
-  submodel_grid = NULL
+  submodel_grid = NULL,
+  source = c("pred", "cal")
 ) {
-  .data <- static$data$pred$data
-  .ind <- static$data$pred$ind
+  source <- rlang::arg_match(source)
+  .data <- static$data[[source]]$data
+  .ind <- static$data[[source]]$ind
 
   model_fit <- wflow_fit |> hardhat::extract_fit_parsnip()
 
@@ -253,7 +255,7 @@ predict_all_types <- function(
   for (type_iter in static$pred_types) {
     tmp_res <- predict_wrapper(
       model = model_fit,
-      new_data = processed_data_pred$predictors,
+      new_data = processed_data$predictors,
       type = type_iter,
       eval_time = static$eval_time,
       subgrid = submodel_grid
@@ -289,7 +291,7 @@ predict_all_types <- function(
   }
 
   pred <- pred |>
-    dplyr::full_join(processed_data_pred$outcomes, by = ".row")
+    dplyr::full_join(processed_data$outcomes, by = ".row")
 
   # Add implicitly grouped metric data, if applicable
   metrics_by <- get_metrics_by(static$metrics)

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -193,8 +193,15 @@ finalize_fit_post <- function(
   wflow_current,
   data_calibration = NULL,
   grid = NULL,
-  cal_predictions = NULL
+  predictions_calibration = NULL
 ) {
+  if (!is.null(data_calibration) && !is.null(predictions_calibration)) {
+    cli::cli_warn(
+      "Both {.arg data_calibration} and {.arg predictions_calibration} were
+      supplied; using {.arg predictions_calibration}."
+    )
+  }
+
   if (is.null(grid)) {
     grid <- dplyr::tibble()
   }
@@ -203,20 +210,20 @@ finalize_fit_post <- function(
     finalize_tailor(grid)
   wflow_current <- set_workflow_tailor(wflow_current, post_obj)
 
-  if (!is.null(cal_predictions)) {
-    fit_post_from_predictions(wflow_current, cal_predictions)
+  if (!is.null(predictions_calibration)) {
+    fit_post_from_predictions(wflow_current, predictions_calibration)
   } else {
     workflows::.fit_post(wflow_current, data_calibration)
   }
 }
 
-fit_post_from_predictions <- function(wflow, cal_predictions) {
-  tailor_obj <- hardhat::extract_postprocessor(wflow)
+fit_post_from_predictions <- function(wflow, predictions_calibration) {
+  tailor_obj <- hardhat::extract_postprocessor(wflow, estimated = FALSE)
   outcome_names <- names(hardhat::extract_mold(wflow)$outcomes)
 
   post_fit <- tailor::fit(
     object = tailor_obj,
-    .data = cal_predictions,
+    .data = predictions_calibration,
     outcome = outcome_names,
     estimate = tidyselect::any_of(c(".pred", ".pred_class")),
     probabilities = c(

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -189,7 +189,12 @@ has_tailor_estimated <- function(x) {
 # ------------------------------------------------------------------------------
 # Prediction and postprocessing
 
-finalize_fit_post <- function(wflow_current, data_calibration, grid = NULL) {
+finalize_fit_post <- function(
+  wflow_current,
+  data_calibration = NULL,
+  grid = NULL,
+  cal_predictions = NULL
+) {
   if (is.null(grid)) {
     grid <- dplyr::tibble()
   }
@@ -198,7 +203,30 @@ finalize_fit_post <- function(wflow_current, data_calibration, grid = NULL) {
     finalize_tailor(grid)
   wflow_current <- set_workflow_tailor(wflow_current, post_obj)
 
-  workflows::.fit_post(wflow_current, data_calibration)
+  if (!is.null(cal_predictions)) {
+    fit_post_from_predictions(wflow_current, cal_predictions)
+  } else {
+    workflows::.fit_post(wflow_current, data_calibration)
+  }
+}
+
+fit_post_from_predictions <- function(wflow, cal_predictions) {
+  tailor_obj <- hardhat::extract_postprocessor(wflow)
+  outcome_names <- names(hardhat::extract_mold(wflow)$outcomes)
+
+  post_fit <- tailor::fit(
+    object = tailor_obj,
+    .data = cal_predictions,
+    outcome = outcome_names,
+    estimate = tidyselect::any_of(c(".pred", ".pred_class")),
+    probabilities = c(
+      tidyselect::contains(".pred_"),
+      -tidyselect::matches("^\\.pred$|^\\.pred_class$")
+    )
+  )
+
+  wflow$post$fit <- post_fit
+  wflow
 }
 
 # ------------------------------------------------------------------------------

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -191,17 +191,9 @@ has_tailor_estimated <- function(x) {
 
 finalize_fit_post <- function(
   wflow_current,
-  data_calibration = NULL,
-  grid = NULL,
-  predictions_calibration = NULL
+  predictions_calibration,
+  grid = NULL
 ) {
-  if (!is.null(data_calibration) && !is.null(predictions_calibration)) {
-    cli::cli_warn(
-      "Both {.arg data_calibration} and {.arg predictions_calibration} were
-      supplied; using {.arg predictions_calibration}."
-    )
-  }
-
   if (is.null(grid)) {
     grid <- dplyr::tibble()
   }
@@ -210,13 +202,13 @@ finalize_fit_post <- function(
     finalize_tailor(grid)
   wflow_current <- set_workflow_tailor(wflow_current, post_obj)
 
-  if (!is.null(predictions_calibration)) {
-    fit_post_from_predictions(wflow_current, predictions_calibration)
-  } else {
-    workflows::.fit_post(wflow_current, data_calibration)
-  }
+  fit_post_from_predictions(wflow_current, predictions_calibration)
 }
 
+# This mimics `.fit_post()`, except it takes predictions instead of the
+# unprocessed calibration data.
+# We do that because we want to predict for all submodels at once
+# (as we do for the assessment set).
 fit_post_from_predictions <- function(wflow, predictions_calibration) {
   tailor_obj <- hardhat::extract_postprocessor(wflow, estimated = FALSE)
   outcome_names <- names(hardhat::extract_mold(wflow)$outcomes)

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -205,7 +205,7 @@ finalize_fit_post <- function(
   fit_post_from_predictions(wflow_current, predictions_calibration)
 }
 
-# This mimics `.fit_post()`, except it takes predictions instead of the
+# This mimics `workflows::.fit_post()`, except it takes predictions instead of the
 # unprocessed calibration data.
 # We do that because we want to predict for all submodels at once
 # (as we do for the assessment set).

--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -352,14 +352,19 @@ finalize_fit_model <- function(wflow_current, grid) {
 # ------------------------------------------------------------------------------
 # To call after the model is set and we loop over predict and/or post parameters
 # See #1128
-process_prediction_data <- function(wflow_fit, static) {
-  .data <- static$data$pred$data
-  .ind <- static$data$pred$ind
+process_prediction_data <- function(
+  wflow_fit,
+  static,
+  source = c("pred", "cal")
+) {
+  source <- rlang::arg_match(source)
+  .data <- static$data[[source]]$data
+  .ind <- static$data[[source]]$ind
 
-  processed_data_pred <- forge_from_workflow(.data, wflow_fit)
-  processed_data_pred$outcomes <- processed_data_pred$outcomes |>
+  processed_data <- forge_from_workflow(.data, wflow_fit)
+  processed_data$outcomes <- processed_data$outcomes |>
     dplyr::mutate(.row = .ind)
-  processed_data_pred
+  processed_data
 }
 
 

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -86,6 +86,9 @@
         location = location,
         notes = notes
       )
+    if (is_failure(pred_data)) {
+      next
+    }
 
     # Also process the calibration data (if needed for postprocessor fitting).
     has_post_estimation <- static$post_estimation
@@ -113,10 +116,6 @@
     wflow_with_fitted_pre <- current_wflow
 
     grid_with_pre <- current_grid
-
-    if (is_failure(pred_data)) {
-      next
-    }
 
     for (iter_model in seq_len(num_iterations_model)) {
       current_sched_model <- current_sched_pre$model_stage[[1]][iter_model, ]

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -88,15 +88,10 @@
       )
 
     # Also process the calibration data (if needed for postprocessor fitting).
-    # Reuse process_prediction_data() by temporarily swapping cal into the pred
-    # slot of static, since both have the same structure ($data + $ind).
     cal_pred_data <- NULL
-    static_for_cal <- NULL
     if (!is.null(static$data$cal)) {
-      static_for_cal <- static
-      static_for_cal$data$pred <- static$data$cal
       cal_pred_data <- .catch_and_log(
-        process_prediction_data(current_wflow, static_for_cal),
+        process_prediction_data(current_wflow, static, source = "cal"),
         control = static$control,
         split_labels = split_labs,
         location = location,

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -254,6 +254,7 @@
         # if the postprocessor does not require a fit,
         # this does not cause data leakage
         current_cal_pred <- current_pred
+        
         if (has_post_estimation) {
           if (has_submodel) {
             current_cal_pred <- cal_pred_all_submodels |>

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -93,6 +93,9 @@
     # Also process the calibration data (if needed for postprocessor fitting).
     has_post_estimation <- static$post_estimation
     if (has_post_estimation) {
+      location <- glue::glue(
+        "preprocessor {iter_pre}/{num_iterations_pre} (calibration data)"
+      )
       cal_pred_data <- .catch_and_log(
         process_prediction_data(current_wflow, static, source = "cal"),
         control = static$control,

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -88,8 +88,8 @@
       )
 
     # Also process the calibration data (if needed for postprocessor fitting).
-    cal_pred_data <- NULL
-    if (!is.null(static$data$cal)) {
+    has_post_estimation <- static$post_estimation
+    if (has_post_estimation) {
       cal_pred_data <- .catch_and_log(
         process_prediction_data(current_wflow, static, source = "cal"),
         control = static$control,
@@ -185,7 +185,7 @@
 
         # Also predict on calibration data for all submodels at once
         cal_pred_all_submodels <- NULL
-        if (!is.null(cal_pred_data) && !is_failure(cal_pred_data)) {
+        if (has_post_estimation && !is_failure(cal_pred_data)) {
           cal_pred_all_submodels <- .catch_and_log(
             predict_all_types(
               current_wflow,
@@ -247,7 +247,7 @@
         # For submodels these were pre-computed above; for non-submodels we
         # predict here (once per model, shared across post iterations).
         current_cal_pred <- NULL
-        if (static$post_estimation) {
+        if (has_post_estimation) {
           if (has_submodel) {
             if (
               !is.null(cal_pred_all_submodels) &&
@@ -257,7 +257,7 @@
                 dplyr::filter(.data[[sub_nm]] == sub_val) |>
                 dplyr::select(-dplyr::all_of(sub_nm))
             }
-          } else if (!is.null(cal_pred_data) && !is_failure(cal_pred_data)) {
+          } else if (!is_failure(cal_pred_data)) {
             current_cal_pred <- .catch_and_log(
               predict_all_types(
                 current_wflow,
@@ -306,7 +306,7 @@
             # pre-computed calibration predictions. Otherwise, use the raw
             # training data (no data leakage since no fitting occurs).
             current_wflow <- .catch_and_log(
-              if (static$post_estimation) {
+              if (has_post_estimation) {
                 finalize_fit_post(
                   wflow_with_fitted_pre_and_model,
                   grid = current_sched_post,

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -190,6 +190,9 @@
 
         # Also predict on calibration data for all submodels at once
         if (has_post_estimation) {
+          location <- glue::glue(
+            "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model} (calibration predictions)"
+          )
           cal_pred_all_submodels <- .catch_and_log(
             predict_all_types(
               current_wflow,

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -190,8 +190,9 @@
             predict_all_types(
               current_wflow,
               cal_pred_data,
-              static_for_cal,
-              grid_pred_all_submodels
+              static,
+              grid_pred_all_submodels,
+              source = "cal"
             ),
             control = static$control,
             split_labels = split_labs,
@@ -258,7 +259,12 @@
             }
           } else if (!is.null(cal_pred_data) && !is_failure(cal_pred_data)) {
             current_cal_pred <- .catch_and_log(
-              predict_all_types(current_wflow, cal_pred_data, static_for_cal),
+              predict_all_types(
+                current_wflow,
+                cal_pred_data,
+                static,
+                source = "cal"
+              ),
               control = static$control,
               split_labels = split_labs,
               location = glue::glue(

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -87,6 +87,23 @@
         notes = notes
       )
 
+    # Also process the calibration data (if needed for postprocessor fitting).
+    # Reuse process_prediction_data() by temporarily swapping cal into the pred
+    # slot of static, since both have the same structure ($data + $ind).
+    cal_pred_data <- NULL
+    static_for_cal <- NULL
+    if (!is.null(static$data$cal)) {
+      static_for_cal <- static
+      static_for_cal$data$pred <- static$data$cal
+      cal_pred_data <- .catch_and_log(
+        process_prediction_data(current_wflow, static_for_cal),
+        control = static$control,
+        split_labels = split_labs,
+        location = location,
+        notes = notes
+      )
+    }
+
     # Update y_name in case the workflow had an inline function like `log(mpg) ~ .`
     static$y_name <- outcome_names(current_wflow)
 
@@ -170,6 +187,27 @@
           next
         }
         pred_all_submodels <- remove_log_notes(pred_all_submodels)
+
+        # Also predict on calibration data for all submodels at once
+        cal_pred_all_submodels <- NULL
+        if (!is.null(cal_pred_data) && !is_failure(cal_pred_data)) {
+          cal_pred_all_submodels <- .catch_and_log(
+            predict_all_types(
+              current_wflow,
+              cal_pred_data,
+              static_for_cal,
+              grid_pred_all_submodels
+            ),
+            control = static$control,
+            split_labels = split_labs,
+            location = location,
+            notes = notes
+          )
+
+          if (!is_failure(cal_pred_all_submodels)) {
+            cal_pred_all_submodels <- remove_log_notes(cal_pred_all_submodels)
+          }
+        }
       }
 
       for (iter_pred in seq_len(num_iterations_pred)) {
@@ -209,6 +247,36 @@
         has_post <- has_tailor(current_wflow)
         num_iterations_post <- max(nrow(current_sched_pred$post_stage[[1]]), 1)
 
+        # Compute calibration predictions for this predict iteration.
+        # For submodels these were pre-computed above; for non-submodels we
+        # predict here (once per model, shared across post iterations).
+        current_cal_pred <- NULL
+        if (static$post_estimation) {
+          if (has_submodel) {
+            if (
+              !is.null(cal_pred_all_submodels) &&
+                !is_failure(cal_pred_all_submodels)
+            ) {
+              current_cal_pred <- cal_pred_all_submodels |>
+                dplyr::filter(.data[[sub_nm]] == sub_val) |>
+                dplyr::select(-dplyr::all_of(sub_nm))
+            }
+          } else if (!is.null(cal_pred_data) && !is_failure(cal_pred_data)) {
+            current_cal_pred <- .catch_and_log(
+              predict_all_types(current_wflow, cal_pred_data, static_for_cal),
+              control = static$control,
+              split_labels = split_labs,
+              location = glue::glue(
+                "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model} (calibration predictions)"
+              ),
+              notes = notes
+            )
+            if (!is_failure(current_cal_pred)) {
+              current_cal_pred <- remove_log_notes(current_cal_pred)
+            }
+          }
+        }
+
         # ----------------------------------------------------------------------
         # Iterate over postprocessors
 
@@ -229,26 +297,27 @@
               current_sched_post
             )
 
-            # make data for post-processor
-            if (
-              workflows::.workflow_postprocessor_requires_fit(current_wflow)
-            ) {
-              tailor_train_data <- static$data$cal$data
-            } else {
-              # if the postprocessor does not require a fit,
-              # this does not cause data leakage
-              tailor_train_data <- static$data$fit$data
-            }
-
             location <- glue::glue(
               "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model}, postprocessing {iter_pred}/{num_iterations_pred}"
             )
+
+            # If the postprocessor requires fitting (e.g. calibration), use
+            # pre-computed calibration predictions. Otherwise, use the raw
+            # training data (no data leakage since no fitting occurs).
             current_wflow <- .catch_and_log(
-              finalize_fit_post(
-                wflow_with_fitted_pre_and_model,
-                data_calibration = tailor_train_data,
-                grid = current_sched_post
-              ),
+              if (static$post_estimation) {
+                finalize_fit_post(
+                  wflow_with_fitted_pre_and_model,
+                  grid = current_sched_post,
+                  cal_predictions = current_cal_pred
+                )
+              } else {
+                finalize_fit_post(
+                  wflow_with_fitted_pre_and_model,
+                  data_calibration = static$data$fit$data,
+                  grid = current_sched_post
+                )
+              },
               control = static$control,
               split_labels = split_labs,
               location = location,

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -309,7 +309,7 @@
                 finalize_fit_post(
                   wflow_with_fitted_pre_and_model,
                   grid = current_sched_post,
-                  cal_predictions = current_cal_pred
+                  predictions_calibration = current_cal_pred
                 )
               } else {
                 finalize_fit_post(

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -100,6 +100,9 @@
         location = location,
         notes = notes
       )
+      if (is_failure(cal_pred_data)) {
+        next
+      }
     }
 
     # Update y_name in case the workflow had an inline function like `log(mpg) ~ .`
@@ -183,8 +186,7 @@
         pred_all_submodels <- remove_log_notes(pred_all_submodels)
 
         # Also predict on calibration data for all submodels at once
-        cal_pred_all_submodels <- NULL
-        if (has_post_estimation && !is_failure(cal_pred_data)) {
+        if (has_post_estimation) {
           cal_pred_all_submodels <- .catch_and_log(
             predict_all_types(
               current_wflow,
@@ -199,9 +201,10 @@
             notes = notes
           )
 
-          if (!is_failure(cal_pred_all_submodels)) {
-            cal_pred_all_submodels <- remove_log_notes(cal_pred_all_submodels)
+          if (is_failure(cal_pred_all_submodels)) {
+            next
           }
+          cal_pred_all_submodels <- remove_log_notes(cal_pred_all_submodels)
         }
       }
 
@@ -248,15 +251,10 @@
         current_cal_pred <- NULL
         if (has_post_estimation) {
           if (has_submodel) {
-            if (
-              !is.null(cal_pred_all_submodels) &&
-                !is_failure(cal_pred_all_submodels)
-            ) {
-              current_cal_pred <- cal_pred_all_submodels |>
-                dplyr::filter(.data[[sub_nm]] == sub_val) |>
-                dplyr::select(-dplyr::all_of(sub_nm))
-            }
-          } else if (!is_failure(cal_pred_data)) {
+            current_cal_pred <- cal_pred_all_submodels |>
+              dplyr::filter(.data[[sub_nm]] == sub_val) |>
+              dplyr::select(-dplyr::all_of(sub_nm))
+          } else {
             current_cal_pred <- .catch_and_log(
               predict_all_types(
                 current_wflow,
@@ -271,9 +269,11 @@
               ),
               notes = notes
             )
-            if (!is_failure(current_cal_pred)) {
-              current_cal_pred <- remove_log_notes(current_cal_pred)
+
+            if (is_failure(current_cal_pred)) {
+              next
             }
+            current_cal_pred <- remove_log_notes(current_cal_pred)
           }
         }
 

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -248,10 +248,9 @@
         has_post <- has_tailor(current_wflow)
         num_iterations_post <- max(nrow(current_sched_pred$post_stage[[1]]), 1)
 
-        # Compute calibration predictions for this predict iteration.
-        # For submodels these were pre-computed above; for non-submodels we
-        # predict here (once per model, shared across post iterations).
-        current_cal_pred <- NULL
+        # if the postprocessor does not require a fit,
+        # this does not cause data leakage
+        current_cal_pred <- current_pred
         if (has_post_estimation) {
           if (has_submodel) {
             current_cal_pred <- cal_pred_all_submodels |>
@@ -304,24 +303,12 @@
             location <- glue::glue(
               "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model}, postprocessing {iter_pred}/{num_iterations_pred}"
             )
-
-            # If the postprocessor requires fitting (e.g. calibration), use
-            # pre-computed calibration predictions. Otherwise, use the raw
-            # training data (no data leakage since no fitting occurs).
             current_wflow <- .catch_and_log(
-              if (has_post_estimation) {
-                finalize_fit_post(
-                  wflow_with_fitted_pre_and_model,
-                  grid = current_sched_post,
-                  predictions_calibration = current_cal_pred
-                )
-              } else {
-                finalize_fit_post(
-                  wflow_with_fitted_pre_and_model,
-                  data_calibration = static$data$fit$data,
-                  grid = current_sched_post
-                )
-              },
+              finalize_fit_post(
+                wflow_with_fitted_pre_and_model,
+                current_cal_pred,
+                grid = current_sched_post
+              ),
               control = static$control,
               split_labels = split_labs,
               location = location,

--- a/R/loop_over_all_stages.R
+++ b/R/loop_over_all_stages.R
@@ -258,6 +258,9 @@
               dplyr::filter(.data[[sub_nm]] == sub_val) |>
               dplyr::select(-dplyr::all_of(sub_nm))
           } else {
+            location <- glue::glue(
+              "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model} (calibration predictions)"
+            )
             current_cal_pred <- .catch_and_log(
               predict_all_types(
                 current_wflow,
@@ -267,9 +270,7 @@
               ),
               control = static$control,
               split_labels = split_labs,
-              location = glue::glue(
-                "preprocessor {iter_pre}/{num_iterations_pre}, model {iter_model}/{num_iterations_model} (calibration predictions)"
-              ),
+              location = location,
               notes = notes
             )
 

--- a/inst/loop.qmd
+++ b/inst/loop.qmd
@@ -14,13 +14,16 @@ The loop runs over a single resample. The basic structure is:
 	- Fit preprocessor
 	- Apply it to analysis set
 	- Apply it to the assessment set
+	- Apply it to the calibration set
 	- For each (non-sub) model parameter combination
 		- Fit the model
 		- Predict for all submodel parameters at once (via multi_predict)
+		- Predict on calibration data for all submodels at once
 		- For each submodel parameter value
 			- Filter to this submodel's predictions
+			- Filter to this submodel's calibration predictions
 			- For each post parameter combination
-				- Fit the postprocessor
+				- Fit the postprocessor on the calibration predictions
 				- Apply the postprocessor to the predictions (on the assessment set)
 				- Combine (post-processed) predictions with the grid to `final_pred`
 				- Save `final_pred` by appending it to `pred_reserve`
@@ -119,6 +122,12 @@ When there's no postprocessor requiring calibration, `cal` is NULL and `fit` use
 - `final_pred` - predictions after postprocessing (ready to save)
 - `pred_reserve` - accumulator for all final predictions
 
+**Calibration objects:**
+
+- `cal_pred_data` - processed calibration data (features + outcomes), analogous to `pred_data`
+- `cal_pred_all_submodels` - batched calibration predictions for all submodel values
+- `current_cal_pred` - calibration predictions for current pred iteration (filtered from `cal_pred_all_submodels`)
+
 **General conventions:**
 
 - `static` - things that don't change during the loop
@@ -132,7 +141,8 @@ When there's no postprocessor requiring calibration, `cal` is NULL and `fit` use
 
 - `finalize_fit_pre()` - finalize recipe params, fit preprocessor
 - `finalize_fit_model()` - finalize model params, fit model
-- `finalize_fit_post()` - finalize tailor params, fit postprocessor
+- `finalize_fit_post()` - finalize tailor params, fit postprocessor on pre-computed predictions
+- `fit_post_from_predictions()` - fit the postprocessor from predictions (instead of raw data)
 
 **Grid helpers:**
 
@@ -141,8 +151,8 @@ When there's no postprocessor requiring calibration, `cal` is NULL and `fit` use
 
 **Prediction:**
 
-- `process_prediction_data()` - apply fitted preprocessor to assessment data
-- `predict_all_types()` - generate all needed prediction types
+- `process_prediction_data()` - apply fitted preprocessor to data (`source = "pred"` for assessment, `source = "cal"` for calibration)
+- `predict_all_types()` - generate all needed prediction types (`source = "pred"` for assessment, `source = "cal"` for calibration)
 
 ### Error handling
 
@@ -178,6 +188,7 @@ The nested structure avoids redundant computation:
 | Processed prediction data | Once per preproc param combo | All predictions below it |
 | Model fit | Once per model param combo | All submodel predictions |
 | Submodel predictions | Once per model (batched) | All submodel × post combos |
+| Calibration predictions | Once per model (batched) | All submodel × post combos |
 | Postprocessor fit | Once per post param combo | That specific config |
 
 Submodel parameters (like `penalty` in glmnet) are predicted all at once using `multi_predict()`, which is much faster than predicting one at a time.

--- a/tests/testthat/test-loop-over-all-stages-helpers-train-post.R
+++ b/tests/testthat/test-loop-over-all-stages-helpers-train-post.R
@@ -4,13 +4,12 @@ test_that("tailor trains calibrator", {
 
   cls <- make_post_data()
 
-  wflow <- workflow(class ~ ., logistic_reg())
-
   wflow_cal <- workflow(class ~ ., logistic_reg(), cls_est_post)
   wflow_fit <- .fit_pre(wflow_cal, cls$data) |>
     .fit_model(control = control_workflow())
 
-  wflow_fit <- finalize_fit_post(wflow_fit, cls$data, grid = tibble())
+  cal_preds <- augment(extract_fit_parsnip(wflow_fit), cls$data)
+  wflow_fit <- finalize_fit_post(wflow_fit, cal_preds, grid = tibble())
   res <- extract_postprocessor(wflow_fit, estimated = TRUE)
   expect_s3_class(res, "tailor")
   expect_true(res$adjustments[[1]]$trained)
@@ -37,11 +36,8 @@ test_that("tailor updated with grid and fit", {
   wflow_fit <- .fit_pre(wflow_cal, cls$data) |>
     .fit_model(control = control_workflow())
 
-  wflow_fit <- finalize_fit_post(
-    wflow_fit,
-    cls$data,
-    grid = tibble(cut = 0)
-  )
+  cal_preds <- augment(extract_fit_parsnip(wflow_fit), cls$data)
+  wflow_fit <- finalize_fit_post(wflow_fit, cal_preds, grid = tibble(cut = 0))
   wflow_fit <- .fit_finalize(wflow_fit)
 
   re_predicted <- predict(wflow_fit, cls$data)

--- a/tests/testthat/test-loop-over-all-stages-post-estimation-no-tuning.R
+++ b/tests/testthat/test-loop-over-all-stages-post-estimation-no-tuning.R
@@ -233,3 +233,81 @@ test_that("verifying .loop_over_all_stages, submodels only, post estimation with
 
   # TODO more tests can be added when calibration method = "none" is implemented
 })
+
+test_that("submodel calibration varies per submodel value (#1144)", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("glmnet")
+  skip_if_not_installed("probably")
+  skip_if_not_installed("mgcv")
+
+  set.seed(1)
+  dat <- modeldata::sim_regression(500)
+  rs <- vfold_cv(dat, v = 3)
+
+  rs_split <- rs$splits[[1]]
+  rs_args <- rsample::.get_split_args(rs)
+
+  rs_iter <- vec_list_rowwise(rs) |>
+    purrr::pluck(1) |>
+    mutate(.seeds = get_parallel_seeds(1))
+
+  wflow <- workflow(outcome ~ ., glmn_spec, reg_cal)
+  grd <- tibble(penalty = c(0.001, 0.1), mixture = c(1, 1))
+
+  extract_cal_coef <- function(wf) {
+    extract_postprocessor(wf, estimated = TRUE)$adjustments[[
+      1
+    ]]$results$fit$estimates[[1]]$estimate |>
+      coefficients()
+  }
+
+  static <- make_static(
+    wflow,
+    param_info = extract_parameter_set_dials(wflow),
+    grid = grd,
+    metrics = metric_set(rmse),
+    eval_time = NULL,
+    split_args = rs_args,
+    control = control_grid(
+      save_pred = TRUE,
+      extract = extract_cal_coef
+    )
+  )
+
+  data_splits <- .get_data_subsets(wflow, rs_split, rs_args)
+  static <- update_static(static, data_splits)
+  static$y_name <- "outcome"
+
+  res <- .loop_over_all_stages(rs_iter, grd, static)
+  extracts <- res$.extracts[[1]]
+
+  loop_cal_p1 <- extracts$.extracts[[1]]
+  loop_cal_p2 <- extracts$.extracts[[2]]
+
+  # The two calibration models should differ because different penalty values
+  # produce different predictions on the calibration set.
+  expect_false(identical(loop_cal_p1, loop_cal_p2))
+
+  # Fit a reference model outside the loop for penalty = 0.001.
+  # Use the same seed so internal_calibration_split produces the same split.
+  withr::local_preserve_seed()
+  assign(".Random.seed", rs_iter$.seeds[[1]], envir = .GlobalEnv)
+  inner_split <- rsample::internal_calibration_split(
+    rs_split,
+    split_args = rs_args
+  )
+
+  ref_wf <- workflow(
+    outcome ~ .,
+    linear_reg(penalty = 0.001, mixture = 1, engine = "glmnet"),
+    reg_cal
+  ) |>
+    fit(
+      data = analysis(inner_split),
+      data_calibration = calibration(inner_split)
+    )
+
+  ref_cal <- extract_cal_coef(ref_wf)
+
+  expect_equal(loop_cal_p1, ref_cal)
+})

--- a/tests/testthat/test-loop-over-all-stages-post-estimation-no-tuning.R
+++ b/tests/testthat/test-loop-over-all-stages-post-estimation-no-tuning.R
@@ -255,9 +255,8 @@ test_that("submodel calibration varies per submodel value (#1144)", {
   grd <- tibble(penalty = c(0.001, 0.1), mixture = c(1, 1))
 
   extract_cal_coef <- function(wf) {
-    extract_postprocessor(wf, estimated = TRUE)$adjustments[[
-      1
-    ]]$results$fit$estimates[[1]]$estimate |>
+    postprocessor <- extract_postprocessor(wf, estimated = TRUE)
+    postprocessor$adjustments[[1]]$results$fit$estimates[[1]]$estimate |>
       coefficients()
   }
 
@@ -288,8 +287,6 @@ test_that("submodel calibration varies per submodel value (#1144)", {
   # produce different predictions on the calibration set.
   expect_false(identical(loop_cal_p1, loop_cal_p2))
 
-  # Fit a reference model outside the loop for penalty = 0.001.
-  # Use the same seed so internal_calibration_split produces the same split.
   withr::local_preserve_seed()
   assign(".Random.seed", rs_iter$.seeds[[1]], envir = .GlobalEnv)
   inner_split <- rsample::internal_calibration_split(


### PR DESCRIPTION
closes #1144

Instead of letting `.fit_post()` generate calibration predictions, we now pre-compute them ourselves using the same `predict_all_types()` machinery that handles assessment predictions. For submodels, this predicts all values at once via `multi_predict()`, then filters per iteration — mirroring how assessment predictions already work.