### PR TITLE
deprecate `finalize_workflow_preprocessor()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     glue (>= 1.6.2),
     GauPro (>= 0.2.15),
     hardhat (>= 1.4.2),
+    lifecycle,
     parallel,
     parsnip (>= 1.4.1.9002),
     purrr (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Authors@R: c(
 Description: The ability to tune models is important. 'tune' contains
     functions and classes to be used in conjunction with other
     'tidymodels' packages for finding reasonable values of
-    hyper-parameters in models, preprocessing methods, and
-    post-processing steps.
+    hyper-parameters in models, preprocessing methods, and post-processing
+    steps.
 License: MIT + file LICENSE
 URL: https://tune.tidymodels.org/, https://github.com/tidymodels/tune
 BugReports: https://github.com/tidymodels/tune/issues
@@ -21,10 +21,10 @@ Imports:
     cli (>= 3.3.0),
     dials (>= 1.3.0.9000),
     dplyr (>= 1.1.0),
+    GauPro (>= 0.2.15),
     generics (>= 0.1.2),
     ggplot2,
     glue (>= 1.6.2),
-    GauPro (>= 0.2.15),
     hardhat (>= 1.4.2),
     lifecycle,
     parallel,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tune (development version)
 
+* `finalize_workflow_preprocessor()` is deprecated (#1157).
+
 * Model tuning has been enabled for quantile regression models. (#1125)
 
 * In `tune_grid()`, a bug was fixed that caused inefficiency where preprocessing steps were applied to data being predicted several times (redundantly). We now execute that operation once. (#1101)

--- a/R/grid_helpers.R
+++ b/R/grid_helpers.R
@@ -114,7 +114,13 @@ has_metrics_by <- function(metrics_by) {
 
 #' @export
 #' @rdname tune-internal-functions
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' `finalize_workflow_preprocessor()` is deprecated.
 finalize_workflow_preprocessor <- function(workflow, grid_preprocessor) {
+  lifecycle::deprecate_warn("2.1.0", "finalize_workflow_preprocessor()")
+
   # Already finalized, nothing to tune
   if (ncol(grid_preprocessor) == 0L) {
     return(workflow)

--- a/man/tune-internal-functions.Rd
+++ b/man/tune-internal-functions.Rd
@@ -67,6 +67,10 @@ always unique and do not represent a tuning "issue" can bypass the cataloger
 by setting \code{catalog = FALSE}.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+\code{finalize_workflow_preprocessor()} is deprecated.
+
 These are not to be meant to be invoked directly by users.
 }
 \keyword{internal}

--- a/tests/testthat/_snaps/grid.md
+++ b/tests/testthat/_snaps/grid.md
@@ -65,3 +65,11 @@
        9 <split [29/3]> Fold09 <tibble [6 x 5]> <tibble [0 x 4]>
       10 <split [29/3]> Fold10 <tibble [6 x 5]> <tibble [0 x 4]>
 
+# finalize_workflow_preprocessor() is deprecated
+
+    Code
+      wflow <- finalize_workflow_preprocessor(wflow, grid)
+    Condition
+      Warning:
+      `finalize_workflow_preprocessor()` was deprecated in tune 2.1.0.
+

--- a/tests/testthat/test-grid.R
+++ b/tests/testthat/test-grid.R
@@ -787,3 +787,12 @@ test_that("retain extra attributes", {
   expect_null(attr(res, "workflow"))
   expect_true(inherits(attr(res2, "workflow"), "workflow"))
 })
+
+test_that("finalize_workflow_preprocessor() is deprecated", {
+  helper_objects <- helper_objects_tune()
+  wflow <- workflow() |>
+    add_recipe(helper_objects$rec_tune_1) |>
+    add_model(helper_objects$lm_mod)
+  grid <- tibble::tibble(num_comp = 1L)
+  expect_snapshot(wflow <- finalize_workflow_preprocessor(wflow, grid))
+})


### PR DESCRIPTION
closes #1157

This means that tidyclust and agua will start sending deprecation warnings, more details in the issue comment

Note that adding lifecycle to the description moves the check on the number of dependencies from INFO to NOTE
```
❯ checking package dependencies ... NOTE
```
but doesn't tune have an exception for this? We run into this again in https://github.com/tidymodels/tune/pull/1178 and will also for https://github.com/tidymodels/tune/issues/1161
