### PR TITLE
Fix cli formatting: use variable interpolation in cli_abort calls

### DIFF
--- a/R/loop_over_all_stages-helpers.R
+++ b/R/loop_over_all_stages-helpers.R
@@ -530,7 +530,7 @@ make_config_labs <- function(grid, param, val = "pre") {
       )
     } else {
       cli::cli_abort(
-        "No prediction types are known for mode {.val model_mode}."
+        "No prediction types are known for mode {.val {model_mode}}."
       )
     }
 

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -389,7 +389,7 @@ eval_mirai <- function(.x, .f, ..., .args) {
   } else if (framework == "mirai") {
     res <- list(fn = "eval_mirai", ns = NULL)
   } else {
-    cli::cli_abort("Frmework {.val framework} is unknown.")
+    cli::cli_abort("Framework {.val {framework}} is unknown.")
   }
   res
 }


### PR DESCRIPTION
Addresses issue #1180

## Changes
- Fix cli formatting in `.determine_pred_types()`: {.val model_mode} -> {.val {model_mode}}
- Fix cli formatting in `.par_fns()`: {.val framework} -> {.val {framework}}
- Fix typo in `.par_fns()`: Frmework -> Framework

## Validation
- Syntax check passed
- Manual testing confirmed correct behavior
- No existing tests affected