### PR TITLE
Clarify tune_grid object documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Bug Fixes
 
+* The `tune_grid()` documentation no longer states that `object` must be
+  finalized without tuning parameters (#982).
+
 * Resampling and tuning would fail for quantile regression models if they passed a quantile regression metric (#1186)
 
 # tune 2.1.0

--- a/R/tune_grid.R
+++ b/R/tune_grid.R
@@ -6,6 +6,9 @@
 #'
 #' @inheritParams last_fit
 #' @inheritParams fit_resamples
+#' @param object A `parsnip` model specification or an unfitted
+#'   [workflows::workflow()]. Tuning parameters may be marked with
+#'   [tune()] and are evaluated over the values supplied in `grid`.
 #' @param param_info A [dials::parameters()] object or `NULL`. If none is given,
 #' a parameters set is derived from other arguments. Passing this argument can
 #' be useful when parameter ranges need to be customized.

--- a/man/tune_grid.Rd
+++ b/man/tune_grid.Rd
@@ -33,9 +33,8 @@ tune_grid(object, ...)
 }
 \arguments{
 \item{object}{A \code{parsnip} model specification or an unfitted
-\link[workflows:workflow]{workflow()}. No tuning parameters are allowed; if arguments
-have been marked with \link[hardhat:tune]{tune()}, their values must be
-\link[=finalize_model]{finalized}.}
+\link[workflows:workflow]{workflow()}. Tuning parameters may be marked with
+\code{\link[=tune]{tune()}} and are evaluated over the values supplied in \code{grid}.}
 
 \item{...}{Not currently used.}
 


### PR DESCRIPTION
Fixes #982.

This updates the `tune_grid()` `object` parameter documentation so it no longer inherits the `last_fit()` wording that says tuning parameters are not allowed. The revised text notes that parameters may be marked with `tune()` and evaluated over `grid`.

Checks:
- `Rscript -e 'tools::checkRd("man/tune_grid.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .`\n- `R_LIBS_USER=/tmp/tune-r-lib _R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests tune_2.1.0.9000.tar.gz`